### PR TITLE
OpenModel Profile Version 0.2.3

### DIFF
--- a/OpenModelProfile/OpenModel_Profile.profile.di
+++ b/OpenModelProfile/OpenModel_Profile.profile.di
@@ -15,6 +15,9 @@
           <emfPageIdentifier href="OpenModel_Profile.profile.notation#_W3I3kKiLEeSly6b4dPxjLg"/>
         </children>
         <children>
+          <emfPageIdentifier href="OpenModel_Profile.profile.notation#_1C8x0BdkEeatXPvf_dRw8w"/>
+        </children>
+        <children>
           <emfPageIdentifier href="OpenModel_Profile.profile.notation#_W3I4gaiLEeSly6b4dPxjLg"/>
         </children>
       </children>

--- a/OpenModelProfile/OpenModel_Profile.profile.notation
+++ b/OpenModelProfile/OpenModel_Profile.profile.notation
@@ -1,49 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:css="http://www.eclipse.org/papyrus/infra/gmfdiag/css" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
-  <notation:Diagram xmi:id="_W3I3kKiLEeSly6b4dPxjLg" type="PapyrusUMLProfileDiagram" name="OpenModel_Profile" measurementUnit="Pixel">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:css="http://www.eclipse.org/papyrus/infra/gmfdiag/css" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <notation:Diagram xmi:id="_W3I3kKiLEeSly6b4dPxjLg" type="PapyrusUMLProfileDiagram" name="OpenModelProfile_RequiredStereotypes" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_W3I3kaiLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I3kqiLEeSly6b4dPxjLg" type="1034">
         <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_W3I3k6iLEeSly6b4dPxjLg" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_F21zsMvgEeWuP4zc4scymQ" type="3002">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_P_PnEMvgEeWuP4zc4scymQ" name="maskLabel">
-            <stringListValue>multiplicity</stringListValue>
-            <stringListValue>visibility</stringListValue>
-            <stringListValue>defaultValue</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>type</stringListValue>
-            <stringListValue>derived</stringListValue>
-          </styles>
-          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_Um0xgHBhEd6FKu9XX1078A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F21zscvgEeWuP4zc4scymQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_F23B0MvgEeWuP4zc4scymQ" type="3002">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_QljZIMvgEeWuP4zc4scymQ" name="maskLabel">
-            <stringListValue>multiplicity</stringListValue>
-            <stringListValue>visibility</stringListValue>
-            <stringListValue>defaultValue</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>type</stringListValue>
-            <stringListValue>derived</stringListValue>
-          </styles>
-          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F23B0cvgEeWuP4zc4scymQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_F23o4MvgEeWuP4zc4scymQ" type="3002">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Q_KzAMvgEeWuP4zc4scymQ" name="maskLabel">
-            <stringListValue>multiplicity</stringListValue>
-            <stringListValue>visibility</stringListValue>
-            <stringListValue>defaultValue</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>type</stringListValue>
-            <stringListValue>derived</stringListValue>
-          </styles>
-          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F23o4cvgEeWuP4zc4scymQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_F24P8MvgEeWuP4zc4scymQ" type="3002">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_RSuoMMvgEeWuP4zc4scymQ" name="maskLabel">
+        <children xmi:type="notation:Shape" xmi:id="_eu9NYFh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_m-UbgFh1EeaaGczhAqBKxg" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
             <stringListValue>visibility</stringListValue>
             <stringListValue>defaultValue</stringListValue>
@@ -52,13 +16,94 @@
             <stringListValue>derived</stringListValue>
           </styles>
           <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_tD9I4MvfEeWuP4zc4scymQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F24P8cvgEeWuP4zc4scymQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eu9NYVh1EeaaGczhAqBKxg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_F243AMvgEeWuP4zc4scymQ" type="3002">
-          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vo1ZEMviEeWuP4zc4scymQ" source="displayNameLabelIcon">
-            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vo2AIMviEeWuP4zc4scymQ" key="displayNameLabelIcon_value" value="true"/>
-          </eAnnotations>
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_RpLZUMvgEeWuP4zc4scymQ" name="maskLabel">
+        <children xmi:type="notation:Shape" xmi:id="_eu-bgFh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_nVdJIFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_Um0xgHBhEd6FKu9XX1078A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eu-bgVh1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eu-bglh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_nxtAQFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_iwNxQHBlEd6FKu9XX1078A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eu-bg1h1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eu_CkFh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_oJEXYFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_sUuCwHEoEd6SxZ5y0DIogw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eu_CkVh1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_eu_poFh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ohyZYFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_09m2UFh0EeaaGczhAqBKxg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_eu_poVh1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_evAQsFh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_o3F7AFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_5atTwFh0EeaaGczhAqBKxg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_evAQsVh1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_evAQslh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_pLZXEFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_8JaVsFh0EeaaGczhAqBKxg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_evAQs1h1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_evA3wFh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ppAgIFh1EeaaGczhAqBKxg" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#__RruMFh0EeaaGczhAqBKxg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_evA3wVh1EeaaGczhAqBKxg"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_evBe0Fh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_p8bycFh1EeaaGczhAqBKxg" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
             <stringListValue>visibility</stringListValue>
             <stringListValue>defaultValue</stringListValue>
@@ -67,10 +112,10 @@
             <stringListValue>derived</stringListValue>
           </styles>
           <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_28fUQMvfEeWuP4zc4scymQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F243AcvgEeWuP4zc4scymQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_evBe0Vh1EeaaGczhAqBKxg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_F243AsvgEeWuP4zc4scymQ" type="3002">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_SAiwcMvgEeWuP4zc4scymQ" name="maskLabel">
+        <children xmi:type="notation:Shape" xmi:id="_evBe0lh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_qVWBsFh1EeaaGczhAqBKxg" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
             <stringListValue>visibility</stringListValue>
             <stringListValue>defaultValue</stringListValue>
@@ -79,10 +124,10 @@
             <stringListValue>derived</stringListValue>
           </styles>
           <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_EKbhgL7REeGcHtJ-koFuEQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F243A8vgEeWuP4zc4scymQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_evBe01h1EeaaGczhAqBKxg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_F25eEMvgEeWuP4zc4scymQ" type="3002">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_SYeIQMvgEeWuP4zc4scymQ" name="maskLabel">
+        <children xmi:type="notation:Shape" xmi:id="_evCF4Fh1EeaaGczhAqBKxg" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_qtjGUFh1EeaaGczhAqBKxg" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
             <stringListValue>visibility</stringListValue>
             <stringListValue>defaultValue</stringListValue>
@@ -91,7 +136,7 @@
             <stringListValue>derived</stringListValue>
           </styles>
           <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_S3McgP19EeGrxoCd_NcLdw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_F25eEcvgEeWuP4zc4scymQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_evCF4Vh1EeaaGczhAqBKxg"/>
         </children>
         <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
       </children>
@@ -103,7 +148,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhOAwqqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3mqiLEeSly6b4dPxjLg" x="160" y="280" height="151"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3mqiLEeSly6b4dPxjLg" x="129" y="-328" height="217"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I3m6iLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I3nKiLEeSly6b4dPxjLg" type="1034">
@@ -164,45 +209,48 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhXxwqqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_JVMFMHBhEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3o6iLEeSly6b4dPxjLg" x="-234" y="280" height="102"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3o6iLEeSly6b4dPxjLg" x="-234" y="-326" height="102"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I3rKiLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I3raiLEeSly6b4dPxjLg" type="1034">
         <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jG59cHEqEd6SxZ5y0DIogw"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_W3I3rqiLEeSly6b4dPxjLg" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_W3I3r6iLEeSly6b4dPxjLg" type="3002" fontHeight="8">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_YcUsUKqyEeSqFPhVNQ1oeg" name="maskLabel">
-            <stringListValue>visibility</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>derived</stringListValue>
+        <children xmi:type="notation:Shape" xmi:id="_pkDF4FfsEeavh4gnMhE61Q" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_qdvuAFfsEeavh4gnMhE61Q" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
-            <stringListValue>defaultValue</stringListValue>
-            <stringListValue>type</stringListValue>
-          </styles>
-          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_BpwpoL7TEeGcHtJ-koFuEQ"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_W3I3sKiLEeSly6b4dPxjLg" type="3002" fontHeight="8">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_Y3aF0KqyEeSqFPhVNQ1oeg" name="maskLabel">
             <stringListValue>visibility</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>derived</stringListValue>
-            <stringListValue>multiplicity</stringListValue>
             <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
             <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
           </styles>
           <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_w9boYHEqEd6SxZ5y0DIogw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_pkDF4VfsEeavh4gnMhE61Q"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_W3I3saiLEeSly6b4dPxjLg" type="3002" fontHeight="8">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_ZQ15gKqyEeSqFPhVNQ1oeg" name="maskLabel">
-            <stringListValue>visibility</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>derived</stringListValue>
+        <children xmi:type="notation:Shape" xmi:id="_pkFiIFfsEeavh4gnMhE61Q" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_qyFmUFfsEeavh4gnMhE61Q" name="maskLabel">
             <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
             <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
             <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_BpwpoL7TEeGcHtJ-koFuEQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_pkFiIVfsEeavh4gnMhE61Q"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_pkGJMFfsEeavh4gnMhE61Q" type="3002">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_sHEcQFfsEeavh4gnMhE61Q" name="maskLabel">
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>type</stringListValue>
+            <stringListValue>derived</stringListValue>
           </styles>
           <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_psZSoP19EeGrxoCd_NcLdw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_pkGJMVfsEeavh4gnMhE61Q"/>
         </children>
         <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jG59cHEqEd6SxZ5y0DIogw"/>
       </children>
@@ -214,58 +262,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhXxyKqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jG59cHEqEd6SxZ5y0DIogw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3s6iLEeSly6b4dPxjLg" x="1281" y="278" height="86"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I31KiLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I31aiLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I31qiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I316iLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhXx4aqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhXx4qqxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhXx46qxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I32KiLEeSly6b4dPxjLg" x="240" y="-192" height="55"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I35qiLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I356iLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I36KiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I36aiLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhg7vKqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhg7vaqxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhg7vqqxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I36qiLEeSly6b4dPxjLg" x="1008" y="-192" height="55"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I386iLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I39KiLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I39aiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I39qiLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhg7xaqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhg7xqqxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhg7x6qxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I396iLEeSly6b4dPxjLg" x="1222" y="-192" height="55"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3s6iLEeSly6b4dPxjLg" x="513" y="128" height="86"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I3-6iLEeSly6b4dPxjLg" type="2006" fontHeight="8" fillColor="8905185" transparency="0" lineColor="14263149" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I3_KiLEeSly6b4dPxjLg" type="5023">
@@ -294,7 +291,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhg7yqqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Enumeration" href="OpenModel_Profile.profile.uml#_tIP_UL7QEeGcHtJ-koFuEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4A6iLEeSly6b4dPxjLg" x="571" y="534"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4A6iLEeSly6b4dPxjLg" x="344" y="376"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I4BKiLEeSly6b4dPxjLg" type="2006" fontHeight="8" fillColor="8905185" transparency="0" lineColor="14263149" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I4BaiLEeSly6b4dPxjLg" type="5023">
@@ -317,86 +314,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhg7zaqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Enumeration" href="OpenModel_Profile.profile.uml#_HgbRQBGqEd-nT5bmeQ1LHg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4CqiLEeSly6b4dPxjLg" x="767" y="534"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I4C6iLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I4DKiLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4DaiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4D6iLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhg7zqqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhg7z6qxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhg70KqxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4EKiLEeSly6b4dPxjLg" x="745" y="-192" width="108" height="55"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I4HqiLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I4H6iLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4IKiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4IaiLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhqstqqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhqst6qxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhqsuKqxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4IqiLEeSly6b4dPxjLg" x="-180" y="-192" height="55"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I4JqiLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I4J6iLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4KKiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4KaiLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhqsuaqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhqsuqqxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhqsu6qxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4KqiLEeSly6b4dPxjLg" x="352" y="-192" height="55"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I4K6iLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I4LKiLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4LaiLEeSly6b4dPxjLg" type="1071">
-        <children xmi:type="notation:Shape" xmi:id="_W3I4LqiLEeSly6b4dPxjLg" type="3002" fontHeight="8">
-          <styles xmi:type="notation:StringListValueStyle" xmi:id="_FsjlcKiMEeSly6b4dPxjLg" name="maskLabel">
-            <stringListValue>visibility</stringListValue>
-            <stringListValue>name</stringListValue>
-            <stringListValue>derived</stringListValue>
-            <stringListValue>multiplicity</stringListValue>
-            <stringListValue>defaultValue</stringListValue>
-            <stringListValue>type</stringListValue>
-          </styles>
-          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_ny5SwJ2CEeSDYd59zPupRA"/>
-        </children>
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4L6iLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_vhqsvKqxEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_vhqsvaqxEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhqsvqqxEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4MKiLEeSly6b4dPxjLg" x="88" y="-192" height="55"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4CqiLEeSly6b4dPxjLg" x="540" y="376"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I4OaiLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I4OqiLEeSly6b4dPxjLg" type="1034">
@@ -435,71 +353,27 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhqsx6qxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_oKbrsKiIEeSJmIxGbzx9kA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4P6iLEeSly6b4dPxjLg" x="607" y="280" height="70"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Cdt1cKiNEeSly6b4dPxjLg" type="1002">
-      <children xmi:type="notation:DecorationNode" xmi:id="_CeAwYKiNEeSly6b4dPxjLg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_GxMCgPNBEeGLMdrUcsEncQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Cdt1caiNEeSly6b4dPxjLg" x="-238" y="-112" width="225" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_McsnEKiNEeSly6b4dPxjLg" type="1002">
-      <children xmi:type="notation:DecorationNode" xmi:id="_McsnEqiNEeSly6b4dPxjLg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_-Js00KiHEeSJmIxGbzx9kA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_McsnEaiNEeSly6b4dPxjLg" x="-3" y="-112" width="185" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_VxwR8KiNEeSly6b4dPxjLg" type="1002">
-      <children xmi:type="notation:DecorationNode" xmi:id="_VxwR8qiNEeSly6b4dPxjLg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_tH7r0I7kEeGyB5ASrrNdIA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VxwR8aiNEeSly6b4dPxjLg" x="191" y="-112" width="225" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_BQEhIKiOEeSly6b4dPxjLg" type="1002">
-      <children xmi:type="notation:DecorationNode" xmi:id="_BQKnwKiOEeSly6b4dPxjLg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_s8198NyHEeG3LugjzyfwGA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BQEhIaiOEeSly6b4dPxjLg" x="655" y="-112" width="289"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_-D4DMKiTEeSly6b4dPxjLg" type="1002">
-      <children xmi:type="notation:DecorationNode" xmi:id="_-D4DMqiTEeSly6b4dPxjLg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_9H4noL7XEeGcHtJ-koFuEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-D4DMaiTEeSly6b4dPxjLg" x="950" y="-112" width="217" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_-8jXoKiTEeSly6b4dPxjLg" type="1002">
-      <children xmi:type="notation:DecorationNode" xmi:id="_-8jXoqiTEeSly6b4dPxjLg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_htBYgL7YEeGcHtJ-koFuEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-8jXoaiTEeSly6b4dPxjLg" x="1176" y="-112" width="193" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4P6iLEeSly6b4dPxjLg" x="-79" y="128" height="70"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_oqcLAKiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_oqcLAqiUEeSly6b4dPxjLg" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_nd89oHBjEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqcLAaiUEeSly6b4dPxjLg" x="-190" y="457" width="257" height="37"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqcLAaiUEeSly6b4dPxjLg" x="-190" y="-88" width="257" height="37"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_pTpgEKiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_pTpgEqiUEeSly6b4dPxjLg" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_sTEScHBjEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pTpgEaiUEeSly6b4dPxjLg" x="247" y="459" width="217" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pTpgEaiUEeSly6b4dPxjLg" x="216" y="-88" width="217" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_p4130KiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_p4130qiUEeSly6b4dPxjLg" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_mpzJ8KiJEeSJmIxGbzx9kA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p4130aiUEeSly6b4dPxjLg" x="636" y="459" width="217" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p4130aiUEeSly6b4dPxjLg" x="-50" y="266" width="217" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rcrCEKiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_rcrCEqiUEeSly6b4dPxjLg" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_wWsYgHEqEd6SxZ5y0DIogw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rcrCEaiUEeSly6b4dPxjLg" x="1311" y="457" width="215" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_L0fMoKqzEeSqFPhVNQ1oeg" type="1002" fontName="Segoe UI" lineColor="0">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_L0fMoqqzEeSqFPhVNQ1oeg" source="ShadowFigure">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_L0fMo6qzEeSqFPhVNQ1oeg" key="ShadowFigure_Value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_L0fMpKqzEeSqFPhVNQ1oeg" source="displayNameLabelIcon">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_L0fMpaqzEeSqFPhVNQ1oeg" key="displayNameLabelIcon_value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_L0fMpqqzEeSqFPhVNQ1oeg" source="QualifiedName">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_L0fMp6qzEeSqFPhVNQ1oeg" key="QualifiedNameDepth" value="1000"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_L0fMqKqzEeSqFPhVNQ1oeg" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_JvB8AKqzEeSqFPhVNQ1oeg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L0fMoaqzEeSqFPhVNQ1oeg" x="-240" y="-8" width="682"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rcrCEaiUEeSly6b4dPxjLg" x="547" y="266" width="215" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_8xKUcEZPEeW32YsOmT7W0Q" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8xMwsEZPEeW32YsOmT7W0Q" source="ShadowFigure">
@@ -557,7 +431,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xbaMkZPEeW32YsOmT7W0Q"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_74KP4EZPEeW32YsOmT7W0Q"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xKUcUZPEeW32YsOmT7W0Q" x="1608" y="278" height="91"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xKUcUZPEeW32YsOmT7W0Q" x="537" y="-328" height="91"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_XnHqQEZQEeW32YsOmT7W0Q" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_XnIRUEZQEeW32YsOmT7W0Q" source="ShadowFigure">
@@ -571,7 +445,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_XnI4ZEZQEeW32YsOmT7W0Q" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_DyUDAEZQEeW32YsOmT7W0Q"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XnHqQUZQEeW32YsOmT7W0Q" x="1635" y="457" width="220" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XnHqQUZQEeW32YsOmT7W0Q" x="564" y="-88" width="220" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_6E4ssEZVEeW32YsOmT7W0Q" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6E560EZVEeW32YsOmT7W0Q" source="ShadowFigure">
@@ -641,7 +515,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6FJyckZVEeW32YsOmT7W0Q"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_FRG9AHBnEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6E4ssUZVEeW32YsOmT7W0Q" x="945" y="278" height="105"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6E4ssUZVEeW32YsOmT7W0Q" x="217" y="128" height="105"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GCiKcEZWEeW32YsOmT7W0Q" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_GCjYkEZWEeW32YsOmT7W0Q" source="ShadowFigure">
@@ -655,309 +529,200 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_GCj_pEZWEeW32YsOmT7W0Q" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_FRG9A3BnEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GCixgEZWEeW32YsOmT7W0Q" x="972" y="457" width="220" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_bJE60EZgEeWzOqfPW42hmw" type="1026" fontHeight="8" fillColor="15912618" lineColor="12678440">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bJXOsEZgEeWzOqfPW42hmw" source="ShadowFigure">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bJXOsUZgEeWzOqfPW42hmw" key="ShadowFigure_Value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bJX1wEZgEeWzOqfPW42hmw" source="displayNameLabelIcon">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bJX1wUZgEeWzOqfPW42hmw" key="displayNameLabelIcon_value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_bJX1wkZgEeWzOqfPW42hmw" source="QualifiedName">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_bJX1w0ZgEeWzOqfPW42hmw" key="QualifiedNameDepth" value="1000"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_bJX1xEZgEeWzOqfPW42hmw" type="1034"/>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_bJX1xUZgEeWzOqfPW42hmw" type="1071">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_bJX1xkZgEeWzOqfPW42hmw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_bJX1x0ZgEeWzOqfPW42hmw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJX1yEZgEeWzOqfPW42hmw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJX1yUZgEeWzOqfPW42hmw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_bJX1ykZgEeWzOqfPW42hmw" visible="false" type="1019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_bJX1y0ZgEeWzOqfPW42hmw"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_bJX1zEZgEeWzOqfPW42hmw"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_bJX1zUZgEeWzOqfPW42hmw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJX1zkZgEeWzOqfPW42hmw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_bK11YEZgEeWzOqfPW42hmw" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_bK11YUZgEeWzOqfPW42hmw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bK11YkZgEeWzOqfPW42hmw"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_aUYHcEZgEeWzOqfPW42hmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bJE60UZgEeWzOqfPW42hmw" x="495" y="-192" width="109" height="57"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_4cq7QEZhEeWzOqfPW42hmw" type="1002" fontName="Segoe UI" lineColor="0">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4criUEZhEeWzOqfPW42hmw" source="ShadowFigure">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4csJYEZhEeWzOqfPW42hmw" key="ShadowFigure_Value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4csJYUZhEeWzOqfPW42hmw" source="displayNameLabelIcon">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4csJYkZhEeWzOqfPW42hmw" key="displayNameLabelIcon_value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4csJY0ZhEeWzOqfPW42hmw" source="QualifiedName">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4csJZEZhEeWzOqfPW42hmw" key="QualifiedNameDepth" value="1000"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_4cswcEZhEeWzOqfPW42hmw" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_Uyzf0EZhEeWzOqfPW42hmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4cq7QUZhEeWzOqfPW42hmw" x="456" y="-110" width="188"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_mOrjgJDhEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_mOrjgpDhEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mOrjgZDhEeW51dNDZIXIMA" x="244" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_mO8CMJDhEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_mO8CMZDhEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mO8CM5DhEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mO8CMpDhEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_CfoQoJDiEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_Cfo3sJDiEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CfoQoZDiEeW51dNDZIXIMA" x="1124" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Cf4IQJDiEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Cf4IQZDiEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Cf4IQ5DiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Cf4IQpDiEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_eVeWIJDiEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_eVeWIpDiEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eVeWIZDiEeW51dNDZIXIMA" x="-181" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_eVtmsJDiEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_eVtmsZDiEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eVtms5DiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eVtmspDiEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_sxukUJDiEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_sxvLYJDiEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sxukUZDiEeW51dNDZIXIMA" x="-112" y="168"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_syEikJDiEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_syEikZDiEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_syEik5DiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_syEikpDiEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_szF2QJDiEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_szF2QpDiEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_szF2QZDiEeW51dNDZIXIMA" x="988" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_szT4sJDiEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_szT4sZDiEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_szT4s5DiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_szT4spDiEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_8pCbQJDiEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_8pCbQpDiEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8pCbQZDiEeW51dNDZIXIMA" x="1695" y="165"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_8pS585DiEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_8pS59JDiEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8pS59pDiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8pS59ZDiEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_NfvSoJDjEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_NfvSopDjEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NfvSoZDjEeW51dNDZIXIMA" x="495" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Nf9VE5DjEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Nf9VFJDjEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Nf9VFpDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nf9VFZDjEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_UfrgQJDjEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_UfrgQpDjEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UfrgQZDjEeW51dNDZIXIMA" x="83" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_Uf7X4JDjEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_Uf7X4ZDjEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Uf7X45DjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Uf7X4pDjEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_cqAdYJDjEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_cqBEcJDjEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Interface"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cqAdYZDjEeW51dNDZIXIMA" x="694" y="170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_cqTYUJDjEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_cqTYUZDjEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cqTYU5DjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Interface"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cqTYUpDjEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_gQvTgJDjEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_gQvTgpDjEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gQvTgZDjEeW51dNDZIXIMA" x="1032" y="167"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_gRCOcJDjEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_gRCOcZDjEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gRCOc5DjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gRCOcpDjEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_7cUUAJDjEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_7cU7EJDjEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7cUUAZDjEeW51dNDZIXIMA" x="1368" y="165"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_7ci9gJDjEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7ci9gZDjEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7ci9g5DjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7ci9gpDjEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_7dvQUJDjEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_7dvQUpDjEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dvQUZDjEeW51dNDZIXIMA" x="812" y="-350"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_7d9SwJDjEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_7d9SwZDjEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7d9Sw5DjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7d9SwpDjEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JVUEIJDkEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_JVUEIpDkEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JVUEIZDkEeW51dNDZIXIMA" x="305" y="170"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JVmYAJDkEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JVmYAZDkEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JVmYA5DkEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JVmYApDkEeW51dNDZIXIMA" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JW28QJDkEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_JW28QpDkEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JW28QZDkEeW51dNDZIXIMA" x="689" y="-349"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_JXGM0JDkEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_JXGM0ZDkEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXGM05DkEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JXGM0pDkEeW51dNDZIXIMA" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GCixgEZWEeW32YsOmT7W0Q" x="244" y="266" width="220" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_cRYskJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_cRYskpDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_cRXecJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cRYskZDkEeW51dNDZIXIMA" x="-51" y="237" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cRYskZDkEeW51dNDZIXIMA" x="-44" y="-369" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_pAzlgJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_pAzlgZDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_pAy-cJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pAzlgpDkEeW51dNDZIXIMA" x="361" y="238" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pAzlgpDkEeW51dNDZIXIMA" x="344" y="-368" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_q_HsUZDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_q_ITYJDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_q_HsUJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q_ITYZDkEeW51dNDZIXIMA" x="755" y="239" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q_ITYZDkEeW51dNDZIXIMA" x="68" y="87" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_t8mxIJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_t8mxIZDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_t8mKEJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t8mxIpDkEeW51dNDZIXIMA" x="1109" y="237" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_t8mxIpDkEeW51dNDZIXIMA" x="369" y="88" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_xlhYkJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_xlhYkZDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_xlgxgJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xlhYkpDkEeW51dNDZIXIMA" x="1438" y="238" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xlhYkpDkEeW51dNDZIXIMA" x="665" y="88" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_0RnLYJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_0RnLYZDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_0RmkUJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0RnLYpDkEeW51dNDZIXIMA" x="1769" y="238" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0RnLYpDkEeW51dNDZIXIMA" x="696" y="-368" width="66" height="22"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_N507MFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_N507MVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_N507M1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N507MlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PqMsoFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PqN6wFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PqMsoVfkEeak-v4LxEsCQw" x="274" y="-440"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Pqu4IFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Pqu4IVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pqu4I1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Pqu4IlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_R-K6YFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_R-K6YlfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R-K6YVfkEeak-v4LxEsCQw" x="-112" y="-440"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_R-nmUFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_R-nmUVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_R-nmU1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_R-nmUlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VWfhEFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_VWgIIFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VWfhEVfkEeak-v4LxEsCQw" x="304" y="16"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VW_QUFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_VW_QUVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VW_QU1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VW_QUlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XFsN0FfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_XFtb8FfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XFsN0VfkEeak-v4LxEsCQw" x="604" y="16"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_XGMkIFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_XGMkIVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XGMkI1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XGMkIlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ywEDIFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ywEqMFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Interface"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ywEDIVfkEeak-v4LxEsCQw" x="8" y="16"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ywjyY1fkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ywjyZFfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ywkZcFfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Interface"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ywjyZVfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3ScCIFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3ScpMFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ScCIVfkEeak-v4LxEsCQw" x="624" y="-440"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_3S8_gFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_3S8_gVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3S8_g1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3S8_glfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O9bCAFfrEeak-v4LxEsCQw" type="2006" fillColor="8905185" lineColor="14263149">
+      <children xmi:type="notation:DecorationNode" xmi:id="_O9bpEFfrEeak-v4LxEsCQw" type="5023"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_O9bpEVfrEeak-v4LxEsCQw" type="1063">
+        <children xmi:type="notation:Shape" xmi:id="_lVLHIFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_gJ9mgFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lVLHIVfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_lVMVQFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_iqOj0FfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lVMVQVfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_lVM8UFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_joPrQFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lVM8UVfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_lVNjYFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_kqUMQFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_lVNjYVfrEeak-v4LxEsCQw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_O9bpElfrEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_O9bpE1frEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_O9bpFFfrEeak-v4LxEsCQw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O9bpFVfrEeak-v4LxEsCQw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="OpenModel_Profile.profile.uml#_M9B3kFfrEeak-v4LxEsCQw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O9bCAVfrEeak-v4LxEsCQw" x="-16" y="376"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O-rmQFfrEeak-v4LxEsCQw" type="2006" fillColor="8905185" lineColor="14263149">
+      <children xmi:type="notation:DecorationNode" xmi:id="_O-rmQlfrEeak-v4LxEsCQw" type="5023"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_O-rmQ1frEeak-v4LxEsCQw" type="1063">
+        <children xmi:type="notation:Shape" xmi:id="_qvI1cFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_nmqBkFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_qvI1cVfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_qvKqoFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_oZfMsFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_qvKqoVfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_qvLRsFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_qDEZoFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_qvLRsVfrEeak-v4LxEsCQw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_O-rmRFfrEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_O-rmRVfrEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_O-rmRlfrEeak-v4LxEsCQw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O-rmR1frEeak-v4LxEsCQw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="OpenModel_Profile.profile.uml#_NtRBsFfrEeak-v4LxEsCQw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O-rmQVfrEeak-v4LxEsCQw" x="104" y="376"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_O_pPkFfrEeak-v4LxEsCQw" type="2006" fillColor="8905185" lineColor="14263149">
+      <children xmi:type="notation:DecorationNode" xmi:id="_O_pPklfrEeak-v4LxEsCQw" type="5023"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_O_pPk1frEeak-v4LxEsCQw" type="1063">
+        <children xmi:type="notation:Shape" xmi:id="_wDVS8FfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_tw9nsFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wDVS8VfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wDWhEFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_usdmoFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wDWhEVfrEeak-v4LxEsCQw"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_wDXIIFfrEeak-v4LxEsCQw" type="1037">
+          <element xmi:type="uml:EnumerationLiteral" href="OpenModel_Profile.profile.uml#_vencUFfrEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_wDXIIVfrEeak-v4LxEsCQw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_O_pPlFfrEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_O_pPlVfrEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_O_pPllfrEeak-v4LxEsCQw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O_pPl1frEeak-v4LxEsCQw"/>
+      </children>
+      <element xmi:type="uml:Enumeration" href="OpenModel_Profile.profile.uml#_OZ1z0FfrEeak-v4LxEsCQw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O_pPkVfrEeak-v4LxEsCQw" x="232" y="376"/>
     </children>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_W3I4SKiLEeSly6b4dPxjLg"/>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_090lsEsKEeWB6K89oO7z_w" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <element xmi:type="uml:Profile" href="OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
