### PR TITLE
fix Spec use as attribute bug

### DIFF
--- a/xmi2yang tool-v2.0/main.js
+++ b/xmi2yang tool-v2.0/main.js
@@ -1121,14 +1121,17 @@ function createClass(obj,nodeType) {
                         }
                     }
                 }
-                
-                if(specTargetFlag == true){
-                    node.attribute[i].isSpecTarget = true;
+                if(node.name.indexOf("Spec") == -1){
+                    if(specTargetFlag == true){
+                        node.attribute[i].isSpecTarget = true;
+                    }
+                    if(specReferenceFlag == true){
+                        node.attribute[i].isSpecReference = true;
+                    }
+                }else{
+                    console.log("test");
                 }
 
-                if(specReferenceFlag == true){
-                    node.attribute[i].isSpecReference = true;
-                }
 
 
 


### PR DESCRIPTION
In last commit, Specification and SpecTarget are ignored when they appear as "ownedAttribute" in the uml model. Then I discovered that they should be mapped to regular leaf in the ResourceSpec, ExtensionSpec groupings. This commit resolves this issue.