### PR TITLE
resolve rpc multiplixity issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Version 1.3, we add the following features:
 
 -Resolve "revision" and "namespace" issues.
 
+-Resolve "rpc" multiplicity issue, which cause leaf-list translated to leaf.
+
 
 Version 1.2:
 

--- a/xmi2yang tool-v1.3/main.js
+++ b/xmi2yang tool-v1.3/main.js
@@ -1135,7 +1135,11 @@ function obj2yang(ele){
                 var pValue = ele[i].attribute[j];
                 for(var k=0;k<Typedef.length;k++){
                     if(Typedef[k].id==pValue.type){
-                        pValue.nodeType="leaf";
+                        if(pValue.nodeType=="list"){
+                            pValue.nodeType="leaf-list";
+                        }else{
+                            pValue.nodeType="leaf";
+                        }
                         pValue.isUses=false;
                         if(Typedef[k].path==ele[i].path){
                             pValue.type=Typedef[k].name;


### PR DESCRIPTION
The bug causes the rpc element which should be translated to "leaf-list" is translated to "leaf".