-    <edges xmi:type="notation:Connector" xmi:id="_CeKhYKiNEeSly6b4dPxjLg" type="1022" source="_Cdt1cKiNEeSly6b4dPxjLg" target="_W3I4HqiLEeSly6b4dPxjLg" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_CeKhYaiNEeSly6b4dPxjLg"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CeKhYqiNEeSly6b4dPxjLg" points="[-14, 0, 0, 25]$[-14, -25, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DggvMKiNEeSly6b4dPxjLg" id="(0.5422222222222223,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DggvMaiNEeSly6b4dPxjLg" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_MdJTAKiNEeSly6b4dPxjLg" type="1022" source="_McsnEKiNEeSly6b4dPxjLg" target="_W3I4K6iLEeSly6b4dPxjLg" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_MdJTAaiNEeSly6b4dPxjLg"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MdJTAqiNEeSly6b4dPxjLg" points="[52, 0, -23, 25]$[52, -25, -23, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NNfx4KiNEeSly6b4dPxjLg" id="(0.4864864864864865,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NNfx4aiNEeSly6b4dPxjLg" id="(0.5135135135135135,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Vx5b4KiNEeSly6b4dPxjLg" type="1022" source="_VxwR8KiNEeSly6b4dPxjLg" target="_W3I31KiLEeSly6b4dPxjLg" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Vx5b4aiNEeSly6b4dPxjLg"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Vx5b4qiNEeSly6b4dPxjLg" points="[-24, 0, 23, 25]$[-24, -25, 23, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WbtN4KiNEeSly6b4dPxjLg" id="(0.5555555555555556,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WbtN4aiNEeSly6b4dPxjLg" id="(0.29,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_BQc7oKiOEeSly6b4dPxjLg" type="1022" source="_BQEhIKiOEeSly6b4dPxjLg" target="_W3I4C6iLEeSly6b4dPxjLg" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_BQc7oaiOEeSly6b4dPxjLg"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BQc7oqiOEeSly6b4dPxjLg" points="[-13, 0, 1, 25]$[-13, -25, 1, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CGz74KiOEeSly6b4dPxjLg" id="(0.532871972318339,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CGz74aiOEeSly6b4dPxjLg" id="(0.4685714285714286,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_-EUIEKiTEeSly6b4dPxjLg" type="1022" source="_-D4DMKiTEeSly6b4dPxjLg" target="_W3I35qiLEeSly6b4dPxjLg" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_-EUIEaiTEeSly6b4dPxjLg"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-EUIEqiTEeSly6b4dPxjLg" points="[5, 0, -13, 25]$[5, -25, -13, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__eUn8KiTEeSly6b4dPxjLg" id="(0.46543778801843316,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__eUn8aiTEeSly6b4dPxjLg" id="(0.61,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_-9ADkKiTEeSly6b4dPxjLg" type="1022" source="_-8jXoKiTEeSly6b4dPxjLg" target="_W3I386iLEeSly6b4dPxjLg" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_-9ADkaiTEeSly6b4dPxjLg"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-9ADkqiTEeSly6b4dPxjLg" points="[16, 0, -26, 25]$[16, -25, -26, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__tgTcKiTEeSly6b4dPxjLg" id="(0.41450777202072536,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__tgTcaiTEeSly6b4dPxjLg" id="(0.76,1.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_oqvF8KiUEeSly6b4dPxjLg" type="1022" source="_oqcLAKiUEeSly6b4dPxjLg" target="_W3I3m6iLEeSly6b4dPxjLg" routing="Rectilinear">
       <styles xmi:type="notation:FontStyle" xmi:id="_oqvF8aiUEeSly6b4dPxjLg"/>
       <element xsi:nil="true"/>
@@ -969,8 +734,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_pT8bAaiUEeSly6b4dPxjLg"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pT8bAqiUEeSly6b4dPxjLg" points="[1, 0, -17, 34]$[1, -34, -17, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s0l3QKiUEeSly6b4dPxjLg" id="(0.4700460829493088,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s0l3QaiUEeSly6b4dPxjLg" id="(0.4846153846153846,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s0l3QKiUEeSly6b4dPxjLg" id="(0.42857142857142855,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s0l3QaiUEeSly6b4dPxjLg" id="(0.4818941504178273,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_p5IywKiUEeSly6b4dPxjLg" type="1022" source="_p4130KiUEeSly6b4dPxjLg" target="_W3I4OaiLEeSly6b4dPxjLg" routing="Rectilinear">
       <styles xmi:type="notation:FontStyle" xmi:id="_p5IywaiUEeSly6b4dPxjLg"/>
@@ -982,290 +747,135 @@
     <edges xmi:type="notation:Connector" xmi:id="_rdHG8KiUEeSly6b4dPxjLg" type="1022" source="_rcrCEKiUEeSly6b4dPxjLg" target="_W3I3rKiLEeSly6b4dPxjLg" routing="Rectilinear">
       <styles xmi:type="notation:FontStyle" xmi:id="_rdHG8aiUEeSly6b4dPxjLg"/>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rdHG8qiUEeSly6b4dPxjLg" points="[-7, 0, 10, 93]$[-7, -93, 10, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rdHG8qiUEeSly6b4dPxjLg" points="[-14, 0, 4, 52]$[-14, -52, 4, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tq5NIKiUEeSly6b4dPxjLg" id="(0.5395348837209303,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tq5NIaiUEeSly6b4dPxjLg" id="(0.4708029197080292,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_L0oWkKqzEeSqFPhVNQ1oeg" type="1022" source="_L0fMoKqzEeSqFPhVNQ1oeg" target="_W3I4JqiLEeSly6b4dPxjLg" routing="Rectilinear" lineColor="0">
-      <styles xmi:type="notation:FontStyle" xmi:id="_L0oWkaqzEeSqFPhVNQ1oeg" fontName="Segoe UI"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L0oWkqqzEeSqFPhVNQ1oeg" points="[324, -69, 25, 109]$[324, -150, 25, 28]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SdizEEsLEeWB6K89oO7z_w" id="(0.9765395894428153,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SdjaIEsLEeWB6K89oO7z_w" id="(0.74,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Xnrq8EZQEeW32YsOmT7W0Q" type="1022" source="_XnHqQEZQEeW32YsOmT7W0Q" target="_8xKUcEZPEeW32YsOmT7W0Q" routing="Rectilinear" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_Xnrq8UZQEeW32YsOmT7W0Q" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xnrq8kZQEeW32YsOmT7W0Q" points="[-18, 0, -8, 88]$[-18, -88, -8, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g309QEsJEeWPu70AtsUhhw" id="(0.6181818181818182,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xnrq8kZQEeW32YsOmT7W0Q" points="[-25, 0, -18, 149]$[-25, -149, -18, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g309QEsJEeWPu70AtsUhhw" id="(0.6045454545454545,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g309QUsJEeWPu70AtsUhhw" id="(0.5583941605839416,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_GC_dcEZWEeW32YsOmT7W0Q" type="1022" source="_GCiKcEZWEeW32YsOmT7W0Q" target="_6E4ssEZVEeW32YsOmT7W0Q" routing="Rectilinear" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_GC_dcUZWEeW32YsOmT7W0Q" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GC_dckZWEeW32YsOmT7W0Q" points="[10, 0, 26, 74]$[10, -74, 26, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g3ciwEsJEeWPu70AtsUhhw" id="(0.4636363636363636,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g3ciwUsJEeWPu70AtsUhhw" id="(0.4124087591240876,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GC_dckZWEeW32YsOmT7W0Q" points="[10, 0, 9, 33]$[10, -33, 9, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g3ciwEsJEeWPu70AtsUhhw" id="(0.45,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g3ciwUsJEeWPu70AtsUhhw" id="(0.4635036496350365,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_4dgBsEZhEeWzOqfPW42hmw" type="1022" source="_4cq7QEZhEeWzOqfPW42hmw" target="_bJE60EZgEeWzOqfPW42hmw" lineColor="0">
-      <styles xmi:type="notation:FontStyle" xmi:id="_4dgBsUZhEeWzOqfPW42hmw" fontName="Segoe UI"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4dgBskZhEeWzOqfPW42hmw" points="[0, 0, -546, 164]$[492, -148, -54, 16]"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_mO8CNJDhEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_mOrjgJDhEeW51dNDZIXIMA" target="_mO8CMJDhEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_mO8CNZDhEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mO8COZDhEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
+    <edges xmi:type="notation:Connector" xmi:id="_N51iQFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" target="_N507MFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_N51iQVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_N51iRVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mO8CNpDhEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mO8CN5DhEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mO8COJDhEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N51iQlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_N51iQ1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_N51iRFfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_mPk7YJDhEeW51dNDZIXIMA" type="1013" source="_W3I4K6iLEeSly6b4dPxjLg" target="_mOrjgJDhEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_mPk7YZDhEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_usAfoJ2CEeSDYd59zPupRA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mPk7YpDhEeW51dNDZIXIMA" points="[-27, 28, 134, -137]$[-161, 165, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ni3IMJDhEeW51dNDZIXIMA" id="(0.6232876712328768,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ni3vQJDhEeW51dNDZIXIMA" id="(0.33,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_qOscUJDhEeW51dNDZIXIMA" type="1013" source="_W3I31KiLEeSly6b4dPxjLg" target="_mOrjgJDhEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_qOscUZDhEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_Kg_CQJniEeGA7rUYI1JIwg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qOscUpDhEeW51dNDZIXIMA" points="[4, -27, 0, 132]$[0, -134, -4, 25]"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_rVSQ8JDhEeW51dNDZIXIMA" type="1013" source="_W3I4JqiLEeSly6b4dPxjLg" target="_mOrjgJDhEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_rVSQ8ZDhEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_NUNNcJ2CEeSDYd59zPupRA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rVSQ8pDhEeW51dNDZIXIMA" points="[-19, -27, 89, 132]$[-92, -134, 16, 25]"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Cf4IRJDiEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_CfoQoJDiEeW51dNDZIXIMA" target="_Cf4IQJDiEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Cf4IRZDiEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Cf4ISZDiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
+    <edges xmi:type="notation:Connector" xmi:id="_Pqu4JFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_PqMsoFfkEeak-v4LxEsCQw" target="_Pqu4IFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Pqu4JVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Pqu4KVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Cf4IRpDiEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cf4IR5DiEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Cf4ISJDiEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Pqu4JlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pqu4J1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Pqu4KFfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Cgz8YJDiEeW51dNDZIXIMA" type="1013" source="_W3I35qiLEeSly6b4dPxjLg" target="_CfoQoJDiEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Cgz8YZDiEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_HlsDQL7YEeGcHtJ-koFuEQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Cgz8YpDiEeW51dNDZIXIMA" points="[-33, 0, -77, 107]$[-33, -52, -77, 55]$[45, -52, 1, 55]$[45, -107, 1, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHp58JDiEeW51dNDZIXIMA" id="(0.98,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_DHqhAJDiEeW51dNDZIXIMA" id="(0.26,1.0)"/>
+    <edges xmi:type="notation:Connector" xmi:id="_PrYYYFfkEeak-v4LxEsCQw" type="1013" source="_W3I3kaiLEeSly6b4dPxjLg" target="_PqMsoFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_PrYYYVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_HXmXIHBhEd6FKu9XX1078A"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PrYYYlfkEeak-v4LxEsCQw" points="[-99, 76, 232, -177]$[-331, 253, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QNe_4FfkEeak-v4LxEsCQw" id="(0.47692307692307695,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QNfm8FfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_S3EZIJDiEeW51dNDZIXIMA" type="1013" source="_W3I386iLEeSly6b4dPxjLg" target="_CfoQoJDiEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_S3EZIZDiEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_u271EL7YEeGcHtJ-koFuEQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_S3EZIpDiEeW51dNDZIXIMA" points="[-7, 0, 88, 107]$[-7, -54, 88, 53]$[-78, -54, 17, 53]$[-78, -107, 17, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XfqU4JDiEeW51dNDZIXIMA" id="(0.5,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xfq78JDiEeW51dNDZIXIMA" id="(0.53,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_eVtmtJDiEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_eVeWIJDiEeW51dNDZIXIMA" target="_eVtmsJDiEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_eVtmtZDiEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eVtmuZDiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eVtmtpDiEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eVtmt5DiEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eVtmuJDiEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_eWXG8JDiEeW51dNDZIXIMA" type="1013" source="_W3I4HqiLEeSly6b4dPxjLg" target="_eVeWIJDiEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_eWXG8ZDiEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_BkIu0PNBEeGLMdrUcsEncQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eWXG8pDiEeW51dNDZIXIMA" points="[21, 28, -109, -137]$[130, 165, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f453wJDiEeW51dNDZIXIMA" id="(0.49,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_f453wZDiEeW51dNDZIXIMA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_syEilJDiEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_sxukUJDiEeW51dNDZIXIMA" target="_syEikJDiEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_syEilZDiEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_syEimZDiEeW51dNDZIXIMA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_R-nmVFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_R-K6YFfkEeak-v4LxEsCQw" target="_R-nmUFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_R-nmVVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_R-nmWVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_syEilpDiEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_syEil5DiEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_syEimJDiEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_R-nmVlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_R-nmV1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_R-nmWFfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_sywfEJDiEeW51dNDZIXIMA" type="1013" source="_W3I3m6iLEeSly6b4dPxjLg" target="_sxukUJDiEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_sywfEZDiEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_R_QfgFfkEeak-v4LxEsCQw" type="1013" source="_W3I3m6iLEeSly6b4dPxjLg" target="_R-K6YFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_R_QfgVfkEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_NDZcUHBhEd6FKu9XX1078A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sywfEpDiEeW51dNDZIXIMA" points="[6, 0, 6, 62]$[6, -30, 6, 32]$[6, -62, 6, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u0npIJDiEeW51dNDZIXIMA" id="(0.48255813953488375,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_u0npIZDiEeW51dNDZIXIMA" id="(0.46,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_R_QfglfkEeak-v4LxEsCQw" points="[10, 51, -45, -224]$[55, 275, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S2PK0FfkEeak-v4LxEsCQw" id="(0.502906976744186,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S2Px4FfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_szT4tJDiEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_szF2QJDiEeW51dNDZIXIMA" target="_szT4sJDiEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_szT4tZDiEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_szT4uZDiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_szT4tpDiEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_szT4t5DiEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_szT4uJDiEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_sz_1MJDiEeW51dNDZIXIMA" type="1013" source="_W3I35qiLEeSly6b4dPxjLg" target="_szF2QJDiEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_sz_1MZDiEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_5K_C4baPEeSnGaxGaNSs1w"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sz_1MpDiEeW51dNDZIXIMA" points="[-53, 0, -25, 107]$[-53, -107, -25, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0BbsQJDiEeW51dNDZIXIMA" id="(0.91,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0BbsQZDiEeW51dNDZIXIMA" id="(0.83,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_8pS595DiEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_8pCbQJDiEeW51dNDZIXIMA" target="_8pS585DiEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_8pS5-JDiEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8pThAJDiEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8pS5-ZDiEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8pS5-pDiEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8pS5-5DiEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_8qDu8JDiEeW51dNDZIXIMA" type="1013" source="_8xKUcEZPEeW32YsOmT7W0Q" target="_8pCbQJDiEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_8qDu8ZDiEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_nOpb8EZUEeW32YsOmT7W0Q"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8qDu8pDiEeW51dNDZIXIMA" points="[113, 0, -22, 72]$[113, -72, -22, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ERqMJDiEeW51dNDZIXIMA" id="(0.5255474452554745,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ERqMZDiEeW51dNDZIXIMA" id="(0.52,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Nf9VF5DjEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_NfvSoJDjEeW51dNDZIXIMA" target="_Nf9VE5DjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Nf9VGJDjEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Nf9VHJDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Nf9VGZDjEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Nf9VGpDjEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Nf9VG5DjEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NgoqgJDjEeW51dNDZIXIMA" type="1013" source="_bJE60EZgEeWzOqfPW42hmw" target="_NfvSoJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NgoqgZDjEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_3ciJYEZgEeWzOqfPW42hmw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NgoqgpDjEeW51dNDZIXIMA" points="[-54, 16, 495, -148]$[-549, 164, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PHn2cJDjEeW51dNDZIXIMA" id="(0.45871559633027525,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PHodgJDjEeW51dNDZIXIMA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Uf7X5JDjEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_UfrgQJDjEeW51dNDZIXIMA" target="_Uf7X4JDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Uf7X5ZDjEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Uf7X6ZDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uf7X5pDjEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uf7X55DjEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uf7X6JDjEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_UgoigJDjEeW51dNDZIXIMA" type="1013" source="_W3I4K6iLEeSly6b4dPxjLg" target="_UfrgQJDjEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_UgoigZDjEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_1tBEQJ2CEeSDYd59zPupRA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UgoigpDjEeW51dNDZIXIMA" points="[-59, 0, 0, 107]$[-59, -107, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Vj-O0JDjEeW51dNDZIXIMA" id="(0.6027397260273972,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Vj-14JDjEeW51dNDZIXIMA" id="(0.34,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cqTYVJDjEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_cqAdYJDjEeW51dNDZIXIMA" target="_cqTYUJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cqTYVZDjEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cqTYWZDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Interface"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cqTYVpDjEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cqTYV5DjEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cqTYWJDjEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_crGpkJDjEeW51dNDZIXIMA" type="1013" source="_W3I4OaiLEeSly6b4dPxjLg" target="_cqAdYJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_crGpkZDjEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_vdlJMKiIEeSJmIxGbzx9kA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_crGpkpDjEeW51dNDZIXIMA" points="[-82, -35, 655, 280]$[-737, -315, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eE8KUJDjEeW51dNDZIXIMA" id="(0.4708029197080292,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eE8KUZDjEeW51dNDZIXIMA" id="(0.5,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_gRCOdJDjEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_gQvTgJDjEeW51dNDZIXIMA" target="_gRCOcJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_gRCOdZDjEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gRCOeZDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_VW_QVFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_VWfhEFfkEeak-v4LxEsCQw" target="_VW_QUFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VW_QVVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VW_QWVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gRCOdpDjEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gRCOd5DjEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gRCOeJDjEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VW_QVlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VW_QV1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VW_QWFfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_gR2t0JDjEeW51dNDZIXIMA" type="1013" source="_6E4ssEZVEeW32YsOmT7W0Q" target="_gQvTgJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_gR2t0ZDjEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_VXmUUFfkEeak-v4LxEsCQw" type="1013" source="_6E4ssEZVEeW32YsOmT7W0Q" target="_VWfhEFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VXmUUVfkEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_FRG9HnBnEd6FKu9XX1078A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gR2t0pDjEeW51dNDZIXIMA" points="[-137, -41, 961, 289]$[-1098, -330, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hZd2IJDjEeW51dNDZIXIMA" id="(0.4854014598540146,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hZd2IZDjEeW51dNDZIXIMA" id="(0.5,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VXmUUlfkEeak-v4LxEsCQw" points="[-113, -52, 240, 112]$[-353, -164, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WLtR0FfkEeak-v4LxEsCQw" id="(0.5036496350364964,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WLuf8FfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7ci9hJDjEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_7cUUAJDjEeW51dNDZIXIMA" target="_7ci9gJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7ci9hZDjEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7ci9iZDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_XGMkJFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_XFsN0FfkEeak-v4LxEsCQw" target="_XGMkIFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XGMkJVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_XGNLMFfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7ci9hpDjEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7ci9h5DjEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7ci9iJDjEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XGMkJlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XGMkJ1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XGMkKFfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7dUZkJDjEeW51dNDZIXIMA" type="1013" source="_W3I3rKiLEeSly6b4dPxjLg" target="_7cUUAJDjEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7dUZkZDjEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_XG7j8FfkEeak-v4LxEsCQw" type="1013" source="_W3I3rKiLEeSly6b4dPxjLg" target="_XFsN0FfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_XG7j8VfkEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_sGoRgHEqEd6SxZ5y0DIogw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7dUZkpDjEeW51dNDZIXIMA" points="[107, 0, -39, 63]$[107, -63, -39, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_81u-AJDjEeW51dNDZIXIMA" id="(0.11313868613138686,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_81u-AZDjEeW51dNDZIXIMA" id="(0.9,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XG7j8lfkEeak-v4LxEsCQw" points="[-137, -33, 512, 122]$[-649, -155, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xzg9IFfkEeak-v4LxEsCQw" id="(0.5036496350364964,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XzhkMFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7d9SxJDjEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_7dvQUJDjEeW51dNDZIXIMA" target="_7d9SwJDjEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7d9SxZDjEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_7d9SyZDjEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
+    <edges xmi:type="notation:Connector" xmi:id="_ywkZcVfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_ywEDIFfkEeak-v4LxEsCQw" target="_ywjyY1fkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ywkZclfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ywkZdlfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Interface"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7d9SxpDjEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7d9Sx5DjEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7d9SyJDjEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ywkZc1fkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ywkZdFfkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ywkZdVfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_7e4f0JDjEeW51dNDZIXIMA" type="1013" source="_W3I4C6iLEeSly6b4dPxjLg" target="_7dvQUJDjEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_7e4f0ZDjEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_6EFhANyHEeG3LugjzyfwGA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7e4f0pDjEeW51dNDZIXIMA" points="[15, 0, -36, 108]$[15, -54, -36, 54]$[51, -54, 0, 54]$[51, -108, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8RqnoJDjEeW51dNDZIXIMA" id="(0.5370370370370371,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8RrOsJDjEeW51dNDZIXIMA" id="(0.42,1.0)"/>
+    <edges xmi:type="notation:Connector" xmi:id="_yxYRwFfkEeak-v4LxEsCQw" type="1013" source="_W3I4OaiLEeSly6b4dPxjLg" target="_ywEDIFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_yxYRwVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_vdlJMKiIEeSJmIxGbzx9kA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yxYRwlfkEeak-v4LxEsCQw" points="[-14, -35, 43, 112]$[-57, -147, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zbbUUFfkEeak-v4LxEsCQw" id="(0.4744525547445255,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zbb7YFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JVmYBJDkEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_JVUEIJDkEeW51dNDZIXIMA" target="_JVmYAJDkEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JVmYBZDkEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JVmYCZDkEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+    <edges xmi:type="notation:Connector" xmi:id="_3S8_hFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_3ScCIFfkEeak-v4LxEsCQw" target="_3S8_gFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3S8_hVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_3S9mkFfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JVmYBpDkEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JVmYB5DkEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JVmYCJDkEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3S8_hlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3S8_h1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3S8_iFfkEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JWa3YJDkEeW51dNDZIXIMA" type="1013" source="_W3I3kaiLEeSly6b4dPxjLg" target="_JVUEIJDkEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JWa3YZDkEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_HXmXIHBhEd6FKu9XX1078A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JWa3YpDkEeW51dNDZIXIMA" points="[71, 0, -33, 55]$[71, -55, -33, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ST5vwJDkEeW51dNDZIXIMA" id="(0.5,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ST5vwZDkEeW51dNDZIXIMA" id="(0.46,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JXGM1JDkEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_JW28QJDkEeW51dNDZIXIMA" target="_JXGM0JDkEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JXGM1ZDkEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_JXGM2ZDkEeW51dNDZIXIMA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JXGM1pDkEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXGM15DkEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JXGM2JDkEeW51dNDZIXIMA"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_JX8hYJDkEeW51dNDZIXIMA" type="1013" source="_W3I4C6iLEeSly6b4dPxjLg" target="_JW28QJDkEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_JX8hYZDkEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_ia2l4NyHEeG3LugjzyfwGA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JX8hYpDkEeW51dNDZIXIMA" points="[-38, 0, -26, 107]$[-38, -107, -26, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lag2EJDkEeW51dNDZIXIMA" id="(0.31213872832369943,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LahdIJDkEeW51dNDZIXIMA" id="(0.77,1.0)"/>
+    <edges xmi:type="notation:Connector" xmi:id="_3T0iMFfkEeak-v4LxEsCQw" type="1013" source="_8xKUcEZPEeW32YsOmT7W0Q" target="_3ScCIFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3T0iMVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_nOpb8EZUEeW32YsOmT7W0Q"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3T0iMlfkEeak-v4LxEsCQw" points="[-110, 46, 571, -237]$[-681, 283, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4OmIYFfkEeak-v4LxEsCQw" id="(0.5036496350364964,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4OmIYVfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_W3I4gaiLEeSly6b4dPxjLg" type="PapyrusUMLProfileDiagram" name="Lifecycle" measurementUnit="Pixel">
@@ -1284,7 +894,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9inUqqzEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_FU4UgJ2EEeSk-dMsN-xZbw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4hqiLEeSly6b4dPxjLg" x="15" y="19" width="141" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4hqiLEeSly6b4dPxjLg" x="24" y="56" width="145" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I4h6iLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="14263149" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I4iKiLEeSly6b4dPxjLg" type="1034">
@@ -1301,7 +911,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9inVaqzEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_HmOsEJ2EEeSk-dMsN-xZbw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4i6iLEeSly6b4dPxjLg" x="15" y="93" width="141" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4i6iLEeSly6b4dPxjLg" x="24" y="232" width="145" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I4jKiLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="14263149" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I4jaiLEeSly6b4dPxjLg" type="1034">
@@ -1318,7 +928,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9inWKqzEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_LEgJwJ2EEeSk-dMsN-xZbw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4kKiLEeSly6b4dPxjLg" x="15" y="167" width="141" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4kKiLEeSly6b4dPxjLg" x="24" y="496" width="145" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I4kaiLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="14263149" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I4kqiLEeSly6b4dPxjLg" type="1034">
@@ -1335,24 +945,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9inW6qzEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_M6xu4J2EEeSk-dMsN-xZbw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4laiLEeSly6b4dPxjLg" x="15" y="242" width="141" height="57"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W3I4lqiLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="14263149" lineWidth="1">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W3I4l6iLEeSly6b4dPxjLg" type="1034">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_OwwZEJ2EEeSk-dMsN-xZbw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4mKiLEeSly6b4dPxjLg" type="1071">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_OwwZEJ2EEeSk-dMsN-xZbw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W3I4maiLEeSly6b4dPxjLg" visible="false" type="1019">
-        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_OwwZEJ2EEeSk-dMsN-xZbw"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_x9inXKqzEeSqFPhVNQ1oeg" visible="false" type="compartment_shape_display">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_x9inXaqzEeSqFPhVNQ1oeg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9inXqqzEeSqFPhVNQ1oeg"/>
-      </children>
-      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_OwwZEJ2EEeSk-dMsN-xZbw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4mqiLEeSly6b4dPxjLg" x="15" y="378" width="141" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4laiLEeSly6b4dPxjLg" x="24" y="408" width="145" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I4m6iLEeSly6b4dPxjLg" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="14263149" lineWidth="1">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I4nKiLEeSly6b4dPxjLg" type="1034">
@@ -1369,7 +962,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x9inYaqzEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_QGmKoJ2EEeSk-dMsN-xZbw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4n6iLEeSly6b4dPxjLg" x="15" y="451" width="141" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I4n6iLEeSly6b4dPxjLg" x="24" y="144" width="145" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_vxEZ0KrhEeSyfrZlx_q6Cw" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vxEZ0qrhEeSyfrZlx_q6Cw" source="ShadowFigure">
@@ -1383,21 +976,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_vxEZ2KrhEeSyfrZlx_q6Cw" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_pWHvoKrhEeSyfrZlx_q6Cw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vxEZ0arhEeSyfrZlx_q6Cw" x="-281" y="505" width="286"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_2STSMKrhEeSyfrZlx_q6Cw" type="1002" fontName="Segoe UI" lineColor="0">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2STSMqrhEeSyfrZlx_q6Cw" source="ShadowFigure">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2SZY0KrhEeSyfrZlx_q6Cw" key="ShadowFigure_Value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2SZY0arhEeSyfrZlx_q6Cw" source="displayNameLabelIcon">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2SZY0qrhEeSyfrZlx_q6Cw" key="displayNameLabelIcon_value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2SZY06rhEeSyfrZlx_q6Cw" source="QualifiedName">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2SZY1KrhEeSyfrZlx_q6Cw" key="QualifiedNameDepth" value="1000"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_2SZY1arhEeSyfrZlx_q6Cw" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_lp_cIKrhEeSyfrZlx_q6Cw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2STSMarhEeSyfrZlx_q6Cw" x="-281" y="380" width="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vxEZ0arhEeSyfrZlx_q6Cw" x="-288" y="104" width="286" height="97"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_AM-yoKriEeSyfrZlx_q6Cw" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AM-yoqriEeSyfrZlx_q6Cw" source="ShadowFigure">
@@ -1411,7 +990,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_ANE5QKriEeSyfrZlx_q6Cw" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_hQ8YQKrhEeSyfrZlx_q6Cw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AM-yoariEeSyfrZlx_q6Cw" x="-281" y="239" width="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AM-yoariEeSyfrZlx_q6Cw" x="-288" y="416" width="286" height="68"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_IaXq0KriEeSyfrZlx_q6Cw" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IaXq0qriEeSyfrZlx_q6Cw" source="ShadowFigure">
@@ -1425,7 +1004,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_IaXq2KriEeSyfrZlx_q6Cw" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_c2XDUKrhEeSyfrZlx_q6Cw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IaXq0ariEeSyfrZlx_q6Cw" x="-281" y="159" width="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IaXq0ariEeSyfrZlx_q6Cw" x="-288" y="496" width="286"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_PPQfAKriEeSyfrZlx_q6Cw" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PPQfAqriEeSyfrZlx_q6Cw" source="ShadowFigure">
@@ -1439,7 +1018,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_PPQfCKriEeSyfrZlx_q6Cw" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_YD8dMKrhEeSyfrZlx_q6Cw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PPQfAariEeSyfrZlx_q6Cw" x="-281" y="36" width="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PPQfAariEeSyfrZlx_q6Cw" x="-288" y="216" width="286"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_U1K-oKriEeSyfrZlx_q6Cw" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_U1K-oqriEeSyfrZlx_q6Cw" source="ShadowFigure">
@@ -1453,7 +1032,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_U1RFRariEeSyfrZlx_q6Cw" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_N7uQAKrhEeSyfrZlx_q6Cw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U1K-oariEeSyfrZlx_q6Cw" x="-280" y="-41" width="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_U1K-oariEeSyfrZlx_q6Cw" x="-289" y="21" width="286" height="68"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_mcv8EJDeEeW51dNDZIXIMA" type="1026" fillColor="15912618" lineColor="14263149">
       <children xmi:type="notation:DecorationNode" xmi:id="_mcwjIJDeEeW51dNDZIXIMA" type="1034"/>
@@ -1470,12 +1049,12 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mcxKOZDeEeW51dNDZIXIMA"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_ma6wEJDeEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mcv8EZDeEeW51dNDZIXIMA" x="15" y="313" width="141" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mcv8EZDeEeW51dNDZIXIMA" x="24" y="-32" width="145" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_rCrv8JDfEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_rCsXAJDfEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_qK1h8JDfEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rCrv8ZDfEeW51dNDZIXIMA" x="-281" y="316" width="286"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rCrv8ZDfEeW51dNDZIXIMA" x="-288" y="-48" width="286" height="57"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_JhmwgJDgEeW51dNDZIXIMA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_JhmwgZDgEeW51dNDZIXIMA" showTitle="true"/>
@@ -1549,18 +1128,40 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aIqCUpDgEeW51dNDZIXIMA" x="200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_beFkMJDgEeW51dNDZIXIMA" type="1031">
-      <children xmi:type="notation:DecorationNode" xmi:id="_beGLQJDgEeW51dNDZIXIMA" type="1084"/>
-      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_beFkMZDgEeW51dNDZIXIMA" x="428" y="249"/>
+    <children xmi:type="notation:Shape" xmi:id="_yulC0BdhEeatXPvf_dRw8w" type="1026" fillColor="15912618" lineColor="14263149">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yunfEBdhEeatXPvf_dRw8w" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yunfERdhEeatXPvf_dRw8w" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yunfEhdhEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yunfExdhEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yunfFBdhEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yunfFRdhEeatXPvf_dRw8w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yunfFhdhEeatXPvf_dRw8w" visible="false" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_yunfFxdhEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_yunfGBdhEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_yunfGRdhEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yunfGhdhEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_wvWWABdhEeatXPvf_dRw8w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yulC0RdhEeatXPvf_dRw8w" x="24" y="320" width="145" height="58"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_beTmo5DgEeW51dNDZIXIMA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_beTmpJDgEeW51dNDZIXIMA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_beTmppDgEeW51dNDZIXIMA" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_3rDj4BdhEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3rEK8BdhEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_19o_0BdhEeatXPvf_dRw8w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3rDj4RdhEeatXPvf_dRw8w" x="-288" y="344" width="281"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_A-45UFflEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_A-6HcFflEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A-5gYFflEeak-v4LxEsCQw" x="272" y="232"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_A_YokFflEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_A_YokVflEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_A_Yok1flEeak-v4LxEsCQw" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_beTmpZDgEeW51dNDZIXIMA" x="200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A_YoklflEeak-v4LxEsCQw" x="200"/>
     </children>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_W3I4zaiLEeSly6b4dPxjLg"/>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_1xZ-wEsKEeWB6K89oO7z_w" name="diagram_compatibility_version" stringValue="1.1.0"/>
@@ -1569,45 +1170,42 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_vxi68arhEeSyfrZlx_q6Cw" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vxi68qrhEeSyfrZlx_q6Cw" points="[0, 0, -85, -420]$[80, 394, -5, -26]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b6oYkEsLEeWB6K89oO7z_w" id="(1.0,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b6o_oEsLEeWB6K89oO7z_w" id="(0.0,0.9310344827586207)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_2SrssKrhEeSyfrZlx_q6Cw" type="1022" source="_2STSMKrhEeSyfrZlx_q6Cw" target="_W3I4lqiLEeSly6b4dPxjLg" lineColor="0">
-      <styles xmi:type="notation:FontStyle" xmi:id="_2SrssarhEeSyfrZlx_q6Cw" fontName="Segoe UI"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2SrssqrhEeSyfrZlx_q6Cw" points="[0, 0, -85, -347]$[79, 321, -6, -26]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-gZQEsLEeWB6K89oO7z_w" id="(1.0,0.3247863247863248)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e-hAUEsLEeWB6K89oO7z_w" id="(0.0,0.6551724137931034)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b6oYkEsLEeWB6K89oO7z_w" id="(1.0,0.47058823529411764)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b6o_oEsLEeWB6K89oO7z_w" id="(0.0,0.5517241379310345)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ANXNIKriEeSyfrZlx_q6Cw" type="1022" source="_AM-yoKriEeSyfrZlx_q6Cw" target="_W3I4kaiLEeSly6b4dPxjLg" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_ANXNIariEeSyfrZlx_q6Cw" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ANXNIqriEeSyfrZlx_q6Cw" points="[0, 0, -85, -273]$[77, 247, -8, -26]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8C3RoBdhEeatXPvf_dRw8w" id="(1.0,0.3888888888888889)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8C34sBdhEeatXPvf_dRw8w" id="(0.0,0.6206896551724138)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Iap-sKriEeSyfrZlx_q6Cw" type="1022" source="_IaXq0KriEeSyfrZlx_q6Cw" target="_W3I4jKiLEeSly6b4dPxjLg" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_Iap-sariEeSyfrZlx_q6Cw" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Iap-sqriEeSyfrZlx_q6Cw" points="[0, 0, -85, -199]$[74, 173, -11, -26]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cymiYEsLEeWB6K89oO7z_w" id="(1.0,0.5138888888888888)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cymiYEsLEeWB6K89oO7z_w" id="(1.0,0.4027777777777778)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cynJcEsLEeWB6K89oO7z_w" id="(0.0,0.5)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_PPiy4KriEeSyfrZlx_q6Cw" type="1022" source="_PPQfAKriEeSyfrZlx_q6Cw" target="_W3I4h6iLEeSly6b4dPxjLg" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_PPiy4ariEeSyfrZlx_q6Cw" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PPiy4qriEeSyfrZlx_q6Cw" points="[0, 0, -85, -125]$[67, 99, -18, -26]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ar8JMBdhEeatXPvf_dRw8w" id="(1.0,0.4188034188034188)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ar_zkBdhEeatXPvf_dRw8w" id="(0.0,0.5689655172413793)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_U1dSgKriEeSyfrZlx_q6Cw" type="1022" source="_U1K-oKriEeSyfrZlx_q6Cw" target="_W3I4gqiLEeSly6b4dPxjLg" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_U1dSgariEeSyfrZlx_q6Cw" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_U1dSgqriEeSyfrZlx_q6Cw" points="[0, 0, -85, -51]$[41, 25, -44, -26]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_deKA0EsLEeWB6K89oO7z_w" id="(1.0,0.9722222222222222)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_deKA0UsLEeWB6K89oO7z_w" id="(0.0,0.20689655172413793)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_deKA0EsLEeWB6K89oO7z_w" id="(1.0,0.6388888888888888)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_deKA0UsLEeWB6K89oO7z_w" id="(0.0,0.7413793103448276)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_rDHNwJDfEeW51dNDZIXIMA" type="1022" source="_rCrv8JDfEeW51dNDZIXIMA" target="_mcv8EJDeEeW51dNDZIXIMA">
       <styles xmi:type="notation:FontStyle" xmi:id="_rDHNwZDfEeW51dNDZIXIMA"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rDHNwpDfEeW51dNDZIXIMA" points="[0, 0, -85, -342]$[78, 313, -7, -29]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_snbgMJDfEeW51dNDZIXIMA" id="(1.0,0.5166666666666667)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_snbgMJDfEeW51dNDZIXIMA" id="(1.0,0.5087719298245614)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_sncHQJDfEeW51dNDZIXIMA" id="(0.0,0.5862068965517241)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JhmwhJDgEeW51dNDZIXIMA" type="StereotypeCommentLink" target="_JhmwgJDgEeW51dNDZIXIMA">
@@ -1700,65 +1298,713 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aIqCV5DgEeW51dNDZIXIMA"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_aIqCWJDgEeW51dNDZIXIMA"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_beTmp5DgEeW51dNDZIXIMA" type="StereotypeCommentLink" source="_beFkMJDgEeW51dNDZIXIMA" target="_beTmo5DgEeW51dNDZIXIMA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_beTmqJDgEeW51dNDZIXIMA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_beUNsJDgEeW51dNDZIXIMA" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_3r0Y4BdhEeatXPvf_dRw8w" type="1022" source="_3rDj4BdhEeatXPvf_dRw8w" target="_yulC0BdhEeatXPvf_dRw8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_3r0Y4RdhEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3r0Y4hdhEeatXPvf_dRw8w" points="[0, 0, -66, -378]$[57, 328, -9, -50]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4czJ4BdhEeatXPvf_dRw8w" id="(1.0,0.36666666666666664)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4czw8BdhEeatXPvf_dRw8w" id="(0.0,0.5517241379310345)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_A_YolFflEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_A-45UFflEeak-v4LxEsCQw" target="_A_YokFflEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_A_YolVflEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_A_YomVflEeak-v4LxEsCQw" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_beTmqZDgEeW51dNDZIXIMA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_beTmqpDgEeW51dNDZIXIMA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_beTmq5DgEeW51dNDZIXIMA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_A_YollflEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A_Yol1flEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A_YomFflEeak-v4LxEsCQw"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_behCAJDgEeW51dNDZIXIMA" type="1013" source="_W3I4lqiLEeSly6b4dPxjLg" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_behCAZDgEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_VqOy0EcsEeWC5rv-TLU4gA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_behCApDgEeW51dNDZIXIMA" points="[0, 28, -272, 116]$[324, 28, 52, 116]$[324, -81, 52, 7]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2HhsJDgEeW51dNDZIXIMA" id="(1.0,0.034482758620689655)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2HhsZDgEeW51dNDZIXIMA" id="(0.0,0.86)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_b4YTgJDgEeW51dNDZIXIMA" type="1013" source="_W3I4gqiLEeSly6b4dPxjLg" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_b4YTgZDgEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_sBFgEEcsEeWC5rv-TLU4gA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b4YTgpDgEeW51dNDZIXIMA" points="[0, 8, -354, -198]$[354, 8, 0, -198]$[354, 206, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2G6opDgEeW51dNDZIXIMA" id="(1.0,0.41379310344827586)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2G6o5DgEeW51dNDZIXIMA" id="(0.82,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_cW-UAJDgEeW51dNDZIXIMA" type="1013" source="_W3I4m6iLEeSly6b4dPxjLg" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_cW-UAZDgEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_A_t_wFflEeak-v4LxEsCQw" type="1013" source="_W3I4m6iLEeSly6b4dPxjLg" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_A_t_wVflEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_RegZQEcsEeWC5rv-TLU4gA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cW-UApDgEeW51dNDZIXIMA" points="[20, 32, -277, 184]$[375, 32, 78, 184]$[375, -152, 78, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2IIwJDgEeW51dNDZIXIMA" id="(0.8581560283687943,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2IIwZDgEeW51dNDZIXIMA" id="(0.05,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_A_t_wlflEeak-v4LxEsCQw" points="[53, -34, -135, -64]$[180, -34, -8, -64]$[180, 30, -8, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-f6kVh1EeaaGczhAqBKxg" id="(0.6344827586206897,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-f6klh1EeaaGczhAqBKxg" id="(0.32,0.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_c4xZgJDgEeW51dNDZIXIMA" type="1013" source="_W3I4h6iLEeSly6b4dPxjLg" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_c4xZgZDgEeW51dNDZIXIMA"/>
-      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_ni6roUcsEeWC5rv-TLU4gA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c4xZgpDgEeW51dNDZIXIMA" points="[0, 11, -358, -124]$[324, 11, -34, -124]$[324, 135, -34, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2HhspDgEeW51dNDZIXIMA" id="(1.0,0.3620689655172414)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2Hhs5DgEeW51dNDZIXIMA" id="(0.86,0.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_dWSb8JDgEeW51dNDZIXIMA" type="1013" source="_W3I4kaiLEeSly6b4dPxjLg" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_dWSb8ZDgEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_EKf5sFflEeak-v4LxEsCQw" type="1013" source="_W3I4kaiLEeSly6b4dPxjLg" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EKf5sVflEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_fBxxAEcsEeWC5rv-TLU4gA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dWSb8pDgEeW51dNDZIXIMA" points="[71, -18, -493, 124]$[514, -130, -50, 12]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2IIwpDgEeW51dNDZIXIMA" id="(1.0,0.5789473684210527)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2IIw5DgEeW51dNDZIXIMA" id="(0.0,0.52)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EKf5slflEeak-v4LxEsCQw" points="[35, 24, -119, 150]$[186, 24, 32, 150]$[186, -126, 32, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-gholh1EeaaGczhAqBKxg" id="(0.7586206896551724,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-gho1h1EeaaGczhAqBKxg" id="(0.16,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_fm7B0JDgEeW51dNDZIXIMA" type="1013" source="_W3I4jKiLEeSly6b4dPxjLg" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_fm7B0ZDgEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_EesBAFflEeak-v4LxEsCQw" type="1013" source="_W3I4jKiLEeSly6b4dPxjLg" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_EesBAVflEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_jHY7gUcsEeWC5rv-TLU4gA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fm7B0pDgEeW51dNDZIXIMA" points="[0, 5, -300, -52]$[294, 5, -6, -52]$[294, 57, -6, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2G6oJDgEeW51dNDZIXIMA" id="(1.0,0.43103448275862066)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i2G6oZDgEeW51dNDZIXIMA" id="(0.28,0.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EesBAlflEeak-v4LxEsCQw" points="[53, 24, -136, 238]$[228, 24, 39, 238]$[228, -214, 39, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-fTgFh1EeaaGczhAqBKxg" id="(0.6344827586206897,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-f6kFh1EeaaGczhAqBKxg" id="(0.33,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_g4k28JDgEeW51dNDZIXIMA" type="1013" source="_mcv8EJDeEeW51dNDZIXIMA" target="_beFkMJDgEeW51dNDZIXIMA" routing="Rectilinear">
-      <styles xmi:type="notation:FontStyle" xmi:id="_g4k28ZDgEeW51dNDZIXIMA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_E1kP8FflEeak-v4LxEsCQw" type="1013" source="_W3I4h6iLEeSly6b4dPxjLg" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_E1kP8VflEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_ni6roUcsEeWC5rv-TLU4gA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E1kP8lflEeak-v4LxEsCQw" points="[0, -23, -103, 20]$[103, -23, 0, 20]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-hIslh1EeaaGczhAqBKxg" id="(1.0,0.8103448275862069)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-hvwFh1EeaaGczhAqBKxg" id="(0.0,0.08)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_FHMLcFflEeak-v4LxEsCQw" type="1013" source="_W3I4gqiLEeSly6b4dPxjLg" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_FHMLcVflEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_sBFgEEcsEeWC5rv-TLU4gA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FHMLclflEeak-v4LxEsCQw" points="[56, -34, -157, -152]$[207, -34, -6, -152]$[207, 118, -6, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-ghoFh1EeaaGczhAqBKxg" id="(0.6137931034482759,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-ghoVh1EeaaGczhAqBKxg" id="(0.54,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HG1H8FflEeak-v4LxEsCQw" type="1013" source="_mcv8EJDeEeW51dNDZIXIMA" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HG1H8VflEeak-v4LxEsCQw"/>
       <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_g4FHsJDgEeW51dNDZIXIMA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g4k28pDgEeW51dNDZIXIMA" points="[0, 26, -272, 54]$[294, 26, 22, 54]$[294, -23, 22, 5]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g5FNQJDgEeW51dNDZIXIMA" id="(1.0,0.15517241379310345)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g5FNQZDgEeW51dNDZIXIMA" id="(0.0,0.9)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HG1H8lflEeak-v4LxEsCQw" points="[53, -34, -195, -240]$[228, -34, -20, -240]$[228, 206, -20, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-hvwVh1EeaaGczhAqBKxg" id="(0.6344827586206897,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-hvwlh1EeaaGczhAqBKxg" id="(0.92,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_JMi3QFflEeak-v4LxEsCQw" type="1013" source="_yulC0BdhEeatXPvf_dRw8w" target="_A-45UFflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_JMi3QVflEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_QiKnYBdiEeatXPvf_dRw8w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JMi3QlflEeak-v4LxEsCQw" points="[0, -26, -103, 79]$[127, -26, 24, 79]$[127, -88, 24, 17]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-hIsFh1EeaaGczhAqBKxg" id="(1.0,0.8620689655172413)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2-hIsVh1EeaaGczhAqBKxg" id="(0.0,0.66)"/>
     </edges>
   </notation:Diagram>
   <css:ModelStyleSheets xmi:id="_hNQ94KiLEeSly6b4dPxjLg"/>
+  <notation:Diagram xmi:id="_1C8x0BdkEeatXPvf_dRw8w" type="PapyrusUMLProfileDiagram" name="OpenModelProfile_OptionalStereotypes" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_1C8yDhdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yDxdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yEBdkEeatXPvf_dRw8w" type="1071">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yERdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yEhdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8yExdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yFBdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_jiSAMI7kEeGyB5ASrrNdIA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yFRdkEeatXPvf_dRw8w" x="223" y="-192" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yFhdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yFxdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yGBdkEeatXPvf_dRw8w" type="1071">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yGRdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yGhdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8yGxdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yHBdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_27D5AL7XEeGcHtJ-koFuEQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yHRdkEeatXPvf_dRw8w" x="308" y="248" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yHhdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yHxdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yIBdkEeatXPvf_dRw8w" type="1071">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yIRdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yIhdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8yIxdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yJBdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_el7rwL7YEeGcHtJ-koFuEQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yJRdkEeatXPvf_dRw8w" x="524" y="248" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yPBdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yPRdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yPhdkEeatXPvf_dRw8w" type="1071">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yPxdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yQBdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8yQRdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yQhdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_bmZPgNyHEeG3LugjzyfwGA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yQxdkEeatXPvf_dRw8w" x="-52" y="248" width="108" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yRBdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yRRdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yRhdkEeatXPvf_dRw8w" type="1071">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yRxdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8ySBdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8ySRdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yShdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_3E1eYPNAEeGLMdrUcsEncQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ySxdkEeatXPvf_dRw8w" x="-176" y="-192" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yTBdkEeatXPvf_dRw8w" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yTRdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yThdkEeatXPvf_dRw8w" type="1071">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yTxdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yUBdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8yURdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yUhdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_vQjMkJ2BEeSDYd59zPupRA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yUxdkEeatXPvf_dRw8w" x="352" y="-192" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yVBdkEeatXPvf_dRw8w" type="1026" fontName="Segoe UI" fontHeight="8" fillColor="15912618" transparency="0" lineColor="12678440" lineWidth="1">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yVRdkEeatXPvf_dRw8w" type="1034">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yVhdkEeatXPvf_dRw8w" type="1071">
+        <children xmi:type="notation:Shape" xmi:id="_1C8yVxdkEeatXPvf_dRw8w" type="3002" fontHeight="8">
+          <styles xmi:type="notation:StringListValueStyle" xmi:id="_1C8yWBdkEeatXPvf_dRw8w" name="maskLabel">
+            <stringListValue>visibility</stringListValue>
+            <stringListValue>name</stringListValue>
+            <stringListValue>derived</stringListValue>
+            <stringListValue>multiplicity</stringListValue>
+            <stringListValue>defaultValue</stringListValue>
+            <stringListValue>type</stringListValue>
+          </styles>
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_ny5SwJ2CEeSDYd59zPupRA"/>
+        </children>
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yWRdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8yWhdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8yWxdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yXBdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_h7id0J2CEeSDYd59zPupRA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yXRdkEeatXPvf_dRw8w" x="16" y="-192" height="55"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yahdkEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yaxdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_GxMCgPNBEeGLMdrUcsEncQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ybBdkEeatXPvf_dRw8w" x="-238" y="-112" width="225" height="41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8ybRdkEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8ybhdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_-Js00KiHEeSJmIxGbzx9kA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ybxdkEeatXPvf_dRw8w" x="-3" y="-112" width="185" height="41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8ycBdkEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8ycRdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_tH7r0I7kEeGyB5ASrrNdIA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ychdkEeatXPvf_dRw8w" x="189" y="-112" width="169" height="41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8ycxdkEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8ydBdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_s8198NyHEeG3LugjzyfwGA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ydRdkEeatXPvf_dRw8w" x="-234" y="328" width="473"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8ydhdkEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8ydxdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_9H4noL7XEeGcHtJ-koFuEQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yeBdkEeatXPvf_dRw8w" x="250" y="328" width="217" height="41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yeRdkEeatXPvf_dRw8w" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yehdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_htBYgL7YEeGcHtJ-koFuEQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yexdkEeatXPvf_dRw8w" x="478" y="328" width="193" height="41"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8yiBdkEeatXPvf_dRw8w" type="1002" fontName="Segoe UI" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8yiRdkEeatXPvf_dRw8w" source="ShadowFigure">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8yihdkEeatXPvf_dRw8w" key="ShadowFigure_Value" value="false"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8yixdkEeatXPvf_dRw8w" source="displayNameLabelIcon">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8yjBdkEeatXPvf_dRw8w" key="displayNameLabelIcon_value" value="false"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8yjRdkEeatXPvf_dRw8w" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8yjhdkEeatXPvf_dRw8w" key="QualifiedNameDepth" value="1000"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yjxdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_JvB8AKqzEeSqFPhVNQ1oeg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ykBdkEeatXPvf_dRw8w" x="-240" y="-24" width="913"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8y4hdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" lineColor="12678440">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y4xdkEeatXPvf_dRw8w" source="ShadowFigure">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8y5BdkEeatXPvf_dRw8w" key="ShadowFigure_Value" value="false"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y5RdkEeatXPvf_dRw8w" source="displayNameLabelIcon">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8y5hdkEeatXPvf_dRw8w" key="displayNameLabelIcon_value" value="false"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y5xdkEeatXPvf_dRw8w" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8y6BdkEeatXPvf_dRw8w" key="QualifiedNameDepth" value="1000"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8y6RdkEeatXPvf_dRw8w" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8y6hdkEeatXPvf_dRw8w" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8y6xdkEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_1C8y7BdkEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_1C8y7RdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y7hdkEeatXPvf_dRw8w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8y7xdkEeatXPvf_dRw8w" visible="false" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8y8BdkEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_1C8y8RdkEeatXPvf_dRw8w"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_1C8y8hdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y8xdkEeatXPvf_dRw8w"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_1C8y9BdkEeatXPvf_dRw8w" visible="false" type="compartment_shape_display">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_1C8y9RdkEeatXPvf_dRw8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y9hdkEeatXPvf_dRw8w"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_aUYHcEZgEeWzOqfPW42hmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y9xdkEeatXPvf_dRw8w" x="504" y="-192" width="109" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_1C8y-BdkEeatXPvf_dRw8w" type="1002" fontName="Segoe UI" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y-RdkEeatXPvf_dRw8w" source="ShadowFigure">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8y-hdkEeatXPvf_dRw8w" key="ShadowFigure_Value" value="false"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y-xdkEeatXPvf_dRw8w" source="displayNameLabelIcon">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8y_BdkEeatXPvf_dRw8w" key="displayNameLabelIcon_value" value="false"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y_RdkEeatXPvf_dRw8w" source="QualifiedName">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8y_hdkEeatXPvf_dRw8w" key="QualifiedNameDepth" value="1000"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_1C8y_xdkEeatXPvf_dRw8w" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_Uyzf0EZhEeWzOqfPW42hmw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8zABdkEeatXPvf_dRw8w" x="448" y="-110" width="221"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uWAUcBgvEeavBLLlfRT9gQ" type="1026" fillColor="15912618" lineColor="12678440">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uWBikBgvEeavBLLlfRT9gQ" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_uWCJoBgvEeavBLLlfRT9gQ" type="1071">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_uWCJoRgvEeavBLLlfRT9gQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_uWCJohgvEeavBLLlfRT9gQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_uWCJoxgvEeavBLLlfRT9gQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uWCJpBgvEeavBLLlfRT9gQ"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_uWCJpRgvEeavBLLlfRT9gQ" visible="false" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_uWCJphgvEeavBLLlfRT9gQ"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_uWCJpxgvEeavBLLlfRT9gQ"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_uWCJqBgvEeavBLLlfRT9gQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uWCJqRgvEeavBLLlfRT9gQ"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_OwwZEJ2EEeSk-dMsN-xZbw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uWAUcRgvEeavBLLlfRT9gQ" x="-25" y="592" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZsVP0BgxEeavBLLlfRT9gQ" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZsV24BgxEeavBLLlfRT9gQ" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_lp_cIKrhEeSyfrZlx_q6Cw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZsVP0RgxEeavBLLlfRT9gQ" x="-162" y="672" width="375"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Y8f-cFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Y8f-clfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y8f-cVfkEeak-v4LxEsCQw" x="223" y="-304"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Y894gFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Y894gVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Y894g1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y894glfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_b3700FfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_b39C8FfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b38b4FfkEeak-v4LxEsCQw" x="422" y="136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_b4iRwFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_b4iRwVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_b4iRw1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b4iRwlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_h-5zEFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_h-6aIFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h-5zEVfkEeak-v4LxEsCQw" x="16" y="136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_h_lvk1fkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_h_lvlFfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_h_mWoFfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_h_lvlVfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iWBSkFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_iWCgsFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iWBSkVfkEeak-v4LxEsCQw" x="-116" y="136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_iWi3AFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_iWi3AVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iWi3A1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iWi3AlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_oUGakFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_oUHosFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oUGakVfkEeak-v4LxEsCQw" x="-176" y="-304"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_oUpNIFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_oUpNIVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oUpNI1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oUpNIlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v3M_oFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_v3NmsVfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3NmsFfkEeak-v4LxEsCQw" x="39" y="-304"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_v3y1g1fkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_v3y1hFfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v3zckFfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v3y1hVfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0TT-kFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_0TUloFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0TT-kVfkEeak-v4LxEsCQw" x="308" y="136"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_0TxRkFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_0TxRkVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0TxRk1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0TxRklfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-hIdcFfkEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_-hJEgFfkEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-hIdcVfkEeak-v4LxEsCQw" x="508" y="-304"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-hu6YFfkEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-hu6YVfkEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-hu6Y1fkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-hu6YlfkEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Cb5C0FflEeak-v4LxEsCQw" type="1031">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Cb5C0lflEeak-v4LxEsCQw" type="1084"/>
+      <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Cb5C0VflEeak-v4LxEsCQw" x="134" y="480"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_CcbOUFflEeak-v4LxEsCQw" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_CcbOUVflEeak-v4LxEsCQw" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CcbOU1flEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CcbOUlflEeak-v4LxEsCQw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="__ZM7oFfpEeak-v4LxEsCQw" type="1026" fillColor="15912618" lineColor="12678440">
+      <children xmi:type="notation:DecorationNode" xmi:id="__ZOJwFfpEeak-v4LxEsCQw" type="1034"/>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__ZOJwVfpEeak-v4LxEsCQw" type="1071">
+        <children xmi:type="notation:Shape" xmi:id="_g6ObQFfqEeak-v4LxEsCQw" type="3002">
+          <element xmi:type="uml:Property" href="OpenModel_Profile.profile.uml#_g5k7AFfqEeak-v4LxEsCQw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_g6ObQVfqEeak-v4LxEsCQw"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="__ZOJwlfpEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__ZOJw1fpEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__ZOJxFfpEeak-v4LxEsCQw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZOJxVfpEeak-v4LxEsCQw"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="__ZOw0FfpEeak-v4LxEsCQw" visible="false" type="1019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="__ZOw0VfpEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="__ZOw0lfpEeak-v4LxEsCQw"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="__ZOw01fpEeak-v4LxEsCQw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZOw1FfpEeak-v4LxEsCQw"/>
+      </children>
+      <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_949Q4FfpEeak-v4LxEsCQw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__ZM7oVfpEeak-v4LxEsCQw" x="281" y="592" height="57"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OAD3UFfqEeak-v4LxEsCQw" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_OAEeYFfqEeak-v4LxEsCQw" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_NkU9kFfqEeak-v4LxEsCQw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OAD3UVfqEeak-v4LxEsCQw" x="222" y="672" width="265"/>
+    </children>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_1C8zExdkEeatXPvf_dRw8w"/>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_1C9Y4BdkEeatXPvf_dRw8w" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_1C9Y4RdkEeatXPvf_dRw8w">
+      <owner xmi:type="uml:Profile" href="OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </styles>
+    <element xmi:type="uml:Profile" href="OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9Y4hdkEeatXPvf_dRw8w" type="1022" source="_1C8yahdkEeatXPvf_dRw8w" target="_1C8yRBdkEeatXPvf_dRw8w" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9Y4xdkEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9Y5BdkEeatXPvf_dRw8w" points="[-10, 0, 0, 25]$[-10, -25, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y5RdkEeatXPvf_dRw8w" id="(0.5422222222222223,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y5hdkEeatXPvf_dRw8w" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9Y5xdkEeatXPvf_dRw8w" type="1022" source="_1C8ybRdkEeatXPvf_dRw8w" target="_1C8yVBdkEeatXPvf_dRw8w" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9Y6BdkEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9Y6RdkEeatXPvf_dRw8w" points="[52, 0, -23, 25]$[52, -25, -23, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y6hdkEeatXPvf_dRw8w" id="(0.5027027027027027,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y6xdkEeatXPvf_dRw8w" id="(0.5068493150684932,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9Y7BdkEeatXPvf_dRw8w" type="1022" source="_1C8ycBdkEeatXPvf_dRw8w" target="_1C8yDhdkEeatXPvf_dRw8w" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9Y7RdkEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9Y7hdkEeatXPvf_dRw8w" points="[-10, 0, 20, 25]$[-10, -25, 20, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y7xdkEeatXPvf_dRw8w" id="(0.5502958579881657,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y8BdkEeatXPvf_dRw8w" id="(0.29,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9Y8RdkEeatXPvf_dRw8w" type="1022" source="_1C8ycxdkEeatXPvf_dRw8w" target="_1C8yPBdkEeatXPvf_dRw8w" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9Y8hdkEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9Y8xdkEeatXPvf_dRw8w" points="[-12, 0, 0, 25]$[-12, -25, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y9BdkEeatXPvf_dRw8w" id="(0.5168918918918919,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y9RdkEeatXPvf_dRw8w" id="(0.46296296296296297,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9Y9hdkEeatXPvf_dRw8w" type="1022" source="_1C8ydhdkEeatXPvf_dRw8w" target="_1C8yFhdkEeatXPvf_dRw8w" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9Y9xdkEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9Y-BdkEeatXPvf_dRw8w" points="[7, 0, -11, 25]$[7, -25, -11, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y-RdkEeatXPvf_dRw8w" id="(0.46543778801843316,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y-hdkEeatXPvf_dRw8w" id="(0.61,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9Y-xdkEeatXPvf_dRw8w" type="1022" source="_1C8yeRdkEeatXPvf_dRw8w" target="_1C8yHhdkEeatXPvf_dRw8w" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9Y_BdkEeatXPvf_dRw8w"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9Y_RdkEeatXPvf_dRw8w" points="[16, 0, -26, 25]$[16, -25, -26, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y_hdkEeatXPvf_dRw8w" id="(0.41450777202072536,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y_xdkEeatXPvf_dRw8w" id="(0.76,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9ZFBdkEeatXPvf_dRw8w" type="1022" source="_1C8yiBdkEeatXPvf_dRw8w" target="_1C8yTBdkEeatXPvf_dRw8w" routing="Rectilinear" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__92VEBhUEeavBLLlfRT9gQ" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__928IBhUEeavBLLlfRT9gQ" key="routing" value="true"/>
+      </eAnnotations>
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9ZFRdkEeatXPvf_dRw8w" fontName="Segoe UI"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9ZFhdkEeatXPvf_dRw8w" points="[-250, 0, 40, 113]$[-250, -113, 40, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9ZFxdkEeatXPvf_dRw8w" id="(0.9756613756613757,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9ZGBdkEeatXPvf_dRw8w" id="(0.08,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_1C9ZIxdkEeatXPvf_dRw8w" type="1022" source="_1C8y-BdkEeatXPvf_dRw8w" target="_1C8y4hdkEeatXPvf_dRw8w" routing="Rectilinear" lineColor="0">
+      <styles xmi:type="notation:FontStyle" xmi:id="_1C9ZJBdkEeatXPvf_dRw8w" fontName="Segoe UI"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9ZJRdkEeatXPvf_dRw8w" points="[2, -36, 3, 54]$[2, -61, 3, 29]"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZtDokBgxEeavBLLlfRT9gQ" type="1022" source="_ZsVP0BgxEeavBLLlfRT9gQ" target="_uWAUcBgvEeavBLLlfRT9gQ" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZtEPoBgxEeavBLLlfRT9gQ"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZtEPoRgxEeavBLLlfRT9gQ" points="[-6, 0, -2, 23]$[-6, -23, -2, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_buvMcBgxEeavBLLlfRT9gQ" id="(0.5283018867924528,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_buvzgBgxEeavBLLlfRT9gQ" id="(0.57,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Y894hFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_Y8f-cFfkEeak-v4LxEsCQw" target="_Y894gFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Y894hVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Y894iVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y894hlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y894h1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y894iFfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Y9YIMFfkEeak-v4LxEsCQw" type="1013" source="_1C8yDhdkEeatXPvf_dRw8w" target="_Y8f-cFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Y9YIMVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_Kg_CQJniEeGA7rUYI1JIwg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y9YIMlfkEeak-v4LxEsCQw" points="[-46, 28, 228, -137]$[-274, 165, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZjYYQFfkEeak-v4LxEsCQw" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZjY_UFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_b4iRxFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_b3700FfkEeak-v4LxEsCQw" target="_b4iRwFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_b4iRxVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_b4iRyVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b4iRxlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b4iRx1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b4iRyFfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_b5AL0FfkEeak-v4LxEsCQw" type="1013" source="_1C8yFhdkEeatXPvf_dRw8w" target="_b3700FfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_b5AL0VfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_HlsDQL7YEeGcHtJ-koFuEQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b5AL0lfkEeak-v4LxEsCQw" points="[-9, 0, -61, 54]$[-9, -27, -61, 27]$[55, -27, 3, 27]$[55, -54, 3, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_crzhwFfkEeak-v4LxEsCQw" id="(0.74,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cr1W8FfkEeak-v4LxEsCQw" id="(0.24,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dmLfUFfkEeak-v4LxEsCQw" type="1013" source="_1C8yHhdkEeatXPvf_dRw8w" target="_b3700FfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_dmLfUVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_u271EL7YEeGcHtJ-koFuEQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dmLfUlfkEeak-v4LxEsCQw" points="[-2, 0, 79, 54]$[-2, -27, 79, 27]$[-82, -27, -1, 27]$[-82, -54, -1, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fC6jEFfkEeak-v4LxEsCQw" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fC7KIFfkEeak-v4LxEsCQw" id="(0.72,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_h_mWoVfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_h-5zEFfkEeak-v4LxEsCQw" target="_h_lvk1fkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_h_mWolfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_h_mWplfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_h_mWo1fkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h_mWpFfkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_h_mWpVfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iAFe0FfkEeak-v4LxEsCQw" type="1013" source="_1C8yPBdkEeatXPvf_dRw8w" target="_h-5zEFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iAFe0VfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_ia2l4NyHEeG3LugjzyfwGA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iAFe0lfkEeak-v4LxEsCQw" points="[-1, 0, -40, 54]$[-1, -27, -40, 27]$[39, -27, 0, 27]$[39, -54, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kf3T8FfkEeak-v4LxEsCQw" id="(0.75,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kf37AFfkEeak-v4LxEsCQw" id="(0.48,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iWi3BFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_iWBSkFfkEeak-v4LxEsCQw" target="_iWi3AFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iWi3BVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_iWi3CVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iWi3BlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iWi3B1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iWi3CFfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_iXBYIFfkEeak-v4LxEsCQw" type="1013" source="_1C8yPBdkEeatXPvf_dRw8w" target="_iWBSkFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_iXBYIVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_6EFhANyHEeG3LugjzyfwGA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iXBYIlfkEeak-v4LxEsCQw" points="[-7, 0, 30, 62]$[-7, -33, 30, 29]$[-38, -33, -1, 29]$[-38, -62, -1, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jxtNcFfkEeak-v4LxEsCQw" id="(0.28703703703703703,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jxt0gFfkEeak-v4LxEsCQw" id="(0.53,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_oUpNJFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_oUGakFfkEeak-v4LxEsCQw" target="_oUpNIFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_oUpNJVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_oUpNKVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Dependency"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oUpNJlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oUpNJ1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oUpNKFfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_oVPDAFfkEeak-v4LxEsCQw" type="1013" source="_1C8yRBdkEeatXPvf_dRw8w" target="_oUGakFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_oVPDAVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_BkIu0PNBEeGLMdrUcsEncQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oVPDAlfkEeak-v4LxEsCQw" points="[21, 28, -105, -137]$[126, 165, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_peLBAFfkEeak-v4LxEsCQw" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_peLoEFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_qdbekFfkEeak-v4LxEsCQw" type="1013" source="_1C8yTBdkEeatXPvf_dRw8w" target="_Y8f-cFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qdbekVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_NUNNcJ2CEeSDYd59zPupRA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qdbeklfkEeak-v4LxEsCQw" points="[-13, 0, 126, 62]$[-13, -24, 126, 38]$[-124, -24, 15, 38]$[-124, -62, 15, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d-PkkFflEeak-v4LxEsCQw" id="(0.53,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d-QLoFflEeak-v4LxEsCQw" id="(0.76,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_sZh-4FfkEeak-v4LxEsCQw" type="1013" source="_1C8yVBdkEeatXPvf_dRw8w" target="_Y8f-cFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_sZh-4VfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_usAfoJ2CEeSDYd59zPupRA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_sZh-4lfkEeak-v4LxEsCQw" points="[47, -27, -138, 87]$[47, -58, -138, 56]$[151, -58, -34, 56]$[151, -89, -34, 25]"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v3zckVfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_v3M_oFfkEeak-v4LxEsCQw" target="_v3y1g1fkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v3zcklfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_v3zcllfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v3zck1fkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v3zclFfkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_v3zclVfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_v4eyAFfkEeak-v4LxEsCQw" type="1013" source="_1C8yVBdkEeatXPvf_dRw8w" target="_v3M_oFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_v4eyAVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_1tBEQJ2CEeSDYd59zPupRA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_v4eyAlfkEeak-v4LxEsCQw" points="[-15, 28, 74, -137]$[-89, 165, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wvf5kFfkEeak-v4LxEsCQw" id="(0.5068493150684932,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wvggoFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0TxRlFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_0TT-kFfkEeak-v4LxEsCQw" target="_0TxRkFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0TxRlVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_0Tx4olfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0TxRllfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0Tx4oFfkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0Tx4oVfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_0Uax0FfkEeak-v4LxEsCQw" type="1013" source="_1C8yFhdkEeatXPvf_dRw8w" target="_0TT-kFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_0Uax0VfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_5K_C4baPEeSnGaxGaNSs1w"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0Uax0lfkEeak-v4LxEsCQw" points="[-17, -27, 233, 384]$[-250, -411, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0_iLYFfkEeak-v4LxEsCQw" id="(0.5,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0_iycFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-hu6ZFfkEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_-hIdcFfkEeak-v4LxEsCQw" target="_-hu6YFfkEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-hu6ZVfkEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-hu6aVfkEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-hu6ZlfkEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-hu6Z1fkEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-hu6aFfkEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-iXMgFfkEeak-v4LxEsCQw" type="1013" source="_1C8y4hdkEeatXPvf_dRw8w" target="_-hIdcFfkEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-iXMgVfkEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_3ciJYEZgEeWzOqfPW42hmw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-iXMglfkEeak-v4LxEsCQw" points="[-54, -22, 964, 390]$[-1018, -412, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__kG9YFfkEeak-v4LxEsCQw" id="(0.4954128440366973,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__kHkcFfkEeak-v4LxEsCQw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CcbOVFflEeak-v4LxEsCQw" type="StereotypeCommentLink" source="_Cb5C0FflEeak-v4LxEsCQw" target="_CcbOUFflEeak-v4LxEsCQw">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CcbOVVflEeak-v4LxEsCQw"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_CcbOWVflEeak-v4LxEsCQw" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CcbOVlflEeak-v4LxEsCQw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbOV1flEeak-v4LxEsCQw"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CcbOWFflEeak-v4LxEsCQw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_CdFVoFflEeak-v4LxEsCQw" type="1013" source="_uWAUcBgvEeavBLLlfRT9gQ" target="_Cb5C0FflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_CdFVoVflEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_VqOy0EcsEeWC5rv-TLU4gA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CdFVolflEeak-v4LxEsCQw" points="[-4, 0, -123, 62]$[-4, -24, -123, 38]$[130, -24, 11, 38]$[130, -62, 11, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_STueMFflEeak-v4LxEsCQw" id="(0.53,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_STvFQFflEeak-v4LxEsCQw" id="(0.13,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_F65HAFfqEeak-v4LxEsCQw" type="1013" source="__ZM7oFfpEeak-v4LxEsCQw" target="_Cb5C0FflEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_F65HAVfqEeak-v4LxEsCQw"/>
+      <element xmi:type="uml:Extension" href="OpenModel_Profile.profile.uml#_F6Rb8FfqEeak-v4LxEsCQw"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F65HAlfqEeak-v4LxEsCQw" points="[16, 0, 129, 62]$[16, -26, 129, 36]$[-128, -26, -15, 36]$[-128, -62, -15, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F72wUFfqEeak-v4LxEsCQw" id="(0.4178082191780822,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F72wUVfqEeak-v4LxEsCQw" id="(0.95,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OBOU8FfqEeak-v4LxEsCQw" type="1022" source="_OAD3UFfqEeak-v4LxEsCQw" target="__ZM7oFfpEeak-v4LxEsCQw" routing="Rectilinear">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OBOU8VfqEeak-v4LxEsCQw"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OBOU8lfqEeak-v4LxEsCQw" points="[-1, 0, 22, 23]$[-1, -23, 22, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OdJb8FfqEeak-v4LxEsCQw" id="(0.5169811320754717,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OdKDAFfqEeak-v4LxEsCQw" id="(0.38,1.0)"/>
+    </edges>
+  </notation:Diagram>
 </xmi:XMI>

--- a/OpenModelProfile/OpenModel_Profile.profile.uml
+++ b/OpenModelProfile/OpenModel_Profile.profile.uml
@@ -2,6 +2,258 @@
 <xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmlns:umlnotationext="http://www.eclipse.org/papyrus/umlnotation">
   <uml:Profile xmi:id="_m1xqsHBgEd6FKu9XX1078A" name="OpenModel_Profile" metamodelReference="_m2EloXBgEd6FKu9XX1078A">
     <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_m2rCkXBgEd6FKu9XX1078A" source="http://www.eclipse.org/uml2/2.0.0/UML">
+      <contents xmi:type="ecore:EPackage" xmi:id="_iR_kYFh3EeaaGczhAqBKxg" name="OpenModel_Profile" nsURI="http:///schemas/OpenModel_Profile/_iR8hEFh3EeaaGczhAqBKxg/15" nsPrefix="OpenModel_Profile">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSMYs1h3EeaaGczhAqBKxg" source="PapyrusVersion">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iSMYtFh3EeaaGczhAqBKxg" key="Version" value="0.2.3"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iSMYtVh3EeaaGczhAqBKxg" key="Comment" value="Changes are listed in the Applied Comment."/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iSMYtlh3EeaaGczhAqBKxg" key="Copyright" value=""/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iSMYt1h3EeaaGczhAqBKxg" key="Date" value="2016-08-02"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iSMYuFh3EeaaGczhAqBKxg" key="Author" value=""/>
+        </eAnnotations>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iR_kYVh3EeaaGczhAqBKxg" name="OpenModelAttribute">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iR_kYlh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_36ZCQHBgEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iR_kY1h3EeaaGczhAqBKxg" name="base_StructuralFeature" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StructuralFeature"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_kZVh3EeaaGczhAqBKxg" name="partOfObjectKey" ordered="false" lowerBound="1" defaultValueLiteral="0">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Integer"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_kZ1h3EeaaGczhAqBKxg" name="attributeValueChangeNotification" ordered="false" lowerBound="1" eType="_iSALeVh3EeaaGczhAqBKxg" defaultValueLiteral="NA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_kaVh3EeaaGczhAqBKxg" name="isInvariant" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_ka1h3EeaaGczhAqBKxg" name="valueRange" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_kbVh3EeaaGczhAqBKxg" name="bitLength" ordered="false" eType="_iSALflh3EeaaGczhAqBKxg"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_kb1h3EeaaGczhAqBKxg" name="unsigned" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iR_kcVh3EeaaGczhAqBKxg" name="encoding" ordered="false" eType="_iSALhFh3EeaaGczhAqBKxg"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALcVh3EeaaGczhAqBKxg" name="counter" ordered="false" eType="_iSALiVh3EeaaGczhAqBKxg"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALc1h3EeaaGczhAqBKxg" name="unit" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALdVh3EeaaGczhAqBKxg" name="support" ordered="false" lowerBound="1" eType="_iSALjlh3EeaaGczhAqBKxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALd1h3EeaaGczhAqBKxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_iSALeVh3EeaaGczhAqBKxg" name="NotificationDefinition">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALelh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_HgbRQBGqEd-nT5bmeQ1LHg"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALe1h3EeaaGczhAqBKxg" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALfFh3EeaaGczhAqBKxg" name="NO" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALfVh3EeaaGczhAqBKxg" name="YES" value="2"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_iSALflh3EeaaGczhAqBKxg" name="BitLength">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALf1h3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_M9B3kFfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALgFh3EeaaGczhAqBKxg" name="LENGTH_8_BIT"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALgVh3EeaaGczhAqBKxg" name="LENGTH_16_BIT" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALglh3EeaaGczhAqBKxg" name="LENGTH_32_BIT" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALg1h3EeaaGczhAqBKxg" name="LENGTH_64_BIT" value="3"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_iSALhFh3EeaaGczhAqBKxg" name="Encoding">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALhVh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_OZ1z0FfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALhlh3EeaaGczhAqBKxg" name="BASE_64"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALh1h3EeaaGczhAqBKxg" name="HEX" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALiFh3EeaaGczhAqBKxg" name="OCTET" value="2"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_iSALiVh3EeaaGczhAqBKxg" name="Counter">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALilh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_NtRBsFfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALi1h3EeaaGczhAqBKxg" name="COUNTER"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALjFh3EeaaGczhAqBKxg" name="GAUGE" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALjVh3EeaaGczhAqBKxg" name="ZERO_COUNTER" value="2"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_iSALjlh3EeaaGczhAqBKxg" name="SupportQualifier">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALj1h3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_tIP_UL7QEeGcHtJ-koFuEQ"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALkFh3EeaaGczhAqBKxg" name="MANDATORY"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALkVh3EeaaGczhAqBKxg" name="OPTIONAL" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALklh3EeaaGczhAqBKxg" name="CONDITIONAL_MANDATORY" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALk1h3EeaaGczhAqBKxg" name="CONDITIONAL_OPTIONAL" value="3"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_iSALlFh3EeaaGczhAqBKxg" name="CONDITIONAL" value="4"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALlVh3EeaaGczhAqBKxg" name="OpenModelClass">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALllh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_JVMFMHBhEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALl1h3EeaaGczhAqBKxg" name="base_Class" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALmVh3EeaaGczhAqBKxg" name="objectCreationNotification" ordered="false" lowerBound="1" eType="_iSALeVh3EeaaGczhAqBKxg" defaultValueLiteral="NA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALm1h3EeaaGczhAqBKxg" name="objectDeletionNotification" ordered="false" lowerBound="1" eType="_iSALeVh3EeaaGczhAqBKxg" defaultValueLiteral="NA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALnVh3EeaaGczhAqBKxg" name="support" ordered="false" lowerBound="1" eType="_iSALjlh3EeaaGczhAqBKxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALn1h3EeaaGczhAqBKxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALoVh3EeaaGczhAqBKxg" name="OpenModelOperation">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALolh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_FRG9AHBnEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALo1h3EeaaGczhAqBKxg" name="base_Operation" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Operation"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALpVh3EeaaGczhAqBKxg" name="isOperationIdempotent" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALp1h3EeaaGczhAqBKxg" name="isAtomic" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALqVh3EeaaGczhAqBKxg" name="support" ordered="false" lowerBound="1" eType="_iSALjlh3EeaaGczhAqBKxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALq1h3EeaaGczhAqBKxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALrVh3EeaaGczhAqBKxg" name="OpenModelParameter">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALrlh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_jG59cHEqEd6SxZ5y0DIogw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALr1h3EeaaGczhAqBKxg" name="base_Parameter" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Parameter"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALsVh3EeaaGczhAqBKxg" name="valueRange" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALs1h3EeaaGczhAqBKxg" name="support" ordered="false" lowerBound="1" eType="_iSALjlh3EeaaGczhAqBKxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSALtVh3EeaaGczhAqBKxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALt1h3EeaaGczhAqBKxg" name="Names">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALuFh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_jiSAMI7kEeGyB5ASrrNdIA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALuVh3EeaaGczhAqBKxg" name="base_Association" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALu1h3EeaaGczhAqBKxg" name="Choice">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALvFh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_27D5AL7XEeGcHtJ-koFuEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALvVh3EeaaGczhAqBKxg" name="base_DataType" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//DataType"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALv1h3EeaaGczhAqBKxg" name="base_Class" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALwVh3EeaaGczhAqBKxg" name="Exception">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALwlh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_el7rwL7YEeGcHtJ-koFuEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALw1h3EeaaGczhAqBKxg" name="base_DataType" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//DataType"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALxVh3EeaaGczhAqBKxg" name="PassedByReference">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALxlh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_bmZPgNyHEeG3LugjzyfwGA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALx1h3EeaaGczhAqBKxg" name="base_StructuralFeature" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StructuralFeature"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALyVh3EeaaGczhAqBKxg" name="base_Parameter" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Parameter"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALy1h3EeaaGczhAqBKxg" name="NamedBy">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSALzFh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_3E1eYPNAEeGLMdrUcsEncQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSALzVh3EeaaGczhAqBKxg" name="base_Dependency" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Dependency"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSALz1h3EeaaGczhAqBKxg" name="StrictComposite">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL0Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_vQjMkJ2BEeSDYd59zPupRA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL0Vh3EeaaGczhAqBKxg" name="base_Association" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL01h3EeaaGczhAqBKxg" name="Cond">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL1Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_h7id0J2CEeSDYd59zPupRA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAL1Vh3EeaaGczhAqBKxg" name="condition" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL11h3EeaaGczhAqBKxg" name="base_Association" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL2Vh3EeaaGczhAqBKxg" name="base_Generalization" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Generalization"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL21h3EeaaGczhAqBKxg" name="Experimental">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL3Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_FU4UgJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL3Vh3EeaaGczhAqBKxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL31h3EeaaGczhAqBKxg" name="LikelyToChange">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL4Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_HmOsEJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL4Vh3EeaaGczhAqBKxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL41h3EeaaGczhAqBKxg" name="Preliminary">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL5Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_LEgJwJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL5Vh3EeaaGczhAqBKxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL51h3EeaaGczhAqBKxg" name="Obsolete">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL6Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_M6xu4J2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL6Vh3EeaaGczhAqBKxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL61h3EeaaGczhAqBKxg" name="Example">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL7Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_OwwZEJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL7Vh3EeaaGczhAqBKxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL71h3EeaaGczhAqBKxg" name="Faulty">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL8Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_QGmKoJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL8Vh3EeaaGczhAqBKxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL81h3EeaaGczhAqBKxg" name="OpenModelInterface">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL9Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_oKbrsKiIEeSJmIxGbzx9kA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAL9Vh3EeaaGczhAqBKxg" name="base_Interface" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Interface"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAL91h3EeaaGczhAqBKxg" name="support" ordered="false" lowerBound="1" eType="_iSALjlh3EeaaGczhAqBKxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAL-Vh3EeaaGczhAqBKxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAL-1h3EeaaGczhAqBKxg" name="OpenModelNotification">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAL_Fh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_74KP4EZPEeW32YsOmT7W0Q"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAL_Vh3EeaaGczhAqBKxg" name="triggerConditionList" ordered="false" lowerBound="1" upperBound="-1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAL_1h3EeaaGczhAqBKxg" name="support" ordered="false" lowerBound="1" eType="_iSALjlh3EeaaGczhAqBKxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAMAVh3EeaaGczhAqBKxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAMA1h3EeaaGczhAqBKxg" name="base_Signal" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Signal"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAMBVh3EeaaGczhAqBKxg" name="PruneAndRefactor">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAMBlh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_aUYHcEZgEeWzOqfPW42hmw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAMB1h3EeaaGczhAqBKxg" name="base_Realization" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Realization"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAMCVh3EeaaGczhAqBKxg" name="Deprecated">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAMClh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_ma6wEJDeEeW51dNDZIXIMA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAMC1h3EeaaGczhAqBKxg" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAMDVh3EeaaGczhAqBKxg" name="Mature">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAMDlh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_wvWWABdhEeatXPvf_dRw8w"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAMD1h3EeaaGczhAqBKxg" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_iSAMEVh3EeaaGczhAqBKxg" name="Reference">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iSAMElh3EeaaGczhAqBKxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_949Q4FfpEeak-v4LxEsCQw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_iSAME1h3EeaaGczhAqBKxg" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_iSAMFVh3EeaaGczhAqBKxg" name="reference" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+      </contents>
       <contents xmi:type="ecore:EPackage" xmi:id="_0tZP0NyQEeW6C_FaABjU5w" name="OpenModel_Profile" nsURI="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14" nsPrefix="OpenModel_Profile">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_0tkO8NyQEeW6C_FaABjU5w" source="PapyrusVersion">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_0tkO8dyQEeW6C_FaABjU5w" key="Version" value="0.2.2"/>
@@ -5906,673 +6158,16 @@
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZctIZ2FEeSk-dMsN-xZbw" x="31812" y="11616" width="3145" height="1346"/>
         </children>
         <element xsi:nil="true"/>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_eonNIJ2FEeSk-dMsN-xZbw" element="_eoTrIJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_v0xMkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_eonNIp2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_eonNJJ2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_eonNJZ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eonNI52FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_eonNJp2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_eoTrIp2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_eonNKJ2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_eonNJ52FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eonNIZ2FEeSk-dMsN-xZbw" points="[1732, 545, -3086, -1171]$[3799, 545, -1019, -1171]$[3799, 1096, -1019, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_gTuEEJ2FEeSk-dMsN-xZbw" element="_gTk6IJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_0iop4J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_gTuEEp2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_gTuEFJ2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_gTuEFZ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gTuEE52FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_gTuEFp2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_gTk6Ip2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_gTuEGJ2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_gTuEF52FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gTuEEZ2FEeSk-dMsN-xZbw" points="[1732, 413, -6386, -1303]$[7106, 413, -1012, -1303]$[7106, 1096, -1012, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_iiY7EJ2FEeSk-dMsN-xZbw" element="_iiPxIJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_25MRkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_iiisEJ2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_iiisEp2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_iiisE52FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iiisEZ2FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_iiisFJ2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_iiPxIp2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_iiisFp2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_iiisFZ2FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iiY7EZ2FEeSk-dMsN-xZbw" points="[1732, 281, -9686, -1435]$[10387, 281, -1031, -1435]$[10387, 1096, -1031, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_nHBj4J2FEeSk-dMsN-xZbw" element="_nG3y4J2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_5Uz_cJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_nHBj4p2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_nHBj5J2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_nHBj5Z2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHBj452FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_nHBj5p2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_nG3y4p2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_nHBj6J2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_nHBj552FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHBj4Z2FEeSk-dMsN-xZbw" points="[1732, 148, -12986, -1568]$[13695, 148, -1023, -1568]$[13695, 1096, -1023, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_qzHbIJ2FEeSk-dMsN-xZbw" element="_qy0gMJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_6rsS0J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_qzHbIp2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_qzHbJJ2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_qzHbJZ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qzHbI52FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_qzHbJp2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_qy-RMJ2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_qzHbKJ2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_qzHbJ52FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qzHbIZ2FEeSk-dMsN-xZbw" points="[1732, 16, -16286, -1700]$[17002, 16, -1016, -1700]$[17002, 1096, -1016, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_tBCrQJ2FEeSk-dMsN-xZbw" element="_tAvwUJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_8T1VUJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_tBCrQp2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_tBCrRJ2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_tBCrRZ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tBCrQ52FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_tBCrRp2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_tAvwUp2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_tBCrSJ2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_tBCrR52FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tBCrQZ2FEeSk-dMsN-xZbw" points="[1732, -116, -19586, -1832]$[20309, -116, -1009, -1832]$[20309, 1096, -1009, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_uaTkQ52FEeSk-dMsN-xZbw" element="_uaTkQJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="__Eb0sJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_uaTkRZ2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_uaTkR52FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_uaTkSJ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uaTkRp2FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_uaTkSZ2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_uaTkQp2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_uaTkS52FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_uaTkSp2FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uaTkRJ2FEeSk-dMsN-xZbw" points="[1732, -248, -22886, -1964]$[23590, -248, -1028, -1964]$[23590, 1096, -1028, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_vtUrUJ2FEeSk-dMsN-xZbw" element="_vtBJUJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_BQSBMJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_vtUrUp2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_vtUrVJ2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_vtUrVZ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vtUrU52FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_vtUrVp2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_vtBJUp2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_vtUrWJ2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_vtUrV52FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vtUrUZ2FEeSk-dMsN-xZbw" points="[1732, -381, -26186, -2097]$[26897, -381, -1021, -2097]$[26897, 1096, -1021, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_w7uYIJ2FEeSk-dMsN-xZbw" element="_w7knIJ2FEeSk-dMsN-xZbw" source="_SmhwwJ2EEeSk-dMsN-xZbw" target="_DZctIJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_w7uYIp2FEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_w7uYJJ2FEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_w7uYJZ2FEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_w7uYI52FEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_w7uYJp2FEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_w7knIp2FEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_w7uYKJ2FEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_w7uYJ52FEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_w7uYIZ2FEeSk-dMsN-xZbw" points="[1732, -513, -29486, -2229]$[30205, -513, -1013, -2229]$[30205, 1096, -1013, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_ARJqAJ2GEeSk-dMsN-xZbw" element="_AQ2vEJ2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_v0xMkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_ARJqAp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ARJqBJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ARJqBZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ARJqA52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_ARJqBp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_AQ2vEp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ARJqCJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_ARJqB52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ARJqAZ2GEeSk-dMsN-xZbw" points="[1732, 561, -3086, -3003]$[4196, 561, -622, -3003]$[4196, 2944, -622, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_CsBxAJ2GEeSk-dMsN-xZbw" element="_Cru2EJ2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_0iop4J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_CsBxAp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_CsBxBJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_CsBxBZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CsBxA52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_CsBxBp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_Cru2Ep2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_CsBxCJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_CsBxB52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CsBxAZ2GEeSk-dMsN-xZbw" points="[1732, 429, -6386, -3135]$[7503, 429, -615, -3135]$[7503, 2944, -615, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_FTGg8J2GEeSk-dMsN-xZbw" element="_FS8v8J2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_25MRkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_FTGg8p2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_FTGg9J2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_FTGg9Z2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTGg852GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_FTPq4J2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_FS8v8p2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_FTPq4p2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_FTPq4Z2GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FTGg8Z2GEeSk-dMsN-xZbw" points="[1732, 297, -9686, -3267]$[10784, 297, -634, -3267]$[10784, 2944, -634, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_ITUJoJ2GEeSk-dMsN-xZbw" element="_ITKYoJ2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_5Uz_cJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_ITUJop2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ITUJpJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ITUJpZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ITUJo52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_ITUJpp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_ITKYop2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ITUJqJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_ITUJp52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ITUJoZ2GEeSk-dMsN-xZbw" points="[1732, 165, -12986, -3399]$[14091, 165, -627, -3399]$[14091, 2944, -627, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_KcCJoJ2GEeSk-dMsN-xZbw" element="_Kb4_sJ2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_6rsS0J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_KcCJop2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_KcCJpJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_KcCJpZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KcCJo52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_KcCJpp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_Kb4_sp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_KcCJqJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_KcCJp52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KcCJoZ2GEeSk-dMsN-xZbw" points="[1732, 32, -16286, -3532]$[17399, 32, -619, -3532]$[17399, 2944, -619, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_Mc4AAJ2GEeSk-dMsN-xZbw" element="_MclFEJ2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_8T1VUJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_Mc4AAp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Mc4ABJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Mc4ABZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Mc4AA52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_Mc4ABp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_MclFEp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Mc4ACJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_Mc4AB52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Mc4AAZ2GEeSk-dMsN-xZbw" points="[1732, -100, -19586, -3664]$[20706, -100, -612, -3664]$[20706, 2944, -612, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_OmyS0J2GEeSk-dMsN-xZbw" element="_OmpI4J2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="__Eb0sJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_Om8D0J2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Om8D0p2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Om8D052GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Om8D0Z2GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_Om8D1J2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_OmpI4p2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Om8D1p2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_Om8D1Z2GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OmyS0Z2GEeSk-dMsN-xZbw" points="[1732, -232, -22886, -3796]$[23987, -232, -631, -3796]$[23987, 2944, -631, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_QdqU4J2GEeSk-dMsN-xZbw" element="_Qdgj4J2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_BQSBMJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_Qdze0J2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Qdze0p2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Qdze052GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qdze0Z2GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_Qdze1J2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_Qdgj4p2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Qdze1p2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_Qdze1Z2GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QdqU4Z2GEeSk-dMsN-xZbw" points="[1732, -365, -26186, -3929]$[27294, -365, -624, -3929]$[27294, 2944, -624, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_SFf1YJ2GEeSk-dMsN-xZbw" element="_SFWrcJ2GEeSk-dMsN-xZbw" source="_R1brAJ2EEeSk-dMsN-xZbw" target="_DZctIJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_SFf1Yp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_SFpmYJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_SFpmYZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SFf1Y52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_SFpmYp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_SFWrcp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_SFpmZJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_SFpmY52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SFf1YZ2GEeSk-dMsN-xZbw" points="[1732, -497, -29486, -4061]$[30601, -497, -617, -4061]$[30601, 2944, -617, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_UKWpEJ2GEeSk-dMsN-xZbw" element="_UKDuIJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_v0xMkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_UKWpEp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_UKWpFJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_UKWpFZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UKWpE52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_UKWpFp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_UKDuIp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_UKWpGJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_UKWpF52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UKWpEZ2GEeSk-dMsN-xZbw" points="[1732, 557, -3086, -4855]$[4593, 557, -225, -4855]$[4593, 4792, -225, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_WXGNcJ2GEeSk-dMsN-xZbw" element="_WW8ccJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_0iop4J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_WXPXYJ2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_WXPXYp2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_WXPXY52GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WXPXYZ2GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_WXPXZJ2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_WW8ccp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_WXPXZp2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_WXPXZZ2GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WXGNcZ2GEeSk-dMsN-xZbw" points="[1732, 425, -6386, -4987]$[7900, 425, -218, -4987]$[7900, 4792, -218, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_Y5ZyIJ2GEeSk-dMsN-xZbw" element="_Y5G3MJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_25MRkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_Y5ZyIp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Y5ZyJJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Y5ZyJZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y5ZyI52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_Y5ZyJp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_Y5QoMZ2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Y5ZyKJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_Y5ZyJ52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y5ZyIZ2GEeSk-dMsN-xZbw" points="[1732, 293, -9686, -5119]$[11181, 293, -237, -5119]$[11181, 4792, -237, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_faReIJ2GEeSk-dMsN-xZbw" element="_fZ98IJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_5Uz_cJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_faReIp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_faReJJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_faReJZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_faReI52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_faReJp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_fZ98Ip2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_faReKJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_faReJ52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_faReIZ2GEeSk-dMsN-xZbw" points="[1732, 161, -12986, -5251]$[14488, 161, -230, -5251]$[14488, 4792, -230, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_iQEmkJ2GEeSk-dMsN-xZbw" element="_iP61kJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_6rsS0J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_iQEmkp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_iQEmlJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_iQEmlZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iQEmk52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_iQEmlp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_iP61kp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_iQEmmJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_iQEml52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iQEmkZ2GEeSk-dMsN-xZbw" points="[1732, 28, -16286, -5384]$[17796, 28, -222, -5384]$[17796, 4792, -222, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_kXwEwJ2GEeSk-dMsN-xZbw" element="_kXmTwJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_8T1VUJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_kXwEwp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_kXwExJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_kXwExZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kXwEw52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_kXwExp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_kXmTwp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_kXwEyJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_kXwEx52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kXwEwZ2GEeSk-dMsN-xZbw" points="[1732, -104, -19586, -5516]$[21103, -104, -215, -5516]$[21103, 4792, -215, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_oF8NwJ2GEeSk-dMsN-xZbw" element="_oFycwJ2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="__Eb0sJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_oGFXsJ2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_oGFXsp2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_oGFXs52GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oGFXsZ2GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_oGFXtJ2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_oFycwp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_oGFXtp2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_oGFXtZ2GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oF8NwZ2GEeSk-dMsN-xZbw" points="[1732, -236, -22886, -5648]$[24384, -236, -234, -5648]$[24384, 4792, -234, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_rJ340J2GEeSk-dMsN-xZbw" element="_rJk94J2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_BQSBMJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_rJ340p2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_rJ341J2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_rJ341Z2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rJ34052GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_rJ341p2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_rJk94p2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_rJ342J2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_rJ34152GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rJ340Z2GEeSk-dMsN-xZbw" points="[1732, -369, -26186, -5781]$[27691, -369, -227, -5781]$[27691, 4792, -227, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_uBm68J2GEeSk-dMsN-xZbw" element="_uBdJ8J2GEeSk-dMsN-xZbw" source="_OP35kJ2EEeSk-dMsN-xZbw" target="_DZctIJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_uBm68p2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_uBm69J2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_uBm69Z2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uBm6852GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_uBm69p2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_uBdJ8p2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_uBm6-J2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_uBm6952GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uBm68Z2GEeSk-dMsN-xZbw" points="[1732, -501, -29486, -5913]$[30998, -501, -220, -5913]$[30998, 4792, -220, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_ws1yIJ2GEeSk-dMsN-xZbw" element="_wssoMJ2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_v0xMkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_ws_jIJ2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ws_jIp2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ws_jI52GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ws_jIZ2GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_ws_jJJ2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_wssoMp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_ws_jJp2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_ws_jJZ2GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ws1yIZ2GEeSk-dMsN-xZbw" points="[1732, 553, -3086, -6707]$[4990, 553, 172, -6707]$[4990, 6640, 172, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_0pBT0J2GEeSk-dMsN-xZbw" element="_0ouY4J2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_0iop4J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_0pBT0p2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_0pBT1J2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_0pBT1Z2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0pBT052GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_0pBT1p2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_0ouY4p2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_0pBT2J2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_0pBT152GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_0pBT0Z2GEeSk-dMsN-xZbw" points="[1732, 421, -6386, -6839]$[8297, 421, 179, -6839]$[8297, 6640, 179, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_2pkPQJ2GEeSk-dMsN-xZbw" element="_2pRUUJ2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_25MRkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_2pkPQp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_2pkPRJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_2pkPRZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2pkPQ52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_2pkPRp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_2pRUUp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_2pkPSJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_2pkPR52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2pkPQZ2GEeSk-dMsN-xZbw" points="[1732, 289, -9686, -6971]$[11578, 289, 160, -6971]$[11578, 6640, 160, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_4f--UJ2GEeSk-dMsN-xZbw" element="_4f10YJ2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_5Uz_cJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_4f--Up2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_4f--VJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_4f--VZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4f--U52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_4f--Vp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_4f10Yp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_4f--WJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_4f--V52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4f--UZ2GEeSk-dMsN-xZbw" points="[1732, 156, -12986, -7104]$[14885, 156, 167, -7104]$[14885, 6640, 167, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_6W3AYJ2GEeSk-dMsN-xZbw" element="_6WtPYJ2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_6rsS0J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_6W3AYp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_6W3AZJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_6W3AZZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6W3AY52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_6W3AZp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_6WtPYp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_6W3AaJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_6W3AZ52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6W3AYZ2GEeSk-dMsN-xZbw" points="[1732, 24, -16286, -7236]$[18193, 24, 175, -7236]$[18193, 6640, 175, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_8ZLdcJ2GEeSk-dMsN-xZbw" element="_8ZCTgJ2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_8T1VUJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_8ZLdcp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_8ZLddJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_8ZLddZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8ZLdc52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_8ZLddp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_8ZCTgp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_8ZLdeJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_8ZLdd52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8ZLdcZ2GEeSk-dMsN-xZbw" points="[1732, -108, -19586, -7368]$[21500, -108, 182, -7368]$[21500, 6640, 182, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_-6mRUJ2GEeSk-dMsN-xZbw" element="_-6dHYJ2GEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="__Eb0sJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_-6mRUp2GEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_-6mRVJ2GEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_-6mRVZ2GEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-6mRU52GEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_-6mRVp2GEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_-6dHYp2GEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_-6wCUJ2GEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_-6mRV52GEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-6mRUZ2GEeSk-dMsN-xZbw" points="[1732, -240, -22886, -7500]$[24781, -240, 163, -7500]$[24781, 6640, 163, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_BBr5oJ2HEeSk-dMsN-xZbw" element="_BBY-sJ2HEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_BQSBMJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_BBr5op2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_BBr5pJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_BBr5pZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BBr5o52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_BBr5pp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_BBY-sp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_BBr5qJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_BBr5p52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BBr5oZ2HEeSk-dMsN-xZbw" points="[1732, -373, -26186, -7633]$[28088, -373, 170, -7633]$[28088, 6640, 170, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_CzM6kJ2HEeSk-dMsN-xZbw" element="_Cy5_oJ2HEeSk-dMsN-xZbw" source="_MdBb4J2EEeSk-dMsN-xZbw" target="_DZctIJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_CzM6kp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_CzM6lJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_CzM6lZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CzM6k52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_CzM6lp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_CzDJkJ2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_CzM6mJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_CzM6l52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CzM6kZ2HEeSk-dMsN-xZbw" points="[1732, -505, -29486, -7765]$[31395, -505, 177, -7765]$[31395, 6640, 177, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_FQv7EJ2HEeSk-dMsN-xZbw" element="_FQmxIJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_v0xMkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_FQ5sEJ2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_FQ5sEp2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_FQ5sE52HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FQ5sEZ2HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_FQ5sFJ2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_FQmxIp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_FQ5sFp2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_FQ5sFZ2HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FQv7EZ2HEeSk-dMsN-xZbw" points="[1732, 549, -3086, -8559]$[5387, 549, 569, -8559]$[5387, 8488, 569, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_HLV_gJ2HEeSk-dMsN-xZbw" element="_HLDEkJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_0iop4J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_HLV_gp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_HLV_hJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_HLV_hZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HLV_g52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_HLV_hp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_HLDEkp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_HLV_iJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_HLV_h52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HLV_gZ2HEeSk-dMsN-xZbw" points="[1732, 417, -6386, -8691]$[8694, 417, 576, -8691]$[8694, 8488, 576, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_JtpkMJ2HEeSk-dMsN-xZbw" element="_JtgaQJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_25MRkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_JtpkMp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_JtzVMJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_JtzVMZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JtpkM52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_JtzVMp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_JtgaQp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_JtzVNJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_JtzVM52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JtpkMZ2HEeSk-dMsN-xZbw" points="[1732, 285, -9686, -8823]$[11975, 285, 557, -8823]$[11975, 8488, 557, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_LYeHQJ2HEeSk-dMsN-xZbw" element="_LYU9UJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_5Uz_cJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_LYeHQp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_LYeHRJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_LYeHRZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LYeHQ52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_LYeHRp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_LYU9Up2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_LYn4QJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_LYeHR52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LYeHQZ2HEeSk-dMsN-xZbw" points="[1732, 152, -12986, -8956]$[15282, 152, 564, -8956]$[15282, 8488, 564, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_M3Y8UJ2HEeSk-dMsN-xZbw" element="_M3PLUJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_6rsS0J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_M3Y8Up2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_M3Y8VJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_M3Y8VZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M3Y8U52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_M3Y8Vp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_M3PLUp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_M3Y8WJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_M3Y8V52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M3Y8UZ2HEeSk-dMsN-xZbw" points="[1732, 20, -16286, -9088]$[18589, 20, 571, -9088]$[18589, 8488, 571, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_OgH0s52HEeSk-dMsN-xZbw" element="_OgH0sJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_8T1VUJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_OgH0tZ2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_OgH0t52HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_OgH0uJ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OgH0tp2HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_OgH0uZ2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_OgH0sp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_OgH0u52HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_OgH0up2HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OgH0tJ2HEeSk-dMsN-xZbw" points="[1732, -112, -19586, -9220]$[21870, -112, 552, -9220]$[21870, 8488, 552, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_Qh3C8J2HEeSk-dMsN-xZbw" element="_Qhjg8J2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="__Eb0sJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_Qh3C8p2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Qh3C9J2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Qh3C9Z2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Qh3C852HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_Qh3C9p2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_Qhjg8p2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Qh3C-J2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_Qh3C952HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Qh3C8Z2HEeSk-dMsN-xZbw" points="[1732, -245, -22886, -9353]$[25178, -245, 560, -9353]$[25178, 8488, 560, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_SWfpUJ2HEeSk-dMsN-xZbw" element="_SWV4UJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_BQSBMJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_SWfpUp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_SWfpVJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_SWfpVZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SWfpU52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_SWfpVp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_SWV4Up2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_SWfpWJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_SWfpV52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SWfpUZ2HEeSk-dMsN-xZbw" points="[1732, -377, -26186, -9485]$[28485, -377, 567, -9485]$[28485, 8488, 567, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_UDQGEJ2HEeSk-dMsN-xZbw" element="_UDGVEJ2HEeSk-dMsN-xZbw" source="_J8fY0J2EEeSk-dMsN-xZbw" target="_DZctIJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_UDQGEp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_UDQGFJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_UDQGFZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UDQGE52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_UDQGFp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_UDGVEp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_UDQGGJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_UDQGF52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UDQGEZ2HEeSk-dMsN-xZbw" points="[1732, -509, -29486, -9617]$[31792, -509, 574, -9617]$[31792, 8488, 574, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_WKxzQJ2HEeSk-dMsN-xZbw" element="_WKe4UJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_v0xMkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_WKxzQp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_WKxzRJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_WKxzRZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WKxzQ52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_WKxzRp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_WKe4Up2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_WKxzSJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_WKxzR52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WKxzQZ2HEeSk-dMsN-xZbw" points="[1732, 545, -3086, -10411]$[5784, 545, 966, -10411]$[5784, 10336, 966, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_Zcs3AJ2HEeSk-dMsN-xZbw" element="_ZcZ8EJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_0iop4J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_Zcs3Ap2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Zcs3BJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Zcs3BZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zcs3A52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_Zcs3Bp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_ZcZ8Ep2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_Zcs3CJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_Zcs3B52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Zcs3AZ2HEeSk-dMsN-xZbw" points="[1732, 413, -6386, -10543]$[9091, 413, 973, -10543]$[9091, 10336, 973, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_bPQZwJ2HEeSk-dMsN-xZbw" element="_bO9e0J2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_25MRkJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_bPQZwp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_bPQZxJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_bPQZxZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bPQZw52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_bPQZxp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_bPGowZ2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_bPQZyJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_bPQZx52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bPQZwZ2HEeSk-dMsN-xZbw" points="[1732, 281, -9686, -10675]$[12372, 281, 954, -10675]$[12372, 10336, 954, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_c3PrQJ2HEeSk-dMsN-xZbw" element="_c28wUJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_5Uz_cJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_c3PrQp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_c3PrRJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_c3PrRZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c3PrQ52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_c3PrRp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_c28wUp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_c3PrSJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_c3PrR52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c3PrQZ2HEeSk-dMsN-xZbw" points="[1732, 148, -12986, -10808]$[15679, 148, 961, -10808]$[15679, 10336, 961, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_e2AeAJ2HEeSk-dMsN-xZbw" element="_e1tjEJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_6rsS0J2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_e2AeAp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_e2AeBJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_e2AeBZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e2AeA52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_e2AeBp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_e1tjEp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_e2AeCJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_e2AeB52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e2AeAZ2HEeSk-dMsN-xZbw" points="[1732, 16, -16286, -10940]$[18986, 16, 968, -10940]$[18986, 10336, 968, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_g-4PAJ2HEeSk-dMsN-xZbw" element="_g-lUEJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_8T1VUJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_g-4PAp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_g-4PBJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_g-4PBZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g-4PA52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_g-4PBp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_g-lUEp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_g-4PCJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_g-4PB52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g-4PAZ2HEeSk-dMsN-xZbw" points="[1732, -116, -19586, -11072]$[22267, -116, 949, -11072]$[22267, 10336, 949, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_jTzfAJ2HEeSk-dMsN-xZbw" element="_jTf9AJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="__Eb0sJ2EEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_jTzfAp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_jTzfBJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_jTzfBZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jTzfA52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_jTzfBp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_jTf9Ap2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_jTzfCJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_jTzfB52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jTzfAZ2HEeSk-dMsN-xZbw" points="[1732, -249, -22886, -11205]$[25574, -249, 956, -11205]$[25574, 10336, 956, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_lzbjIJ2HEeSk-dMsN-xZbw" element="_lzSZMJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_BQSBMJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_lzbjIp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_lzbjJJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_lzbjJZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lzbjI52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_lzbjJp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_lzSZMp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_lzbjKJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_lzbjJ52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lzbjIZ2HEeSk-dMsN-xZbw" points="[1732, -381, -26186, -11337]$[28882, -381, 964, -11337]$[28882, 10336, 964, -620]"/>
-        </edges>
-        <edges xmi:type="umlnotationext:UMLConnector" xmi:id="_oOTqIJ2HEeSk-dMsN-xZbw" element="_oOAvMJ2HEeSk-dMsN-xZbw" source="_HEKg0J2EEeSk-dMsN-xZbw" target="_DZctIJ2FEeSk-dMsN-xZbw" roundedBendpointsRadius="4" routing="Rectilinear" lineColor="8421504" lineWidth="1" fontName="Segoe UI" fontHeight="8" showStereotype="Text">
-          <children xmi:type="notation:DecorationNode" xmi:id="_oOTqIp2HEeSk-dMsN-xZbw" visible="false" type="NameLabel">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_oOTqJJ2HEeSk-dMsN-xZbw" type="Stereotype"/>
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_oOTqJZ2HEeSk-dMsN-xZbw" type="Name"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oOTqI52HEeSk-dMsN-xZbw" y="-186"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_oOTqJp2HEeSk-dMsN-xZbw" type="ToMultiplicityLabel" element="_oOAvMp2HEeSk-dMsN-xZbw">
-            <children xmi:type="notation:BasicDecorationNode" xmi:id="_oOTqKJ2HEeSk-dMsN-xZbw" type="ExtensionRequired"/>
-            <layoutConstraint xmi:type="notation:Location" xmi:id="_oOTqJ52HEeSk-dMsN-xZbw" y="396"/>
-          </children>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oOTqIZ2HEeSk-dMsN-xZbw" points="[1732, -513, -29486, -11469]$[32189, -513, 971, -11469]$[32189, 10336, 971, -620]"/>
-        </edges>
       </contents>
     </eAnnotations>
-    <ownedComment xmi:type="uml:Comment" xmi:id="_cRXecJDkEeW51dNDZIXIMA">
-      <body>required</body>
-    </ownedComment>
-    <ownedComment xmi:type="uml:Comment" xmi:id="_pAy-cJDkEeW51dNDZIXIMA">
-      <body>required</body>
-    </ownedComment>
-    <ownedComment xmi:type="uml:Comment" xmi:id="_q_HsUJDkEeW51dNDZIXIMA">
-      <body>required</body>
-    </ownedComment>
-    <ownedComment xmi:type="uml:Comment" xmi:id="_t8mKEJDkEeW51dNDZIXIMA">
-      <body>required</body>
-    </ownedComment>
-    <ownedComment xmi:type="uml:Comment" xmi:id="_xlgxgJDkEeW51dNDZIXIMA">
-      <body>required</body>
-    </ownedComment>
-    <ownedComment xmi:type="uml:Comment" xmi:id="_0RmkUJDkEeW51dNDZIXIMA">
-      <body>required</body>
+    <ownedComment xmi:type="uml:Comment" xmi:id="_cxO3YBeFEeaUiMmCiapTYQ" annotatedElement="_m1xqsHBgEd6FKu9XX1078A">
+      <body>Updates in v0.2.3:&#xD;
+Old (obsolete) extensions for lifecycle deleted.&#xD;
+Example stereotype moved from Lifecycle diagram to the Optional Stereotypes diagram.&#xD;
+New lifecycle stereotype Mature added.&#xD;
+New stereotype Reference added.&#xD;
+Split stereotype diagram into separate diagrams for optional and required stereotypes.&#xD;
+New properties (bitLength, unsigned, encoding, counter) for defining attribute types added to OpenModelAttribute stereotype.</body>
     </ownedComment>
     <packageImport xmi:type="uml:PackageImport" xmi:id="_m2EloHBgEd6FKu9XX1078A">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vp7j5XBnEd6FKu9XX1078A" source="uml2.extensions">
@@ -6602,6 +6197,15 @@
         </eAnnotations>
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
       </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_tD9I4MvfEeWuP4zc4scymQ" name="partOfObjectKey" visibility="public">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_04XOcMvhEeWuP4zc4scymQ" annotatedElement="_tD9I4MvfEeWuP4zc4scymQ">
+          <body>This property indicates if the attribute is part of the object key or not.&#xD;
+Value = 0 (default) means the attribute is not part of the object key.&#xD;
+Values > 0 indicate that the attribute is part of the object key and the value defines the order of the attribute in case the key is composed of more than one attribute.</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_y66VMMvfEeWuP4zc4scymQ" name="0"/>
+      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_Um0xgHBhEd6FKu9XX1078A" name="attributeValueChangeNotification" visibility="public" type="_HgbRQBGqEd-nT5bmeQ1LHg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Um0xgXBhEd6FKu9XX1078A" source="uml2.extensions">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vp7j83BnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
@@ -6626,7 +6230,8 @@
           <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-u0GXINVEd6Iy5JPXF_34w" source="uml2.extensions">
             <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_-u0GXYNVEd6Iy5JPXF_34w" key="addedInVersion" value="7"/>
           </eAnnotations>
-          <body>True = attribute can only be set at creation time; False = attribute can be set at any time.</body>
+          <body>This property defines at which time the attribute can be set.&#xD;
+true = attribute can only be set at creation time; false = attribute can be set at any time.</body>
         </ownedComment>
         <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
         <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_oUQooHBlEd6FKu9XX1078A">
@@ -6650,14 +6255,33 @@
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_44BOwEZGEeWEwevcWURJ1Q"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_44B10EZGEeWEwevcWURJ1Q" value="1"/>
       </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_tD9I4MvfEeWuP4zc4scymQ" name="partOfObjectKey" visibility="public">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_04XOcMvhEeWuP4zc4scymQ" annotatedElement="_tD9I4MvfEeWuP4zc4scymQ">
-          <body>This property indicates if the attribute is part of the object key or not.&#xD;
-Value = 0 (default) means the attribute is not part of the object key.&#xD;
-Values > 0 indicate that the attribute is part of the object key and the value defines the order of the attribute in case the key is composed of more than one attribute.</body>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_09m2UFh0EeaaGczhAqBKxg" name="bitLength" type="_M9B3kFfrEeak-v4LxEsCQw">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KgDEEFh1EeaaGczhAqBKxg" annotatedElement="_09m2UFh0EeaaGczhAqBKxg">
+          <body>This optional property defines the bit length of the attribute type; if applicable.</body>
         </ownedComment>
-        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
-        <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_y66VMMvfEeWuP4zc4scymQ" name="0"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4fZiEFh0EeaaGczhAqBKxg"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4fdzgFh0EeaaGczhAqBKxg" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_5atTwFh0EeaaGczhAqBKxg" name="unsigned">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_IRmPgFh1EeaaGczhAqBKxg" annotatedElement="_5atTwFh0EeaaGczhAqBKxg">
+          <body>This property indicates if the attribute type is unsigned (value = true) or signed (value = false); if applicable, otherwise ignored.</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_7mGNQFh0EeaaGczhAqBKxg"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_8JaVsFh0EeaaGczhAqBKxg" name="encoding" type="_OZ1z0FfrEeak-v4LxEsCQw">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_GharUFh1EeaaGczhAqBKxg" annotatedElement="_8JaVsFh0EeaaGczhAqBKxg">
+          <body>This optional property defines the encoding of the attribute type; if applicable.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-zFGoFh0EeaaGczhAqBKxg"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-zGUwFh0EeaaGczhAqBKxg" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="__RruMFh0EeaaGczhAqBKxg" name="counter" type="_NtRBsFfrEeak-v4LxEsCQw">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_EDhskFh1EeaaGczhAqBKxg" annotatedElement="__RruMFh0EeaaGczhAqBKxg">
+          <body>This optional property defines the counter type of the attribute type; if applicable.</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BwLJ4Fh1EeaaGczhAqBKxg"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BwMYAFh1EeaaGczhAqBKxg" value="1"/>
       </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_28fUQMvfEeWuP4zc4scymQ" name="unit" visibility="public">
         <ownedComment xmi:type="uml:Comment" xmi:id="_pcCfoMviEeWuP4zc4scymQ" annotatedElement="_28fUQMvfEeWuP4zc4scymQ">
@@ -6703,6 +6327,9 @@ The spelling of the unit (not only SI units) shall be in accordance to the NIST 
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vp7j_XBnEd6FKu9XX1078A" source="uml2.extensions">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vp7j_nBnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
       </eAnnotations>
+      <ownedComment xmi:type="uml:Comment" xmi:id="_pAy-cJDkEeW51dNDZIXIMA">
+        <body>required</body>
+      </ownedComment>
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_HXmXIXBhEd6FKu9XX1078A" name="extension_OpenModelAttribute" type="_36ZCQHBgEd6FKu9XX1078A" aggregation="composite" association="_HXmXIHBhEd6FKu9XX1078A">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vp7j_3BnEd6FKu9XX1078A" source="uml2.extensions">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vp7kAHBnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
@@ -6797,6 +6424,9 @@ The spelling of the unit (not only SI units) shall be in accordance to the NIST 
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vqFUwXBnEd6FKu9XX1078A" source="uml2.extensions">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vqFUwnBnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
       </eAnnotations>
+      <ownedComment xmi:type="uml:Comment" xmi:id="_cRXecJDkEeW51dNDZIXIMA">
+        <body>required</body>
+      </ownedComment>
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_NDZcUXBhEd6FKu9XX1078A" name="extension_OpenModelClass" type="_JVMFMHBhEd6FKu9XX1078A" aggregation="composite" association="_NDZcUHBhEd6FKu9XX1078A">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vqFUw3BnEd6FKu9XX1078A" source="uml2.extensions">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vqFUxHBnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
@@ -6893,6 +6523,9 @@ Example: When an operation is going to create an object instance which does alre
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FRG9H3BnEd6FKu9XX1078A" source="uml2.extensions">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vqFU5nBnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
       </eAnnotations>
+      <ownedComment xmi:type="uml:Comment" xmi:id="_t8mKEJDkEeW51dNDZIXIMA">
+        <body>required</body>
+      </ownedComment>
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_FRG9IXBnEd6FKu9XX1078A" name="extension_OpenModelOperation" type="_FRG9AHBnEd6FKu9XX1078A" aggregation="composite" association="_FRG9HnBnEd6FKu9XX1078A">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FRG9InBnEd6FKu9XX1078A" source="uml2.extensions">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vqFU53BnEd6FKu9XX1078A" key="addedInVersion" value="1"/>
@@ -6969,6 +6602,9 @@ Example: When an operation is going to create an object instance which does alre
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4YIfnHEqEd6SxZ5y0DIogw" source="uml2.extensions">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4YIfnXEqEd6SxZ5y0DIogw" key="addedInVersion" value="3"/>
       </eAnnotations>
+      <ownedComment xmi:type="uml:Comment" xmi:id="_xlgxgJDkEeW51dNDZIXIMA">
+        <body>required</body>
+      </ownedComment>
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_sGoRgXEqEd6SxZ5y0DIogw" name="extension_OpenModelParameter" type="_jG59cHEqEd6SxZ5y0DIogw" aggregation="composite" association="_sGoRgHEqEd6SxZ5y0DIogw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4YIfnnEqEd6SxZ5y0DIogw" source="uml2.extensions">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4YIfn3EqEd6SxZ5y0DIogw" key="addedInVersion" value="3"/>
@@ -7345,78 +6981,6 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <ownedComment xmi:type="uml:Comment" xmi:id="_N7uQAKrhEeSyfrZlx_q6Cw" annotatedElement="_FU4UgJ2EEeSk-dMsN-xZbw">
         <body>This stereotype indicates that the entity is at a very early stage of development and will almost certainly change. The entity is NOT mature enough to be used in implementation.</body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_WKe4Up2HEeSk-dMsN-xZbw" name="base_StructuralFeature" association="_WKe4UJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3a52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3bJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1cGcEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1ctgEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_ZcZ8Ep2HEeSk-dMsN-xZbw" name="base_Association" association="_ZcZ8EJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3bZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3bp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1ctgUZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1ctgkZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_bPGowZ2HEeSk-dMsN-xZbw" name="base_Constraint" association="_bO9e0J2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3b52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3cJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Constraint"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1ctg0ZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1dUkEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_c28wUp2HEeSk-dMsN-xZbw" name="base_Package" association="_c28wUJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3cZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3cp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Package"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1dUkUZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1dUkkZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_e1tjEp2HEeSk-dMsN-xZbw" name="base_Parameter" association="_e1tjEJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3c52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3dJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1dUk0ZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1d7oEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_g-lUEp2HEeSk-dMsN-xZbw" name="base_Operation" association="_g-lUEJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3dZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3dp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1d7oUZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1d7okZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_jTf9Ap2HEeSk-dMsN-xZbw" name="base_Class" association="_jTf9AJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3d52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3eJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1d7o0ZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1d7pEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_lzSZMp2HEeSk-dMsN-xZbw" name="base_DataType" association="_lzSZMJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3eZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3ep2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1eisEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1eisUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_oOAvMp2HEeSk-dMsN-xZbw" name="base_Generalization" association="_oOAvMJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3e52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3fJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U1eiskZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_U1eis0ZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_sBE5AEcsEeWC5rv-TLU4gA" name="base_Element" association="_sBFgEEcsEeWC5rv-TLU4gA">
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1U84IEcsEeWC5rv-TLU4gA"/>
@@ -7430,78 +6994,6 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <ownedComment xmi:type="uml:Comment" xmi:id="_YD8dMKrhEeSyfrZlx_q6Cw" annotatedElement="_HmOsEJ2EEeSk-dMsN-xZbw">
         <body>This stereotype indicates that although the entity may be mature work in the area has indicated that change will be necessary (e.g. there are new insights in the area or there is now perceived benefit to be had from further rationalization). The entity can still be used in implementation but with caution.</body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_FQmxIp2HEeSk-dMsN-xZbw" name="base_StructuralFeature" association="_FQmxIJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3f52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3gJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_M86rAEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_M87SEEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_HLDEkp2HEeSk-dMsN-xZbw" name="base_Association" association="_HLDEkJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3gZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3gp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NkBuUEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NkBuUUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_JtgaQp2HEeSk-dMsN-xZbw" name="base_Constraint" association="_JtgaQJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3g52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3hJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Constraint"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OFF0AEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OFF0AUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_LYU9Up2HEeSk-dMsN-xZbw" name="base_Package" association="_LYU9UJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3hZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3hp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Package"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OrK8kEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OrLjoEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_M3PLUp2HEeSk-dMsN-xZbw" name="base_Parameter" association="_M3PLUJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3h52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3iJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PWHXAEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PWH-EEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_OgH0sp2HEeSk-dMsN-xZbw" name="base_Operation" association="_OgH0sJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3iZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3ip2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QtO68EZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QtPiAEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_Qhjg8p2HEeSk-dMsN-xZbw" name="base_Class" association="_Qhjg8J2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3i52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3jJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QtPiAUZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QtQJEEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_SWV4Up2HEeSk-dMsN-xZbw" name="base_DataType" association="_SWV4UJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3jZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3jp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QtQJEUZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QtQJEkZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_UDGVEp2HEeSk-dMsN-xZbw" name="base_Generalization" association="_UDGVEJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3j52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3kJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QtQwIEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QtQwIUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_ni6roEcsEeWC5rv-TLU4gA" name="base_Element" association="_ni6roUcsEeWC5rv-TLU4gA">
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2oDewEcsEeWC5rv-TLU4gA"/>
@@ -7515,78 +7007,6 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <ownedComment xmi:type="uml:Comment" xmi:id="_c2XDUKrhEeSyfrZlx_q6Cw" annotatedElement="_LEgJwJ2EEeSk-dMsN-xZbw">
         <body>This stereotype indicates that the entity is at a relatively early stage of development and is likely to change but is mature enough to be used in implementation. </body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_wssoMp2GEeSk-dMsN-xZbw" name="base_StructuralFeature" association="_wssoMJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3k52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3lJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DYCbcEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DYDCgEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_0ouY4p2GEeSk-dMsN-xZbw" name="base_Association" association="_0ouY4J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3lZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3lp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_D-R8EEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_D-R8EUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_2pRUUp2GEeSk-dMsN-xZbw" name="base_Constraint" association="_2pRUUJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3l52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3mJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Constraint"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Er-vkEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Er-vkUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_4f10Yp2GEeSk-dMsN-xZbw" name="base_Package" association="_4f10YJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3mZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3mp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Package"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FVb8QEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FVb8QUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_6WtPYp2GEeSk-dMsN-xZbw" name="base_Parameter" association="_6WtPYJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3m52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3nJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_F5XIsEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_F5XIsUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZCTgp2GEeSk-dMsN-xZbw" name="base_Operation" association="_8ZCTgJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3nZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3np2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GfLykEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GfLykUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_-6dHYp2GEeSk-dMsN-xZbw" name="base_Class" association="_-6dHYJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3n52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3oJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HEh7UEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HEh7UUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_BBY-sp2HEeSk-dMsN-xZbw" name="base_DataType" association="_BBY-sJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3oZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3op2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HshvcEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HsiWgEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_CzDJkJ2HEeSk-dMsN-xZbw" name="base_Generalization" association="_Cy5_oJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3o52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3pJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IQy6IEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IQzhMEZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_jHY7gEcsEeWC5rv-TLU4gA" name="base_Element" association="_jHY7gUcsEeWC5rv-TLU4gA">
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3virQEcsEeWC5rv-TLU4gA"/>
@@ -7600,78 +7020,6 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <ownedComment xmi:type="uml:Comment" xmi:id="_hQ8YQKrhEeSyfrZlx_q6Cw" annotatedElement="_M6xu4J2EEeSk-dMsN-xZbw">
         <body>This stereotype indicates that the entity should not be used in new implementation and that attempts should be made to remove it from existing implementation.</body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_UKDuIp2GEeSk-dMsN-xZbw" name="base_StructuralFeature" association="_UKDuIJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3p52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3qJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7jjygEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7jkZkEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_WW8ccp2GEeSk-dMsN-xZbw" name="base_Association" association="_WW8ccJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3qZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3qp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8H09MEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8H09MUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_Y5QoMZ2GEeSk-dMsN-xZbw" name="base_Constraint" association="_Y5G3MJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3q52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3rJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Constraint"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8wOZ8EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8wOZ8UZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_fZ98Ip2GEeSk-dMsN-xZbw" name="base_Package" association="_fZ98IJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3rZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3rp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Package"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9XToEEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9XUPIEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_iP61kp2GEeSk-dMsN-xZbw" name="base_Parameter" association="_iP61kJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3r52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3sJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_99EAgEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_99EnkEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_kXmTwp2GEeSk-dMsN-xZbw" name="base_Operation" association="_kXmTwJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3sZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3sp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-kP8UEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-kP8UUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_oFycwp2GEeSk-dMsN-xZbw" name="base_Class" association="_oFycwJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3s52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3tJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__LPD0EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__LPD0UZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_rJk94p2GEeSk-dMsN-xZbw" name="base_DataType" association="_rJk94J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3tZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3tp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__zXa0EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__zXa0UZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_uBdJ8p2GEeSk-dMsN-xZbw" name="base_Generalization" association="_uBdJ8J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3t52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3uJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AafsQEZIEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AafsQUZIEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_fBxJ8EcsEeWC5rv-TLU4gA" name="base_Element" association="_fBxxAEcsEeWC5rv-TLU4gA">
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4ydg0EcsEeWC5rv-TLU4gA"/>
@@ -7685,78 +7033,6 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <ownedComment xmi:type="uml:Comment" xmi:id="_lp_cIKrhEeSyfrZlx_q6Cw" annotatedElement="_OwwZEJ2EEeSk-dMsN-xZbw">
         <body>This stereotype indicates that the entity is NOT to be used in implementation and is in the model simply to assist in the understanding of the model (e.g., a specialization of a generalized class where the generalized class is to be used as is and the specialization is simply offered to more easily illustrate an application of the generalized class).</body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_AQ2vEp2GEeSk-dMsN-xZbw" name="base_StructuralFeature" association="_AQ2vEJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3u52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3vJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ybjFIEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ybjsMEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_Cru2Ep2GEeSk-dMsN-xZbw" name="base_Association" association="_Cru2EJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3vZ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3vp2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zO_7UEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zO_7UUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_FS8v8p2GEeSk-dMsN-xZbw" name="base_Constraint" association="_FS8v8J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87S3v52HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87S3wJ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Constraint"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_z8EcsEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_z8EcsUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_ITKYop2GEeSk-dMsN-xZbw" name="base_Package" association="_ITKYoJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAgJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAgZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Package"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0oT3oEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0oUesEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_Kb4_sp2GEeSk-dMsN-xZbw" name="base_Parameter" association="_Kb4_sJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAgp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAg52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1RL1gEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1RMckEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_MclFEp2GEeSk-dMsN-xZbw" name="base_Operation" association="_MclFEJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAhJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAhZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18Z8wEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18aj0EZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_OmpI4p2GEeSk-dMsN-xZbw" name="base_Class" association="_OmpI4J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAhp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAh52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2tBhYEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2tCIcEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_Qdgj4p2GEeSk-dMsN-xZbw" name="base_DataType" association="_Qdgj4J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAiJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAiZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3SVN4EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3SV08EZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_SFWrcp2GEeSk-dMsN-xZbw" name="base_Generalization" association="_SFWrcJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAip2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAi52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4Dx48EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4DygAEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_VqOLwEcsEeWC5rv-TLU4gA" name="base_Element" association="_VqOy0EcsEeWC5rv-TLU4gA">
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_50T_YEcsEeWC5rv-TLU4gA"/>
@@ -7770,623 +7046,11 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <ownedComment xmi:type="uml:Comment" xmi:id="_pWHvoKrhEeSyfrZlx_q6Cw" annotatedElement="_QGmKoJ2EEeSk-dMsN-xZbw">
         <body>This stereotype indicates that the entity should not be used in new implementation and that attempts should be made to remove it from existing implementation as there is a problem with the entity. An update to the model with corrections will be released.</body>
       </ownedComment>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_eoTrIp2FEeSk-dMsN-xZbw" name="base_StructuralFeature" association="_eoTrIJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAjp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAj52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nH6NsEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nH60wEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_gTk6Ip2FEeSk-dMsN-xZbw" name="base_Association" association="_gTk6IJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAkJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAkZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Association"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_n2RvkEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_n2RvkUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_iiPxIp2FEeSk-dMsN-xZbw" name="base_Constraint" association="_iiPxIJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAkp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAk52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Constraint"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ojWQ8EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ojW4AEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_nG3y4p2FEeSk-dMsN-xZbw" name="base_Package" association="_nG3y4J2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAlJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAlZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Package"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pPsZkEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pPtAoEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_qy-RMJ2FEeSk-dMsN-xZbw" name="base_Parameter" association="_qy0gMJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAlp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAl52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Parameter"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p4A90EZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p4A90UZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_tAvwUp2FEeSk-dMsN-xZbw" name="base_Operation" association="_tAvwUJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAmJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAmZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Operation"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qgvKsEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qgvKsUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_uaTkQp2FEeSk-dMsN-xZbw" name="base_Class" association="_uaTkQJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAmp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAm52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rKggcEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rKhHgEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_vtBJUp2FEeSk-dMsN-xZbw" name="base_DataType" association="_vtBJUJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAnJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAnZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#DataType"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_r3kawEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_r3kawUZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="_w7knIp2FEeSk-dMsN-xZbw" name="base_Generalization" association="_w7knIJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAnp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAn52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Generalization"/>
-        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sm2ioEZHEeWEwevcWURJ1Q"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sm3JsEZHEeWEwevcWURJ1Q" value="1"/>
-      </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_Red9AEcsEeWC5rv-TLU4gA" name="base_Element" association="_RegZQEcsEeWC5rv-TLU4gA">
         <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7JwvYEcsEeWC5rv-TLU4gA"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7JwvYUcsEeWC5rv-TLU4gA" value="1"/>
       </ownedAttribute>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_eoTrIJ2FEeSk-dMsN-xZbw" name="StructuralFeature_Faulty" memberEnd="_eoTrIZ2FEeSk-dMsN-xZbw _eoTrIp2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAoJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAoZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_eoTrIZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_eoTrIJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAop2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAo52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_gTk6IJ2FEeSk-dMsN-xZbw" name="Association_Faulty" memberEnd="_gTk6IZ2FEeSk-dMsN-xZbw _gTk6Ip2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cApJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cApZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_gTk6IZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_gTk6IJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cApp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAp52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_iiPxIJ2FEeSk-dMsN-xZbw" name="Constraint_Faulty" memberEnd="_iiPxIZ2FEeSk-dMsN-xZbw _iiPxIp2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAqJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAqZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_iiPxIZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_iiPxIJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAqp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAq52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_nG3y4J2FEeSk-dMsN-xZbw" name="Package_Faulty" memberEnd="_nG3y4Z2FEeSk-dMsN-xZbw _nG3y4p2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cArJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cArZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_nG3y4Z2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_nG3y4J2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cArp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAr52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_qy0gMJ2FEeSk-dMsN-xZbw" name="Parameter_Faulty" memberEnd="_qy0gMZ2FEeSk-dMsN-xZbw _qy-RMJ2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAsJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAsZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_qy0gMZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_qy0gMJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAsp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAs52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_tAvwUJ2FEeSk-dMsN-xZbw" name="Operation_Faulty" memberEnd="_tAvwUZ2FEeSk-dMsN-xZbw _tAvwUp2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAtJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAtZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_tAvwUZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_tAvwUJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAtp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAt52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_uaTkQJ2FEeSk-dMsN-xZbw" name="Class_Faulty" memberEnd="_uaTkQZ2FEeSk-dMsN-xZbw _uaTkQp2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAuJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAuZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_uaTkQZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_uaTkQJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAup2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAu52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_vtBJUJ2FEeSk-dMsN-xZbw" name="DataType_Faulty" memberEnd="_vtBJUZ2FEeSk-dMsN-xZbw _vtBJUp2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAvJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAvZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_vtBJUZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_vtBJUJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAvp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAv52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_w7knIJ2FEeSk-dMsN-xZbw" name="Generalization_Faulty" memberEnd="_w7knIZ2FEeSk-dMsN-xZbw _w7knIp2FEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAwJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAwZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_w7knIZ2FEeSk-dMsN-xZbw" name="extension_Faulty" type="_QGmKoJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_w7knIJ2FEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAwp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAw52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_AQ2vEJ2GEeSk-dMsN-xZbw" name="StructuralFeature_Example" memberEnd="_AQ2vEZ2GEeSk-dMsN-xZbw _AQ2vEp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAxJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAxZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_AQ2vEZ2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_AQ2vEJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAxp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAx52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_Cru2EJ2GEeSk-dMsN-xZbw" name="Association_Example" memberEnd="_Cru2EZ2GEeSk-dMsN-xZbw _Cru2Ep2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAyJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAyZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_Cru2EZ2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_Cru2EJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAyp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAy52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_FS8v8J2GEeSk-dMsN-xZbw" name="Constraint_Example" memberEnd="_FS8v8Z2GEeSk-dMsN-xZbw _FS8v8p2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAzJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAzZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_FS8v8Z2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_FS8v8J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cAzp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cAz52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_ITKYoJ2GEeSk-dMsN-xZbw" name="Package_Example" memberEnd="_ITKYoZ2GEeSk-dMsN-xZbw _ITKYop2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA0J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA0Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_ITKYoZ2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_ITKYoJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA0p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA052HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_Kb4_sJ2GEeSk-dMsN-xZbw" name="Parameter_Example" memberEnd="_Kb4_sZ2GEeSk-dMsN-xZbw _Kb4_sp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA1J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA1Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_Kb4_sZ2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_Kb4_sJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA1p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA152HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_MclFEJ2GEeSk-dMsN-xZbw" name="Operation_Example" memberEnd="_MclFEZ2GEeSk-dMsN-xZbw _MclFEp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA2J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA2Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_MclFEZ2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_MclFEJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA2p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA252HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_OmpI4J2GEeSk-dMsN-xZbw" name="Class_Example" memberEnd="_OmpI4Z2GEeSk-dMsN-xZbw _OmpI4p2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA3J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA3Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_OmpI4Z2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_OmpI4J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA3p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA352HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_Qdgj4J2GEeSk-dMsN-xZbw" name="DataType_Example" memberEnd="_Qdgj4Z2GEeSk-dMsN-xZbw _Qdgj4p2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA4J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA4Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_Qdgj4Z2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_Qdgj4J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA4p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA452HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_SFWrcJ2GEeSk-dMsN-xZbw" name="Generalization_Example" memberEnd="_SFWrcZ2GEeSk-dMsN-xZbw _SFWrcp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA5J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA5Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_SFWrcZ2GEeSk-dMsN-xZbw" name="extension_Example" type="_OwwZEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_SFWrcJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA5p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA552HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_UKDuIJ2GEeSk-dMsN-xZbw" name="StructuralFeature_Obsolete" memberEnd="_UKDuIZ2GEeSk-dMsN-xZbw _UKDuIp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA6J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA6Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_UKDuIZ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_UKDuIJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA6p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA652HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_WW8ccJ2GEeSk-dMsN-xZbw" name="Association_Obsolete" memberEnd="_WW8ccZ2GEeSk-dMsN-xZbw _WW8ccp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA7J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA7Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_WW8ccZ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_WW8ccJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA7p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA752HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_Y5G3MJ2GEeSk-dMsN-xZbw" name="Constraint_Obsolete" memberEnd="_Y5QoMJ2GEeSk-dMsN-xZbw _Y5QoMZ2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA8J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA8Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_Y5QoMJ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_Y5G3MJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA8p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA852HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_fZ98IJ2GEeSk-dMsN-xZbw" name="Package_Obsolete" memberEnd="_fZ98IZ2GEeSk-dMsN-xZbw _fZ98Ip2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA9J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA9Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_fZ98IZ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_fZ98IJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA9p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA952HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_iP61kJ2GEeSk-dMsN-xZbw" name="Parameter_Obsolete" memberEnd="_iP61kZ2GEeSk-dMsN-xZbw _iP61kp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA-J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA-Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_iP61kZ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_iP61kJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA-p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA-52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_kXmTwJ2GEeSk-dMsN-xZbw" name="Operation_Obsolete" memberEnd="_kXmTwZ2GEeSk-dMsN-xZbw _kXmTwp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA_J2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA_Z2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_kXmTwZ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_kXmTwJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cA_p2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cA_52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_oFycwJ2GEeSk-dMsN-xZbw" name="Class_Obsolete" memberEnd="_oFycwZ2GEeSk-dMsN-xZbw _oFycwp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBAJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBAZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_oFycwZ2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_oFycwJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBAp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBA52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_rJk94J2GEeSk-dMsN-xZbw" name="DataType_Obsolete" memberEnd="_rJk94Z2GEeSk-dMsN-xZbw _rJk94p2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBBJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBBZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_rJk94Z2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_rJk94J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBBp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBB52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_uBdJ8J2GEeSk-dMsN-xZbw" name="Generalization_Obsolete" memberEnd="_uBdJ8Z2GEeSk-dMsN-xZbw _uBdJ8p2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBCJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBCZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_uBdJ8Z2GEeSk-dMsN-xZbw" name="extension_Obsolete" type="_M6xu4J2EEeSk-dMsN-xZbw" aggregation="composite" association="_uBdJ8J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBCp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBC52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_wssoMJ2GEeSk-dMsN-xZbw" name="E_Preliminary_StructuralFeature1" memberEnd="_wssoMZ2GEeSk-dMsN-xZbw _wssoMp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBDJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBDZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_wssoMZ2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_wssoMJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBDp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBD52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_0ouY4J2GEeSk-dMsN-xZbw" name="E_Preliminary_Association1" memberEnd="_0ouY4Z2GEeSk-dMsN-xZbw _0ouY4p2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBEJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBEZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_0ouY4Z2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_0ouY4J2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBEp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBE52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_2pRUUJ2GEeSk-dMsN-xZbw" name="E_Preliminary_Constraint1" memberEnd="_2pRUUZ2GEeSk-dMsN-xZbw _2pRUUp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBFJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBFZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_2pRUUZ2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_2pRUUJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBFp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBF52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_4f10YJ2GEeSk-dMsN-xZbw" name="E_Preliminary_Package1" memberEnd="_4f10YZ2GEeSk-dMsN-xZbw _4f10Yp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBGJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBGZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_4f10YZ2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_4f10YJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBGp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBG52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_6WtPYJ2GEeSk-dMsN-xZbw" name="E_Preliminary_Parameter1" memberEnd="_6WtPYZ2GEeSk-dMsN-xZbw _6WtPYp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBHJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBHZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_6WtPYZ2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_6WtPYJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBHp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBH52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_8ZCTgJ2GEeSk-dMsN-xZbw" name="E_Preliminary_Operation1" memberEnd="_8ZCTgZ2GEeSk-dMsN-xZbw _8ZCTgp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBIJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBIZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_8ZCTgZ2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_8ZCTgJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBIp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBI52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_-6dHYJ2GEeSk-dMsN-xZbw" name="E_Preliminary_Class1" memberEnd="_-6dHYZ2GEeSk-dMsN-xZbw _-6dHYp2GEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBJJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBJZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_-6dHYZ2GEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_-6dHYJ2GEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBJp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBJ52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_BBY-sJ2HEeSk-dMsN-xZbw" name="E_Preliminary_DataType1" memberEnd="_BBY-sZ2HEeSk-dMsN-xZbw _BBY-sp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBKJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBKZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_BBY-sZ2HEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_BBY-sJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBKp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBK52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_Cy5_oJ2HEeSk-dMsN-xZbw" name="E_Preliminary_Generalization1" memberEnd="_Cy5_oZ2HEeSk-dMsN-xZbw _CzDJkJ2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBLJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBLZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_Cy5_oZ2HEeSk-dMsN-xZbw" name="extension_Preliminary" type="_LEgJwJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_Cy5_oJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBLp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBL52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_FQmxIJ2HEeSk-dMsN-xZbw" name="StructuralFeature_LikelyToChange" memberEnd="_FQmxIZ2HEeSk-dMsN-xZbw _FQmxIp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBMJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBMZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_FQmxIZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_FQmxIJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBMp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBM52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_HLDEkJ2HEeSk-dMsN-xZbw" name="Association_LikelyToChange" memberEnd="_HLDEkZ2HEeSk-dMsN-xZbw _HLDEkp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBNJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBNZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_HLDEkZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_HLDEkJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBNp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBN52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_JtgaQJ2HEeSk-dMsN-xZbw" name="Constraint_LikelyToChange" memberEnd="_JtgaQZ2HEeSk-dMsN-xZbw _JtgaQp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBOJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBOZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_JtgaQZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_JtgaQJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBOp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBO52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_LYU9UJ2HEeSk-dMsN-xZbw" name="Package_LikelyToChange" memberEnd="_LYU9UZ2HEeSk-dMsN-xZbw _LYU9Up2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBPJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBPZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_LYU9UZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_LYU9UJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBPp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBP52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_M3PLUJ2HEeSk-dMsN-xZbw" name="Parameter_LikelyToChange" memberEnd="_M3PLUZ2HEeSk-dMsN-xZbw _M3PLUp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBQJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBQZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_M3PLUZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_M3PLUJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBQp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBQ52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_OgH0sJ2HEeSk-dMsN-xZbw" name="Operation_LikelyToChange" memberEnd="_OgH0sZ2HEeSk-dMsN-xZbw _OgH0sp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBRJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBRZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_OgH0sZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_OgH0sJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBRp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBR52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_Qhjg8J2HEeSk-dMsN-xZbw" name="Class_LikelyToChange" memberEnd="_Qhjg8Z2HEeSk-dMsN-xZbw _Qhjg8p2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBSJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBSZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_Qhjg8Z2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_Qhjg8J2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBSp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBS52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_SWV4UJ2HEeSk-dMsN-xZbw" name="DataType_LikelyToChange" memberEnd="_SWV4UZ2HEeSk-dMsN-xZbw _SWV4Up2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBTJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBTZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_SWV4UZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_SWV4UJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBTp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBT52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_UDGVEJ2HEeSk-dMsN-xZbw" name="Generalization_LikelyToChange" memberEnd="_UDGVEZ2HEeSk-dMsN-xZbw _UDGVEp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBUJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBUZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_UDGVEZ2HEeSk-dMsN-xZbw" name="extension_LikelyToChange" type="_HmOsEJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_UDGVEJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBUp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBU52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_WKe4UJ2HEeSk-dMsN-xZbw" name="StructuralFeature_Experimental" memberEnd="_WKe4UZ2HEeSk-dMsN-xZbw _WKe4Up2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBVJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBVZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_WKe4UZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_WKe4UJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBVp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBV52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_ZcZ8EJ2HEeSk-dMsN-xZbw" name="Association_Experimental" memberEnd="_ZcZ8EZ2HEeSk-dMsN-xZbw _ZcZ8Ep2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBWJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBWZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_ZcZ8EZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_ZcZ8EJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBWp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBW52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_bO9e0J2HEeSk-dMsN-xZbw" name="Constraint_Experimental" memberEnd="_bPGowJ2HEeSk-dMsN-xZbw _bPGowZ2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBXJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBXZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_bPGowJ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_bO9e0J2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBXp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBX52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_c28wUJ2HEeSk-dMsN-xZbw" name="Package_Experimental" memberEnd="_c28wUZ2HEeSk-dMsN-xZbw _c28wUp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBYJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBYZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_c28wUZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_c28wUJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBYp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBY52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_e1tjEJ2HEeSk-dMsN-xZbw" name="Parameter_Experimental" memberEnd="_e1tjEZ2HEeSk-dMsN-xZbw _e1tjEp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBZJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBZZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_e1tjEZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_e1tjEJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBZp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBZ52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_g-lUEJ2HEeSk-dMsN-xZbw" name="Operation_Experimental" memberEnd="_g-lUEZ2HEeSk-dMsN-xZbw _g-lUEp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBaJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBaZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_g-lUEZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_g-lUEJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBap2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBa52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_jTf9AJ2HEeSk-dMsN-xZbw" name="Class_Experimental" memberEnd="_jTf9AZ2HEeSk-dMsN-xZbw _jTf9Ap2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBbJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBbZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_jTf9AZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_jTf9AJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBbp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBb52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_lzSZMJ2HEeSk-dMsN-xZbw" name="DataType_Experimental" memberEnd="_lzSZMZ2HEeSk-dMsN-xZbw _lzSZMp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBcJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBcZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_lzSZMZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_lzSZMJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBcp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBc52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
-    </packagedElement>
-    <packagedElement xmi:type="uml:Extension" xmi:id="_oOAvMJ2HEeSk-dMsN-xZbw" name="Generalization_Experimental" memberEnd="_oOAvMZ2HEeSk-dMsN-xZbw _oOAvMp2HEeSk-dMsN-xZbw">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBdJ2HEeSk-dMsN-xZbw" source="uml2.extensions">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBdZ2HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-      </eAnnotations>
-      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_oOAvMZ2HEeSk-dMsN-xZbw" name="extension_Experimental" type="_FU4UgJ2EEeSk-dMsN-xZbw" aggregation="composite" association="_oOAvMJ2HEeSk-dMsN-xZbw">
-        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_87cBdp2HEeSk-dMsN-xZbw" source="uml2.extensions">
-          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_87cBd52HEeSk-dMsN-xZbw" key="addedInVersion" value="26"/>
-        </eAnnotations>
-      </ownedEnd>
     </packagedElement>
     <packagedElement xmi:type="uml:Stereotype" xmi:id="_oKbrsKiIEeSJmIxGbzx9kA" name="OpenModelInterface">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ul3N9KiKEeSJmIxGbzx9kA" source="uml2.extensions">
@@ -8439,6 +7103,9 @@ Whereas in an association with a composite end that is not StrictComposite the c
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ul3OBqiKEeSJmIxGbzx9kA" source="uml2.extensions">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ul3OB6iKEeSJmIxGbzx9kA" key="addedInVersion" value="2"/>
       </eAnnotations>
+      <ownedComment xmi:type="uml:Comment" xmi:id="_q_HsUJDkEeW51dNDZIXIMA">
+        <body>required</body>
+      </ownedComment>
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_vdlJMaiIEeSJmIxGbzx9kA" name="extension_OpenModelInterface" type="_oKbrsKiIEeSJmIxGbzx9kA" aggregation="composite" association="_vdlJMKiIEeSJmIxGbzx9kA">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Ul3OCKiKEeSJmIxGbzx9kA" source="uml2.extensions">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Ul3OCaiKEeSJmIxGbzx9kA" key="addedInVersion" value="2"/>
@@ -8506,6 +7173,9 @@ Whereas in an association with a composite end that is not StrictComposite the c
       </ownedAttribute>
     </packagedElement>
     <packagedElement xmi:type="uml:Extension" xmi:id="_nOpb8EZUEeW32YsOmT7W0Q" name="E_OpenModelNotification_Signal1" memberEnd="_nOpb8UZUEeW32YsOmT7W0Q _nOo04EZUEeW32YsOmT7W0Q">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_0RmkUJDkEeW51dNDZIXIMA">
+        <body>required</body>
+      </ownedComment>
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_nOpb8UZUEeW32YsOmT7W0Q" name="extension_OpenModelNotification" type="_74KP4EZPEeW32YsOmT7W0Q" aggregation="composite" association="_nOpb8EZUEeW32YsOmT7W0Q">
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_27bd4EZUEeW32YsOmT7W0Q" value="1"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_27cE8EZUEeW32YsOmT7W0Q" value="1"/>
@@ -8550,6 +7220,56 @@ Whereas in an association with a composite end that is not StrictComposite the c
     </packagedElement>
     <packagedElement xmi:type="uml:Extension" xmi:id="_g4FHsJDgEeW51dNDZIXIMA" name="E_Deprecated_Element1" memberEnd="_g4U_UJDgEeW51dNDZIXIMA _g4VmYJDgEeW51dNDZIXIMA">
       <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_g4U_UJDgEeW51dNDZIXIMA" name="extension_Deprecated" type="_ma6wEJDeEeW51dNDZIXIMA" aggregation="composite" association="_g4FHsJDgEeW51dNDZIXIMA"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Stereotype" xmi:id="_wvWWABdhEeatXPvf_dRw8w" name="Mature">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_19o_0BdhEeatXPvf_dRw8w" annotatedElement="_wvWWABdhEeatXPvf_dRw8w">
+        <body>This stereotype indicates that the entity is fully developed and can be used in implementations without any constraints.</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_QiORwBdiEeatXPvf_dRw8w" name="base_Element" association="_QiKnYBdiEeatXPvf_dRw8w">
+        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Extension" xmi:id="_QiKnYBdiEeatXPvf_dRw8w" name="E_Mature_Element1" memberEnd="_QiNDoBdiEeatXPvf_dRw8w _QiORwBdiEeatXPvf_dRw8w">
+      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_QiNDoBdiEeatXPvf_dRw8w" name="extension_Mature" type="_wvWWABdhEeatXPvf_dRw8w" aggregation="composite" association="_QiKnYBdiEeatXPvf_dRw8w"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Stereotype" xmi:id="_949Q4FfpEeak-v4LxEsCQw" name="Reference">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_NkU9kFfqEeak-v4LxEsCQw" annotatedElement="_949Q4FfpEeak-v4LxEsCQw">
+        <body>This optional stereotype contains a reference upon which the UML artefact is based. A reference to a standard is preferred.</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_F6T4MFfqEeak-v4LxEsCQw" name="base_Element" association="_F6Rb8FfqEeak-v4LxEsCQw">
+        <type xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Element"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_g5k7AFfqEeak-v4LxEsCQw" name="reference">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Extension" xmi:id="_F6Rb8FfqEeak-v4LxEsCQw" name="E_Reference_Element1" memberEnd="_F6TRIFfqEeak-v4LxEsCQw _F6T4MFfqEeak-v4LxEsCQw">
+      <ownedEnd xmi:type="uml:ExtensionEnd" xmi:id="_F6TRIFfqEeak-v4LxEsCQw" name="extension_Reference" type="_949Q4FfpEeak-v4LxEsCQw" aggregation="composite" association="_F6Rb8FfqEeak-v4LxEsCQw"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="_M9B3kFfrEeak-v4LxEsCQw" name="BitLength">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_pqrJgFh0EeaaGczhAqBKxg" annotatedElement="_M9B3kFfrEeak-v4LxEsCQw">
+        <body>This enumeration contains the defined bit length values.</body>
+      </ownedComment>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gJ9mgFfrEeak-v4LxEsCQw" name="LENGTH_8_BIT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iqOj0FfrEeak-v4LxEsCQw" name="LENGTH_16_BIT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_joPrQFfrEeak-v4LxEsCQw" name="LENGTH_32_BIT"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_kqUMQFfrEeak-v4LxEsCQw" name="LENGTH_64_BIT"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="_NtRBsFfrEeak-v4LxEsCQw" name="Counter">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_uRSIQFh0EeaaGczhAqBKxg" annotatedElement="_NtRBsFfrEeak-v4LxEsCQw">
+        <body>This enumeration contains the defined counter types.</body>
+      </ownedComment>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nmqBkFfrEeak-v4LxEsCQw" name="COUNTER"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oZfMsFfrEeak-v4LxEsCQw" name="GAUGE"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_qDEZoFfrEeak-v4LxEsCQw" name="ZERO_COUNTER"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="_OZ1z0FfrEeak-v4LxEsCQw" name="Encoding">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_v8yn0Fh0EeaaGczhAqBKxg" annotatedElement="_OZ1z0FfrEeak-v4LxEsCQw">
+        <body>This enumeration contains the defined encoding types.</body>
+      </ownedComment>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_tw9nsFfrEeak-v4LxEsCQw" name="BASE_64"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_usdmoFfrEeak-v4LxEsCQw" name="HEX"/>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vencUFfrEeak-v4LxEsCQw" name="OCTET"/>
     </packagedElement>
   </uml:Profile>
   <ecore:EAnnotation xmi:id="_Uv5eQKiLEeSly6b4dPxjLg" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData" references="_VgPY4HB5Ed6UZurF9-h-Jw">


### PR DESCRIPTION
Updates:
Old (obsolete) extensions for lifecycle deleted.
Example stereotype moved from Lifecycle diagram to the Optional
Stereotypes diagram.
New lifecycle stereotype Mature added.
New stereotype Reference added.
Split stereotype diagram into separate diagrams for optional and required stereotypes.
New properties (bitLength, unsigned, encoding, counter) for defining attribute types added to OpenModelAttribute stereotype.