### PR TITLE
Set default prefix if not input by the user

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>EAGLEUmlYangTools</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/xmi2yang tool-v2.0/.idea/compiler.xml
+++ b/xmi2yang tool-v2.0/.idea/compiler.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <resourceExtensions />
+    <wildcardResourcePatterns>
+      <entry name="!?*.java" />
+      <entry name="!?*.form" />
+      <entry name="!?*.class" />
+      <entry name="!?*.groovy" />
+      <entry name="!?*.scala" />
+      <entry name="!?*.flex" />
+      <entry name="!?*.kt" />
+      <entry name="!?*.clj" />
+      <entry name="!?*.aj" />
+    </wildcardResourcePatterns>
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/xmi2yang tool-v2.0/.idea/copyright/profiles_settings.xml
+++ b/xmi2yang tool-v2.0/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="" />
+</component>

--- a/xmi2yang tool-v2.0/.idea/jsLibraryMappings.xml
+++ b/xmi2yang tool-v2.0/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="file://$PROJECT_DIR$" libraries="{xmi2yang tool-v2.0 node_modules}" />
+  </component>
+</project>

--- a/xmi2yang tool-v2.0/.idea/libraries/xmi2yang_tool_v2_0_node_modules.xml
+++ b/xmi2yang tool-v2.0/.idea/libraries/xmi2yang_tool_v2_0_node_modules.xml
@@ -1,0 +1,15 @@
+<component name="libraryTable">
+  <library name="xmi2yang tool-v2.0 node_modules" type="javaScript">
+    <properties>
+      <option name="frameworkName" value="node_modules" />
+      <sourceFilesUrls>
+        <item url="file://$PROJECT_DIR$/node_modules" />
+      </sourceFilesUrls>
+    </properties>
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/node_modules" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/xmi2yang tool-v2.0/.idea/misc.xml
+++ b/xmi2yang tool-v2.0/.idea/misc.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenImportPreferences">
+    <option name="generalSettings">
+      <MavenGeneralSettings>
+        <option name="mavenHome" value="Bundled (Maven 3)" />
+      </MavenGeneralSettings>
+    </option>
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="true" assert-keyword="true" jdk-15="true" />
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
+</project>

--- a/xmi2yang tool-v2.0/.idea/modules.xml
+++ b/xmi2yang tool-v2.0/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/xmi2yang tool-v2.0.iml" filepath="$PROJECT_DIR$/.idea/xmi2yang tool-v2.0.iml" />
+    </modules>
+  </component>
+</project>

--- a/xmi2yang tool-v2.0/.idea/workspace.xml
+++ b/xmi2yang tool-v2.0/.idea/workspace.xml
@@ -1,0 +1,758 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="25f23456-4cce-4ad8-88df-769bd2d6e9be" name="Default" comment="" />
+    <ignored path="xmi2yang tool-v2.0.iws" />
+    <ignored path=".idea/workspace.xml" />
+    <ignored path=".idea/dataSources.local.xml" />
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ChangesViewManager" flattened_view="true" show_ignored="false" />
+  <component name="CreatePatchCommitExecutor">
+    <option name="PATCH_PATH" value="" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="default_target" />
+  <component name="FavoritesManager">
+    <favorites_list name="xmi2yang tool-v2.0" />
+  </component>
+  <component name="FileEditorManager">
+    <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
+      <file leaf-file-name="main.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/main.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="13260">
+              <caret line="721" column="12" selection-start-line="721" selection-start-column="12" selection-end-line="721" selection-end-column="12" />
+              <folding>
+                <element signature="e#12594#16410#0" expanded="false" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Tapi.uml" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/project/Tapi.uml">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="0">
+              <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="tapi.yang" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/project/tapi.yang">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="2700">
+              <caret line="135" column="34" selection-start-line="135" selection-start-column="34" selection-end-line="135" selection-end-column="34" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="core-model.yang" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/project/core-model.yang">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="20">
+              <caret line="1" column="53" selection-start-line="1" selection-start-column="53" selection-end-line="1" selection-end-column="53" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="config.txt" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/project/config.txt">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="260">
+              <caret line="13" column="20" selection-start-line="13" selection-start-column="20" selection-end-line="13" selection-end-column="20" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="module.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/model/yang/module.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="300">
+              <caret line="15" column="19" selection-start-line="15" selection-start-column="19" selection-end-line="15" selection-end-column="19" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="util.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/model/yang/util.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="280">
+              <caret line="14" column="14" selection-start-line="14" selection-start-column="14" selection-end-line="14" selection-end-column="14" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="node.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/model/yang/node.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="4940">
+              <caret line="247" column="83" selection-start-line="247" selection-start-column="79" selection-end-line="247" selection-end-column="83" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="OwnedAttribute.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/model/OwnedAttribute.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="660">
+              <caret line="33" column="24" selection-start-line="33" selection-start-column="9" selection-end-line="33" selection-end-column="24" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="GradleLocalSettings">
+    <option name="externalProjectsViewState">
+      <projects_view />
+    </option>
+  </component>
+  <component name="IdeDocumentHistory">
+    <option name="CHANGED_PATHS">
+      <list>
+        <option value="$PROJECT_DIR$/main.js" />
+        <option value="$PROJECT_DIR$/project/config.txt" />
+      </list>
+    </option>
+  </component>
+  <component name="JsBuildToolGruntFileManager" detection-done="true" />
+  <component name="JsBuildToolPackageJson" detection-done="true" />
+  <component name="JsGulpfileManager">
+    <detection-done>true</detection-done>
+  </component>
+  <component name="ProjectFrameBounds">
+    <option name="x" value="-8" />
+    <option name="y" value="-8" />
+    <option name="width" value="1382" />
+    <option name="height" value="744" />
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+      <flattenPackages />
+      <showMembers />
+      <showModules />
+      <showLibraryContents />
+      <hideEmptyPackages />
+      <abbreviatePackageNames />
+      <autoscrollToSource />
+      <autoscrollFromSource />
+      <sortByType />
+      <manualOrder />
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="PackagesPane" />
+      <pane id="ProjectPane">
+        <subPane>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="project" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="model" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="xmi2yang tool-v2.0" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="model" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="yang" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+        </subPane>
+      </pane>
+      <pane id="Scope" />
+      <pane id="Scratches" />
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="settings.editor.selected.configurable" value="reference.projectsettings.compiler.javacompiler" />
+    <property name="settings.editor.splitter.proportion" value="0.2" />
+    <property name="aspect.path.notification.shown" value="true" />
+    <property name="last_opened_file_path" value="G:/javacode/160903" />
+    <property name="nodejs_interpreter_path" value="C:\Program Files\nodejs\node" />
+    <property name="js-jscs-nodeInterpreter" value="C:\Program Files\nodejs\node.exe" />
+    <property name="restartRequiresConfirmation" value="false" />
+  </component>
+  <component name="RunManager" selected="Node.js.main.js">
+    <configuration default="false" name="main.js" type="NodeJSConfigurationType" factoryName="Node.js" temporary="true" path-to-node="project" path-to-js-file="main.js" working-dir="$PROJECT_DIR$">
+      <method />
+    </configuration>
+    <configuration default="true" type="Applet" factoryName="Applet">
+      <option name="HTML_USED" value="false" />
+      <option name="WIDTH" value="400" />
+      <option name="HEIGHT" value="300" />
+      <option name="POLICY_FILE" value="$APPLICATION_HOME_DIR$/bin/appletviewer.policy" />
+      <module />
+      <method />
+    </configuration>
+    <configuration default="true" type="Application" factoryName="Application">
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="ENABLE_SWING_INSPECTOR" value="false" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="FlashRunConfigurationType" factoryName="Flash App">
+      <option name="BCName" value="" />
+      <option name="IOSSimulatorSdkPath" value="" />
+      <option name="adlOptions" value="" />
+      <option name="airProgramParameters" value="" />
+      <option name="appDescriptorForEmulator" value="Android" />
+      <option name="debugTransport" value="USB" />
+      <option name="debuggerSdkRaw" value="BC SDK" />
+      <option name="emulator" value="NexusOne" />
+      <option name="emulatorAdlOptions" value="" />
+      <option name="fastPackaging" value="true" />
+      <option name="fullScreenHeight" value="0" />
+      <option name="fullScreenWidth" value="0" />
+      <option name="launchUrl" value="false" />
+      <option name="launcherParameters">
+        <LauncherParameters>
+          <option name="browser" value="a7bb68e0-33c0-4d6f-a81a-aac1fdb870c8" />
+          <option name="launcherType" value="OSDefault" />
+          <option name="newPlayerInstance" value="false" />
+          <option name="playerPath" value="FlashPlayerDebugger.exe" />
+        </LauncherParameters>
+      </option>
+      <option name="mobileRunTarget" value="Emulator" />
+      <option name="moduleName" value="" />
+      <option name="overriddenMainClass" value="" />
+      <option name="overriddenOutputFileName" value="" />
+      <option name="overrideMainClass" value="false" />
+      <option name="runTrusted" value="true" />
+      <option name="screenDpi" value="0" />
+      <option name="screenHeight" value="0" />
+      <option name="screenWidth" value="0" />
+      <option name="url" value="http://" />
+      <option name="usbDebugPort" value="7936" />
+      <method />
+    </configuration>
+    <configuration default="true" type="FlexUnitRunConfigurationType" factoryName="FlexUnit" appDescriptorForEmulator="Android" class_name="" emulatorAdlOptions="" method_name="" package_name="" scope="Class">
+      <option name="BCName" value="" />
+      <option name="launcherParameters">
+        <LauncherParameters>
+          <option name="browser" value="a7bb68e0-33c0-4d6f-a81a-aac1fdb870c8" />
+          <option name="launcherType" value="OSDefault" />
+          <option name="newPlayerInstance" value="false" />
+          <option name="playerPath" value="FlashPlayerDebugger.exe" />
+        </LauncherParameters>
+      </option>
+      <option name="moduleName" value="" />
+      <option name="trusted" value="true" />
+      <method />
+    </configuration>
+    <configuration default="true" type="GradleRunConfiguration" factoryName="Gradle">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list />
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <method />
+    </configuration>
+    <configuration default="true" type="GrailsRunConfigurationType" factoryName="Grails">
+      <setting name="vmparams" value="" />
+      <setting name="cmdLine" value="run-app" />
+      <setting name="passParentEnv" value="true" />
+      <setting name="launchBrowser" value="true" />
+      <setting name="depsClasspath" value="false" />
+      <method />
+    </configuration>
+    <configuration default="true" type="JUnit" factoryName="JUnit">
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
+      </option>
+      <envs />
+      <patterns />
+      <method />
+    </configuration>
+    <configuration default="true" type="JUnitTestDiscovery" factoryName="JUnit Test Discovery" changeList="All">
+      <module name="" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PACKAGE_NAME" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="METHOD_NAME" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="VM_PARAMETERS" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="singleModule" />
+      </option>
+      <envs />
+      <patterns />
+      <method />
+    </configuration>
+    <configuration default="true" type="JarApplication" factoryName="JAR Application">
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="Java Scratch" factoryName="Java Scratch">
+      <option name="SCRATCH_FILE_ID" value="0" />
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="ENABLE_SWING_INSPECTOR" value="false" />
+      <option name="ENV_VARIABLES" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="JavascriptDebugType" factoryName="JavaScript Debug">
+      <method />
+    </configuration>
+    <configuration default="true" type="JetRunConfigurationType" factoryName="Kotlin">
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" />
+      <option name="PROGRAM_PARAMETERS" />
+      <option name="WORKING_DIRECTORY" />
+      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+      <option name="ALTERNATIVE_JRE_PATH" />
+      <option name="PASS_PARENT_ENVS" value="true" />
+      <module name="xmi2yang tool-v2.0" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="KotlinStandaloneScriptRunConfigurationType" factoryName="Kotlin script">
+      <option name="filePath" />
+      <option name="vmParameters" />
+      <option name="alternativeJrePath" />
+      <option name="programParameters" />
+      <option name="passParentEnvs" value="true" />
+      <option name="workingDirectory" />
+      <option name="isAlternativeJrePathEnabled" value="false" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="NodeJSConfigurationType" factoryName="Node.js" path-to-node="project" working-dir="">
+      <method />
+    </configuration>
+    <configuration default="true" type="Remote" factoryName="Remote">
+      <option name="USE_SOCKET_TRANSPORT" value="true" />
+      <option name="SERVER_MODE" value="false" />
+      <option name="SHMEM_ADDRESS" value="javadebug" />
+      <option name="HOST" value="localhost" />
+      <option name="PORT" value="5005" />
+      <method />
+    </configuration>
+    <configuration default="true" type="js.build_tools.gulp" factoryName="Gulp.js">
+      <node-interpreter>project</node-interpreter>
+      <node-options />
+      <gulpfile />
+      <tasks />
+      <arguments />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="js.build_tools.npm" factoryName="npm">
+      <command value="run-script" />
+      <scripts />
+      <node-interpreter value="project" />
+      <envs />
+      <method />
+    </configuration>
+    <configuration default="true" type="mocha-javascript-test-runner" factoryName="Mocha">
+      <node-interpreter>project</node-interpreter>
+      <node-options />
+      <working-directory>$PROJECT_DIR$</working-directory>
+      <pass-parent-env>true</pass-parent-env>
+      <envs />
+      <ui>bdd</ui>
+      <extra-mocha-options />
+      <test-kind>DIRECTORY</test-kind>
+      <test-directory />
+      <recursive>false</recursive>
+      <method />
+    </configuration>
+    <configuration default="true" type="osgi.bnd.run" factoryName="Run Launcher">
+      <method />
+    </configuration>
+    <configuration default="true" type="osgi.bnd.run" factoryName="Test Launcher (JUnit)">
+      <method />
+    </configuration>
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="Node.js.main.js" />
+    </list>
+    <recent_temporary>
+      <list size="1">
+        <item index="0" class="java.lang.String" itemvalue="Node.js.main.js" />
+      </list>
+    </recent_temporary>
+    <configuration name="&lt;template&gt;" type="TestNG" default="true" selected="false">
+      <option name="MAIN_CLASS_NAME" />
+      <option name="VM_PARAMETERS" value="-ea" />
+      <option name="PARAMETERS" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+    </configuration>
+    <configuration name="&lt;template&gt;" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" default="true" selected="false">
+      <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
+    </configuration>
+  </component>
+  <component name="ShelveChangesManager" show_recycled="false">
+    <option name="remove_strategy" value="false" />
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="-8" y="-8" width="1382" height="744" extended-state="6" />
+    <editor active="false" />
+    <layout>
+      <window_info id="Designer" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Project" active="true" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.2730711" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32876712" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="Palette&#9;" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="8" side_tool="true" content_ui="tabs" />
+      <window_info id="Database" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
+      <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="UI Designer" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="4" side_tool="true" content_ui="tabs" />
+      <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+      <window_info id="Messages" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.3270548" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
+      <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="SLIDING" type="SLIDING" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.380137" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.37606838" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+    </layout>
+  </component>
+  <component name="Vcs.Log.UiProperties">
+    <option name="RECENTLY_FILTERED_USER_GROUPS">
+      <collection />
+    </option>
+    <option name="RECENTLY_FILTERED_BRANCH_GROUPS">
+      <collection />
+    </option>
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="javascript">
+          <url>file://$PROJECT_DIR$/model/yang/util.js</url>
+          <line>14</line>
+          <option name="timeStamp" value="8" />
+        </line-breakpoint>
+      </breakpoints>
+      <option name="time" value="9" />
+    </breakpoint-manager>
+    <watches-manager />
+  </component>
+  <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/main.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="13260">
+          <caret line="721" column="12" selection-start-line="721" selection-start-column="12" selection-end-line="721" selection-end-column="12" />
+          <folding>
+            <element signature="e#12594#16410#0" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/Tapi.uml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/tapi.yang">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="2700">
+          <caret line="135" column="34" selection-start-line="135" selection-start-column="34" selection-end-line="135" selection-end-column="34" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/core-model.yang">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/config.txt">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="260">
+          <caret line="13" column="20" selection-start-line="13" selection-start-column="20" selection-end-line="13" selection-end-column="20" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/module.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="300">
+          <caret line="15" column="19" selection-start-line="15" selection-start-column="19" selection-end-line="15" selection-end-column="19" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/util.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="280">
+          <caret line="14" column="14" selection-start-line="14" selection-start-column="14" selection-end-line="14" selection-end-column="14" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/node.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="4940">
+          <caret line="247" column="83" selection-start-line="247" selection-start-column="79" selection-end-line="247" selection-end-column="83" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/OwnedAttribute.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="660">
+          <caret line="33" column="24" selection-start-line="33" selection-start-column="9" selection-end-line="33" selection-end-column="24" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/main.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="13260">
+          <caret line="721" column="12" selection-start-line="721" selection-start-column="12" selection-end-line="721" selection-end-column="12" />
+          <folding>
+            <element signature="e#12594#16410#0" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/Tapi.uml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/tapi.yang">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="2560">
+          <caret line="128" column="25" selection-start-line="128" selection-start-column="18" selection-end-line="128" selection-end-column="25" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/module.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="300">
+          <caret line="15" column="19" selection-start-line="15" selection-start-column="19" selection-end-line="15" selection-end-column="19" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/util.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/node.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="4940">
+          <caret line="247" column="83" selection-start-line="247" selection-start-column="79" selection-end-line="247" selection-end-column="83" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/OwnedAttribute.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="660">
+          <caret line="33" column="24" selection-start-line="33" selection-start-column="9" selection-end-line="33" selection-end-column="24" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/OwnedAttribute.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="660">
+          <caret line="33" column="24" selection-start-line="33" selection-start-column="9" selection-end-line="33" selection-end-column="24" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/Tapi.uml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/main.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="13260">
+          <caret line="721" column="12" selection-start-line="721" selection-start-column="12" selection-end-line="721" selection-end-column="12" />
+          <folding>
+            <element signature="e#12594#16410#0" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/module.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="300">
+          <caret line="15" column="19" selection-start-line="15" selection-start-column="19" selection-end-line="15" selection-end-column="19" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/node.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="4940">
+          <caret line="247" column="83" selection-start-line="247" selection-start-column="79" selection-end-line="247" selection-end-column="83" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/model/yang/util.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="280">
+          <caret line="14" column="14" selection-start-line="14" selection-start-column="14" selection-end-line="14" selection-end-column="14" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/tapi.yang">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="2700">
+          <caret line="135" column="34" selection-start-line="135" selection-start-column="34" selection-end-line="135" selection-end-column="34" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/config.txt">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="260">
+          <caret line="13" column="20" selection-start-line="13" selection-start-column="20" selection-end-line="13" selection-end-column="20" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project/core-model.yang">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="20">
+          <caret line="1" column="53" selection-start-line="1" selection-start-column="53" selection-end-line="1" selection-end-column="53" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+  </component>
+</project>

--- a/xmi2yang tool-v2.0/.idea/xmi2yang tool-v2.0.iml
+++ b/xmi2yang tool-v2.0/.idea/xmi2yang tool-v2.0.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="xmi2yang tool-v2.0 node_modules" level="project" />
+  </component>
+</module>

--- a/xmi2yang tool-v2.0/main.js
+++ b/xmi2yang tool-v2.0/main.js
@@ -718,7 +718,13 @@ function parseUmlModel(xmi){                    //parse umlmodel
     //var namespace = "urn:onf:params:xml:ns:yang:" + modName.join("-");
     var namespace = "";
     namespace = config.namespace + modName.join("-");
-    var m = new Module(modName.join("-"), namespace, "", config.prefix, config.organization, config.contact, config.revision, comment, currentFileName);
+    var prefix;
+    if(config.prefix == "" || config.prefix == null){
+        prefix = modName.join("-");
+    }else{
+        prefix = config.prefix;
+    }
+    var m = new Module(modName.join("-"), namespace, "", prefix, config.organization, config.contact, config.revision, comment, currentFileName);
     modName.pop();
     //createElement(xmi);//create object class
     var newxmi;
@@ -1259,9 +1265,9 @@ function createClass(obj, nodeType) {
                         }
                     }
                 }
-                if (definedBySpecFlag == true) {
-                    node.attribute[i].isDefinedBySpec = true;
-                }
+//                if (definedBySpecFlag == true) {
+//                    node.attribute[i].isDefinedBySpec = true;
+//                }
                 if(specTargetFlag == true) { // && node.name != "ExtensionsSpec"){
                     node.attribute[i].isSpecTarget = true;
                     node.isSpec = true;
@@ -1894,9 +1900,9 @@ function obj2yang(ele){
                     break;
                 }
             }
-            if(ele[i].key.length != 0){
+            /*if(ele[i].key.length != 0){
                 obj.nodeType = "list";
-            }
+            }*/
             if(k == association.length){
                 obj["ordered-by"] = undefined;
             }
@@ -1911,7 +1917,8 @@ function obj2yang(ele){
             //newobj.uses.push(obj.name);
             newobj.uses.push(obj.name);
             
-        }else if(ele[i].isAbstract == false && ele[i].nodeType == "grouping"){
+        } else if(ele[i].name == "Context") {
+        //else if(ele[i].isAbstract == false && ele[i].nodeType == "grouping"){
             flag=false;
             newobj = new Node(ele[i].name, undefined, "container", undefined, undefined, obj.id, obj.config, obj["ordered-by"], undefined, undefined, ele[i].fileName);
             newobj.key = obj.key;
@@ -1939,6 +1946,7 @@ function obj2yang(ele){
             if(newobj.nodeType !== "list"){
                 newobj["ordered-by"] = undefined;
             }
+            console.info ("******* Top-Level Object: " + newobj.name + " Type:" + newobj.nodeType)
         }
         if(flag && !ele[i].isGrouping){
             obj.name = ele[i].name;
@@ -1946,7 +1954,8 @@ function obj2yang(ele){
         if(ele[i].path == ""){
             for(var t = 0; t < yangModule.length; t++){
                 if(ele[i].fileName == yangModule[t].fileName){
-                    if ((ele[i].isAbstract == false && ele[i].nodeType == "grouping") || ele[i].nodeType == "notification") {
+                	if (ele[i].name == "Context" || ele[i].nodeType == "notification") {
+                    //if ((ele[i].isAbstract == false && ele[i].nodeType == "grouping") || ele[i].nodeType == "notification") {
                         yangModule[t].children.push(newobj);
                     }
                     /*if (feat.length) {
@@ -1966,7 +1975,8 @@ function obj2yang(ele){
             }
             if (tempPath == ele[i].path && packages[t].fileName == ele[i].fileName) {
                 //create a new node if "ele" needs to be instantiate
-                if ((ele[i].isAbstract == false && ele[i].nodeType == "grouping") || ele[i].nodeType == "notification") {
+            	if (ele[i].name == "Context" || ele[i].nodeType == "notification") {
+                //if ((ele[i].isAbstract == false && ele[i].nodeType == "grouping") || ele[i].nodeType == "notification") {
                     packages[t].children.push(newobj)
                 }
                 /*if (feat.length) {

--- a/xmi2yang tool-v2.0/package.json
+++ b/xmi2yang tool-v2.0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmi2yang-tool",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "The UML-YANG mapping tool translates a UML (Unified Modeling Language) model to a YANG model defined in RFC6020. The output YANG files can be conveniently used in REST style API definition. ",
   "main": "main.js",
   "scripts": {

--- a/xmi2yang tool-v2.0/project/CoreModel.uml
+++ b/xmi2yang tool-v2.0/project/CoreModel.uml
@@ -1,0 +1,5092 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_pvGcUDNuEea0Br-ajMxp_A/15" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_pvGcUDNuEea0Br-ajMxp_A/15 OpenModel_Profile.profile.uml#_pvGcUTNuEea0Br-ajMxp_A">
+  <uml:Package xmi:id="_oGqilVLNEeO75dO39GbF8Q" name="CoreModel">
+    <packageImport xmi:type="uml:PackageImport" xmi:id="_8Q4ecKxrEeS5HuAudtqItw">
+      <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+    </packageImport>
+    <packagedElement xmi:type="uml:Package" xmi:id="_Hg3wABizEeSh8KVgZCMyDw" name="CoreNetworkModule">
+      <packagedElement xmi:type="uml:Package" xmi:id="_oGqi3FLNEeO75dO39GbF8Q" name="TypeDefinitions">
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_oGqjalLNEeO75dO39GbF8Q" name="OperationalState">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqja1LNEeO75dO39GbF8Q" annotatedElement="_oGqjalLNEeO75dO39GbF8Q">
+            <body>OBSOLETE: The list of valid operational states for the connection.</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjbFLNEeO75dO39GbF8Q" name="ENABLED"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjbVLNEeO75dO39GbF8Q" name="DISABLED"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_oGqjf1LNEeO75dO39GbF8Q" name="OperType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqjgFLNEeO75dO39GbF8Q" annotatedElement="_oGqjf1LNEeO75dO39GbF8Q">
+            <body>The operation type associated with the protection mechanism (either non-revertive or revertive).</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjgVLNEeO75dO39GbF8Q" name="REVERTIVE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_EZCboGaYEeWrX_JIGzXlSg" annotatedElement="_oGqjgVLNEeO75dO39GbF8Q">
+              <body>Traffic will return to a preferred route on recovery of that route (potentiall after some hold-off time)</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjglLNEeO75dO39GbF8Q" name="NON-REVERTIVE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_MvUxIGaYEeWrX_JIGzXlSg" annotatedElement="_oGqjglLNEeO75dO39GbF8Q">
+              <body>Traffic will be rerouted on failure and not on recovery of any particular route.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_oGqjV1LNEeO75dO39GbF8Q" name="Directionality">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqjWFLNEeO75dO39GbF8Q" annotatedElement="_oGqjV1LNEeO75dO39GbF8Q">
+            <body>OBSOLETE: The enumeration with the options for directionality of the termination point.</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjWVLNEeO75dO39GbF8Q" name="SINK"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjWlLNEeO75dO39GbF8Q" name="SOURCE"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oGqjW1LNEeO75dO39GbF8Q" name="BIDIRECTIONAL"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_XrjoYL7XEeSdssyZX-p90g" name="TopologyPacs">
+          <packagedElement xmi:type="uml:DataType" xmi:id="_6LJtgKNWEeS9Obpdy8FCjA" name="CostCharacteristics">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pp9rwGapEeWrX_JIGzXlSg" annotatedElement="_6LJtgKNWEeS9Obpdy8FCjA">
+              <body>The information for a particular cost characteristic.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_FVmMsKNXEeS9Obpdy8FCjA" name="costName" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_xeCFAGapEeWrX_JIGzXlSg" annotatedElement="_FVmMsKNXEeS9Obpdy8FCjA">
+                <body>The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Gn2ewKNXEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GoHkgKNXEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_HVLe0KNXEeS9Obpdy8FCjA" name="costValue" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_3KqQoGapEeWrX_JIGzXlSg" annotatedElement="_HVLe0KNXEeS9Obpdy8FCjA">
+                <body>The specific cost.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JCANAKNXEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JCRSwKNXEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_SI-YgKQbEeS9Obpdy8FCjA" name="costAlgorithm" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_7rf-kGapEeWrX_JIGzXlSg" annotatedElement="_SI-YgKQbEeS9Obpdy8FCjA">
+                <body>The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Sm1ZMKQbEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_SnGe8KQbEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_dCtNEKQZEeS9Obpdy8FCjA" name="RiskCharacteristic">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_f0zvEGaqEeWrX_JIGzXlSg" annotatedElement="_dCtNEKQZEeS9Obpdy8FCjA">
+              <body>The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_kv5iQKQZEeS9Obpdy8FCjA" name="riskCharacteristicName" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_kPd8gGaqEeWrX_JIGzXlSg" annotatedElement="_kv5iQKQZEeS9Obpdy8FCjA">
+                <body>The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. &#xD;
+For example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).&#xD;
+Depending upon the importance of the traffic being routed different risk characteristics will be evaluated.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lPav0KQZEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lPr1kKQZEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_pVOHkKQZEeS9Obpdy8FCjA" name="riskIdentifierList" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_rEzcoGaqEeWrX_JIGzXlSg" annotatedElement="_pVOHkKQZEeS9Obpdy8FCjA">
+                <body>A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_po54kKQZEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ppK-UKQZEeS9Obpdy8FCjA" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_CxSZ0K4AEeSXJ6XI-2nsRw" name="Capacity">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_wXPmoGaqEeWrX_JIGzXlSg" annotatedElement="_CxSZ0K4AEeSXJ6XI-2nsRw">
+              <body>Informtion on capacity of a particular TopologicalEntity.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_Jsq3kK4AEeSXJ6XI-2nsRw" name="totalSize" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_5lnasGaqEeWrX_JIGzXlSg" annotatedElement="_Jsq3kK4AEeSXJ6XI-2nsRw">
+                <body>Total capacity of the TopologicalEntity in MB/s</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KCIKMK4AEeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KCdhYK4AEeSXJ6XI-2nsRw" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_cF4qkK4AEeSXJ6XI-2nsRw" name="numberOfClientInstances" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_9xuOwGaqEeWrX_JIGzXlSg" annotatedElement="_cF4qkK4AEeSXJ6XI-2nsRw">
+                <body>Where there is some limit to the number of client (e.g. in a channelized case).</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fGIvgK4AEeSXJ6XI-2nsRw"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fGdfoK4AEeSXJ6XI-2nsRw" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_-GPhcL7eEeSdssyZX-p90g" name="maximumClientSize" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_DEkBYGarEeWrX_JIGzXlSg" annotatedElement="_-GPhcL7eEeSdssyZX-p90g">
+                <body>Where a client is of variable capacity but due to some underlying realization the maximum size of the client is smaller than the totalSize.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-umh8L7eEeSdssyZX-p90g"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-wQHwL7eEeSdssyZX-p90g" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_zMhw4MDWEeSoNOrYOfaryg" name="numberingRange" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_MKgSMGarEeWrX_JIGzXlSg" annotatedElement="_zMhw4MDWEeSoNOrYOfaryg">
+                <body>Method for identifying units of capacity via some numbering scheme.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0WGoEMDWEeSoNOrYOfaryg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0WmXUMDWEeSoNOrYOfaryg" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_HSrdMK4HEeSXJ6XI-2nsRw" name="ValidationMechanism">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_QhT6YGarEeWrX_JIGzXlSg" annotatedElement="_HSrdMK4HEeSXJ6XI-2nsRw">
+              <body>Identifies the validation mechanism and describes the characteristics of that mechanism</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_OtjTUK4HEeSXJ6XI-2nsRw" name="validationMechanism" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_VWoqkGarEeWrX_JIGzXlSg" annotatedElement="_OtjTUK4HEeSXJ6XI-2nsRw">
+                <body>Name of mechanism used to validate adjacency</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PEIAQK4HEeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PEelkK4HEeSXJ6XI-2nsRw" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_Sx55kK4HEeSXJ6XI-2nsRw" name="layerProtocolAdjacencyValidated" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_Y-tkgGarEeWrX_JIGzXlSg" annotatedElement="_Sx55kK4HEeSXJ6XI-2nsRw">
+                <body>State of validatiion</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Tz9McK4HEeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_T0RVgK4HEeSXJ6XI-2nsRw" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_bnwf8K4HEeSXJ6XI-2nsRw" name="validationRobustness" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_h4nkcGarEeWrX_JIGzXlSg" annotatedElement="_bnwf8K4HEeSXJ6XI-2nsRw">
+                <body>Quality of validation (i.e. how likely is the stated validation to be invalid)</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cz-bcK4HEeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c0SkgK4HEeSXJ6XI-2nsRw" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_OK-YkLFmEeSZUdYfPSdgew" name="QueuingLatency">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pfX6cGarEeWrX_JIGzXlSg" annotatedElement="_OK-YkLFmEeSZUdYfPSdgew">
+              <body>Provides information on latency characteristic for a particular stated trafficProperty.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_kOFqcLFmEeSZUdYfPSdgew" name="trafficProperty" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_t2u8QGarEeWrX_JIGzXlSg" annotatedElement="_kOFqcLFmEeSZUdYfPSdgew">
+                <body>The identifier of the specific traffic property to which the queuing latency applies.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_q8Sn0LFmEeSZUdYfPSdgew" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_q8mJ0LFmEeSZUdYfPSdgew" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_sUoTwLFmEeSZUdYfPSdgew" name="latencyForTrafficWithProperty" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_0ergoGarEeWrX_JIGzXlSg" annotatedElement="_sUoTwLFmEeSZUdYfPSdgew">
+                <body>The specific queuing latency for the traffic property.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_u6ossLFmEeSZUdYfPSdgew" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_u7m9ELFmEeSZUdYfPSdgew" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_P-Hp8MD4EeSoNOrYOfaryg" name="LayerProtocolName">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_cS4UwGXLEeWWhJGy6csBUQ" annotatedElement="_P-Hp8MD4EeSoNOrYOfaryg">
+            <body>Provides a controlled list of layer protocol names and indicates the naming authority.&#xD;
+&#xD;
+Note that it is expected that attributes will be added to this structure to convey the naming authority name, the name of the layer protocol using a human readable string and any particular standard reference.&#xD;
+&#xD;
+Layer protocol names include:&#xD;
+-	Layer 1 (L1): OTU, ODU&#xD;
+-	Layer 2 (L2): Carrier Grade Ethernet (ETY, ETH), MPLS-TP (MT)&#xD;
+</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_DUU_sGZ_EeWrX_JIGzXlSg" name="PortRole">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_SLFYkGZ_EeWrX_JIGzXlSg" annotatedElement="_DUU_sGZ_EeWrX_JIGzXlSg">
+            <body>The role of a port in the context of the function of the forwarding entity that it bounds</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_2WpC8EC7EeWxhL2B6Peg6A" name="PortDirection">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Gw-MQGasEeWrX_JIGzXlSg" annotatedElement="_2WpC8EC7EeWxhL2B6Peg6A">
+            <body>The orientation of flow at the Port of a Forwarding entity</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_6A9_oEC7EeWxhL2B6Peg6A" name="BIDIRECTIONAL">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_KcZ8MGasEeWrX_JIGzXlSg" annotatedElement="_6A9_oEC7EeWxhL2B6Peg6A">
+              <body>The Port has both an INPUT flow and an OUTPUT flow defined.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_7K6DMEC7EeWxhL2B6Peg6A" name="INPUT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_ReamYGasEeWrX_JIGzXlSg" annotatedElement="_7K6DMEC7EeWxhL2B6Peg6A">
+              <body>The Port only has definition for a flow into the Forwarding entity (i.e. an ingress flow).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8qSLQEC7EeWxhL2B6Peg6A" name="OUTPUT">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_VjvdAGasEeWrX_JIGzXlSg" annotatedElement="_8qSLQEC7EeWxhL2B6Peg6A">
+              <body>The Port only has definition for a flow out of the Forwarding entity (i.e. an egress flow).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_-ixW4EC7EeWxhL2B6Peg6A" name="UNIDENTIFIED_OR_UNKNOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_ZvYXAGasEeWrX_JIGzXlSg" annotatedElement="_-ixW4EC7EeWxhL2B6Peg6A">
+              <body>Not a normal state. The system is unable to determine the correct value.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_dV67AEC8EeWxhL2B6Peg6A" name="ForwardingDirection">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oigQQGawEeWrX_JIGzXlSg" annotatedElement="_dV67AEC8EeWxhL2B6Peg6A">
+            <body>The directionality of a Forwarding entity.</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_fg49wEC8EeWxhL2B6Peg6A" name="BIDIRECTIONAL">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_tv_BwGawEeWrX_JIGzXlSg" annotatedElement="_fg49wEC8EeWxhL2B6Peg6A">
+              <body>The Fowarding entity supports both BIDIRECTIONAL flows at all Ports (i.e. all Ports have both an INPUT flow and an OUTPUT flow defined)</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gq9kMEC8EeWxhL2B6Peg6A" name="UNIDIRECTIONAL">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_y0VFYGawEeWrX_JIGzXlSg" annotatedElement="_gq9kMEC8EeWxhL2B6Peg6A">
+              <body>The Forwarding entity has Ports that are either INPUT or OUTPUT. It has no BIDIRECTIONAL Ports.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_i4cvcEC8EeWxhL2B6Peg6A" name="UNDEFINED_OR_UNKNOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_3pKtYGawEeWrX_JIGzXlSg" annotatedElement="_i4cvcEC8EeWxhL2B6Peg6A">
+              <body>Not a normal state. The system is unable to determine the correct value.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_RWILYEDAEeWQeOKbNUpP9A" name="TerminationDirection">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__8enYGawEeWrX_JIGzXlSg" annotatedElement="_RWILYEDAEeWQeOKbNUpP9A">
+            <body>The directionality of a termination entity</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VOHwoEDAEeWQeOKbNUpP9A" name="BIDIRECTIONAL">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_DgyboGaxEeWrX_JIGzXlSg" annotatedElement="_VOHwoEDAEeWQeOKbNUpP9A">
+              <body>A Termination with both SINK and SOURCE flows.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_W4avQEDAEeWQeOKbNUpP9A" name="SINK">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_HbsK8GaxEeWrX_JIGzXlSg" annotatedElement="_W4avQEDAEeWQeOKbNUpP9A">
+              <body>The flow is up the layer stack from the server side to the client side. &#xD;
+Considering an example of a Termination function within the termination entity, a SINK flow:&#xD;
+- will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component&#xD;
+- then will be decoded and deconstructed &#xD;
+- then relevant parts of the flow will be sent out of the termination function (the client side) where it is essentially at an OUTPUT from the termination component&#xD;
+A SINK termination is one that only supports a SINK flow.&#xD;
+A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XrdVwEDAEeWQeOKbNUpP9A" name="SOURCE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_K-pUUGaxEeWrX_JIGzXlSg" annotatedElement="_XrdVwEDAEeWQeOKbNUpP9A">
+              <body>The flow is down the layer stack from the server side to the client side. &#xD;
+Considering an example of a Termination function within the termination entity, a SOURCE flow:&#xD;
+- will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component&#xD;
+- then will be assembled with various overheads etc and will be coded &#xD;
+- then coded form of the assembly of flow will be sent out of the termination function (the server side) where it is essentially at an OUTPUT from the termination component&#xD;
+A SOURCE termination is one that only supports a SOURCE flow.&#xD;
+A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YcGIgEDAEeWQeOKbNUpP9A" name="UNDEFINED_OR_UNKNOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_OV488GaxEeWrX_JIGzXlSg" annotatedElement="_YcGIgEDAEeWQeOKbNUpP9A">
+              <body>Not a normal state. The system is unable to determine the correct value.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_T5GykEDNEeWQeOKbNUpP9A" name="ExtendedTerminationDirection">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_UhgxsGaxEeWrX_JIGzXlSg" annotatedElement="_T5GykEDNEeWQeOKbNUpP9A">
+            <body>Extended to include contra-direction considerations. Only applies to LP and elements of LP not to LTP??</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_YHthAEDNEeWQeOKbNUpP9A" general="_RWILYEDAEeWQeOKbNUpP9A"/>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_aeRIsEDNEeWQeOKbNUpP9A" name="CONTRA_DIRECTION_SINK">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_g2JzIGaxEeWrX_JIGzXlSg" annotatedElement="_aeRIsEDNEeWQeOKbNUpP9A">
+              <body>The essential flow of the Termination entity is SINK (i.e. up the layer stack) but the INPUT flow of the Termination entity was provided by a SOURCE OUTPUT or taken from a SOURCE INPUT (duplicating the input signal) hence reversing the flow orientation from down the layer stack to up the layer stack.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_cw_ZQEDNEeWQeOKbNUpP9A" name="CONTRA_DIRECTION_SOURCE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_nTpbAGaxEeWrX_JIGzXlSg" annotatedElement="_cw_ZQEDNEeWQeOKbNUpP9A">
+              <body>The essential flow of the Termination entity is SOURCE (i.e. down the layer stack) but the OUTPUT flow of the Termination entity was fed to (and replaces) a SINK OUTPUT or was fed to a SINK INPUT (replacing the normal flow) hence reversing the flow orientation from down the layer stack to up the layer stack.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_c3Hu8Gb3EeWrX_JIGzXlSg" name="ProtectionType">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mmORgGb3EeWrX_JIGzXlSg" annotatedElement="_c3Hu8Gb3EeWrX_JIGzXlSg">
+            <body>Identifies the type of rotection of an FcSwitch.</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Enumeration" xmi:id="_6anG8GeEEeWmgIwAIZlYKQ" name="TerminationState">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_LNz-YGeFEeWmgIwAIZlYKQ" annotatedElement="_6anG8GeEEeWmgIwAIZlYKQ">
+            <body>Provides support for the range of behaviours and specific states that an LP can take with respect to termination of the signal.&#xD;
+Indicates to what degree the LayerTermination is terminated.</body>
+          </ownedComment>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_fQ-KsGeFEeWmgIwAIZlYKQ" name="LP_CAN_NEVER_TERMINATE">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_wToacGeFEeWmgIwAIZlYKQ" annotatedElement="_fQ-KsGeFEeWmgIwAIZlYKQ">
+              <body>A non-flexible case that can never be terminated.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_z8-fsGeFEeWmgIwAIZlYKQ" name="LT_NOT_TERMINATED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_3q5i8GeFEeWmgIwAIZlYKQ" annotatedElement="_z8-fsGeFEeWmgIwAIZlYKQ">
+              <body>A flexible termination that can terminate but is currently not terminated.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_CYFeYGeGEeWmgIwAIZlYKQ" name="TERMINATED_SERVER_TO_CLIENT_FLOW">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Ifb3IGeGEeWmgIwAIZlYKQ" annotatedElement="_CYFeYGeGEeWmgIwAIZlYKQ">
+              <body>A flexible termination that is currently terminated for server to client flow only.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LtQeAGeGEeWmgIwAIZlYKQ" name="TERMINATED_CLIENT_TO_SERVER_FLOW">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_UKGHcGeGEeWmgIwAIZlYKQ" annotatedElement="_LtQeAGeGEeWmgIwAIZlYKQ">
+              <body>A flexible termination that is currently terminated for client to server flow only.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YWtR0GeGEeWmgIwAIZlYKQ" name="TERMINATED_BIDIRECTIONAL">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_cxqaMGeGEeWmgIwAIZlYKQ" annotatedElement="_YWtR0GeGEeWmgIwAIZlYKQ">
+              <body>A flexible termination that is currently terminated in both directions of flow.</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gjpeEGeGEeWmgIwAIZlYKQ" name="LT_PERMENANTLY_TERMINATED">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_nkZkAGeGEeWmgIwAIZlYKQ" annotatedElement="_gjpeEGeGEeWmgIwAIZlYKQ">
+              <body>A non-flexible termination that is always terminated (in both directions of flow for a bidirectional case and in the one direction of flow for both unidirectional cases).</body>
+            </ownedComment>
+          </ownedLiteral>
+          <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ueUCIGeGEeWmgIwAIZlYKQ" name="TERMINATION_STATE_UNKNOWN">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_OseLsGeHEeWmgIwAIZlYKQ" annotatedElement="_ueUCIGeGEeWmgIwAIZlYKQ">
+              <body>There TerminationState cannot be determined.</body>
+            </ownedComment>
+          </ownedLiteral>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_oGqltlLNEeO75dO39GbF8Q" name="ObjectClasses">
+        <packagedElement xmi:type="uml:Class" xmi:id="_oGql-FLNEeO75dO39GbF8Q" name="ForwardingDomain">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_nATnUFlqEeSUSuWjwt7kSQ" annotatedElement="_oGql-FLNEeO75dO39GbF8Q">
+            <body>The ForwardingDomain (FD) object class models the topological component which represents the opportunity to enable forwarding (of specific transport characteristic information at one or more protocol layers) between points represented by the LTP in the model.&#xD;
+The FD object provides the context for instructing the formation, adjustment and removal of FCs and hence offers the potential to enable forwarding. &#xD;
+The LTPs available are those defined at the boundary of the FD.&#xD;
+At a lowere level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). &#xD;
+Note that an NE can encompass multiple switch matrices (FDs) and the FD representing the switch matrix can be further partitioned.&#xD;
+</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_GmUo8I2uEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+          <generalization xmi:type="uml:Generalization" xmi:id="_QTidoJ2IEeSQBuaNnP_LbA" general="_MROewJ2IEeSQBuaNnP_LbA"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqmAlLNEeO75dO39GbF8Q" name="layerProtocolNameList" visibility="public" type="_P-Hp8MD4EeSoNOrYOfaryg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_MgmPsGY3EeWrX_JIGzXlSg" annotatedElement="_oGqmAlLNEeO75dO39GbF8Q">
+              <body>One or more protocol layers at which the FD represents the opportunity to enable forwarding between LTP that bound it.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqmBFLNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqmA1LNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqmBVLNEeO75dO39GbF8Q" name="_lowerLevelFdRefList" visibility="public" type="_oGql-FLNEeO75dO39GbF8Q" aggregation="shared" association="_oGqoD1LNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pTYPQGXOEeWWhJGy6csBUQ" annotatedElement="_oGqmBVLNEeO75dO39GbF8Q">
+              <body>The FD object class supports a recursive aggregation relationship (HigherLevelFdEncompassesLowerLevelFds) such that the internal construction of an FD can be exposed as multiple lower level FDs and associated Links (partitioning).&#xD;
+The aggregated FDs and Links form an interconnected topology that provides and describes the capability of the aggregating FD.&#xD;
+Note that the model actually represents aggregation of lower level FDs into higher level FDs as views rather than FD partition, and supports multiple views. &#xD;
+Aggregation allow reallocation of capacity from lower level FDs to different higher level FDs as if the network is reorganized  (as the association is aggregation not composition).</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqmB1LNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqmBlLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGql_1LNEeO75dO39GbF8Q" name="_fcRefList" visibility="public" type="_oGqmC1LNEeO75dO39GbF8Q" aggregation="shared" association="_oGqm3FLNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_uqwoYGY2EeWrX_JIGzXlSg" annotatedElement="_oGql_1LNEeO75dO39GbF8Q">
+              <body>An FD contains one or more FCs. A contained FC connects LTPs that bound the FD.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqmAVLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqmAFLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_2ES2QFYkEeOVGaP4lO41SQ" name="_ltpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" aggregation="shared" association="_2EZj8FYkEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_XeBh0GXPEeWWhJGy6csBUQ" annotatedElement="_2ES2QFYkEeOVGaP4lO41SQ">
+              <body>An instance of FD is associated with zero or more LTP objects. &#xD;
+The LTPs that bound the FD provide capacity for forwarding.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2ES2QVYkEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2ES2QlYkEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_dm_ngBiQEeSh8KVgZCMyDw" name="_linkRefList" type="_oGqnjVLNEeO75dO39GbF8Q" aggregation="shared" association="_dnWM0BiQEeSh8KVgZCMyDw">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_WI_Q0GY4EeWrX_JIGzXlSg" annotatedElement="_dm_ngBiQEeSh8KVgZCMyDw">
+              <body>The FD encompasses Links that interconnect lower level FDs and collect links that are wholly within the bounds of the FD.&#xD;
+See also _lowerLevelFdRefList.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dm_ngRiQEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dm_nghiQEeSh8KVgZCMyDw" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_oGqmC1LNEeO75dO39GbF8Q" name="ForwardingConstruct">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGql6lLNEeO75dO39GbF8Q" annotatedElement="_oGqmC1LNEeO75dO39GbF8Q">
+            <body>The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs at a particular specific layerProtocol.&#xD;
+Like the LTP the FC supports any transport protocol including all circuit and packet forms.&#xD;
+It is used to effect forwarding of transport characteristic (layer protocol) information.&#xD;
+An FC can be in only one FD.&#xD;
+The ForwardingConstruct is a Forwarding entity.&#xD;
+At a low level of the recursion, a FC represents a cross-connection within an NE. It may also represent a fragment of a cross-connection under certain circumstances.&#xD;
+The FC object can be used to represent many different structures including point-to-point (P2P), point-to-multipoint (P2MP), rooted-multipoint (RMP) and multipoint-to-multipoint (MP2MP) bridge and selector structure for linear, ring or mesh protection schemes.</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_IneoYI2uEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqmFVLNEeO75dO39GbF8Q" name="layerProtocolName" visibility="public" type="_P-Hp8MD4EeSoNOrYOfaryg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_wGzdsGY4EeWrX_JIGzXlSg" annotatedElement="_oGqmFVLNEeO75dO39GbF8Q">
+              <body>The layerProtocol at which the FC enables potential for forwarding.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqmF1LNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqmFlLNEeO75dO39GbF8Q" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_i7UzkFYfEeOVGaP4lO41SQ" name="_lowerLevelFcRefList" type="_oGqmC1LNEeO75dO39GbF8Q" aggregation="shared" association="_i7cIUFYfEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lXFJEGXfEeWrX_JIGzXlSg" annotatedElement="_i7UzkFYfEeOVGaP4lO41SQ">
+              <body>An FC object supports a recursive aggregation relationship such that the internal construction of an FC can be exposed as multiple lower level FC objects (partitioning).&#xD;
+Aggregation is used as for the FD to allow changes in hierarchy.&#xD;
+</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_i7UzkVYfEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_i7UzklYfEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_A8SFwFYgEeOVGaP4lO41SQ" name="_fcRouteRefList" type="_9UVusFYfEeOVGaP4lO41SQ" aggregation="composite" association="_A8YzcFYgEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_uRMkYGXfEeWrX_JIGzXlSg" annotatedElement="_A8SFwFYgEeOVGaP4lO41SQ">
+              <body>An FC object can have zero or more routes, each of which is defined as a list of lower level FC objects describing the flow across the network.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_A8SFwVYgEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_A8SFwlYgEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_gqUk0FYgEeOVGaP4lO41SQ" name="_fcPortList" type="_b_lUAFYgEeOVGaP4lO41SQ" aggregation="composite" association="_gqbSgFYgEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_xC7hoGXeEeWrX_JIGzXlSg" annotatedElement="_gqUk0FYgEeOVGaP4lO41SQ">
+              <body>The association of the FC to LTPs is made via FcPorts (essentially the ports of the FC).</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gqUk0VYgEeOVGaP4lO41SQ" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gqUk0lYgEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_d_droFYhEeOVGaP4lO41SQ" name="_fcSwitchList" type="_a97NQFYhEeOVGaP4lO41SQ" aggregation="composite" association="_d_lncFYhEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_zfUkMGXhEeWrX_JIGzXlSg" annotatedElement="_d_droFYhEeOVGaP4lO41SQ">
+              <body>If an FC exposes protection (having two FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects.&#xD;
+The arrangement of switches for a particular instance is described by a referenced FcSpec</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d_droVYhEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d_drolYhEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_v6GHsJ4LEeOO3om500DFKg" name="_configurationAndSwitchControlList" type="_k1gHQJo5EeOyHKqw-cQ_eg" aggregation="composite" association="_v6VYQJ4LEeOO3om500DFKg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_jJK_cGaBEeWrX_JIGzXlSg" annotatedElement="_v6GHsJ4LEeOO3om500DFKg">
+              <body>A multi-switch controller encapsulated in the FC.&#xD;
+The multi-switch controller coordinates multiple switches in the same FC.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_v6GHsZ4LEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_v6GHsp4LEeOO3om500DFKg" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_7R-PIAgoEeSbuczmw5yq0A" name="_fcSpecRef" type="_huOHsMrVEeOt57ZaJqAnzg" association="_7SNfsAgoEeSbuczmw5yq0A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_9GvqcGYuEeWrX_JIGzXlSg" annotatedElement="_7R-PIAgoEeSbuczmw5yq0A">
+              <body>References the specification that describes the capability and internal structure of of the FC (e.g. The arrangement of switches for a particular instance is described by a referenced FcSpec).&#xD;
+The specification allows interpretation of FcPort role and switch configurations etc.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7R-PIQgoEeSbuczmw5yq0A" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7R-PIggoEeSbuczmw5yq0A" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_9_yMUEDAEeWQeOKbNUpP9A" name="forwardingDirection" visibility="public" type="_dV67AEC8EeWxhL2B6Peg6A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_VWLLwGdUEeWmgIwAIZlYKQ" annotatedElement="_9_yMUEDAEeWQeOKbNUpP9A">
+              <body>The directionality of the ForwardingConstruct. &#xD;
+Is applicable to simple ForwardingConstructs where all FcPorts are BIDIRECTIONAL (the ForwardingConstruct will be BIDIRECTIONAL) or UNIDIRECTIONAL (the ForwardingConstruct will be UNIDIRECTIONAL). &#xD;
+Is not present in more complex cases.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-XpSsEDAEeWQeOKbNUpP9A"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-X6YcEDAEeWQeOKbNUpP9A" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_oGqneFLNEeO75dO39GbF8Q" name="NetworkControlDomain">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_fZoe8FlsEeSUSuWjwt7kSQ">
+            <body>The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected network elements).&#xD;
+In the interfaces between SDN controllers where virtualization is necessary, e.g., in client/server SDN controller relationship, the NCD object defines the scope of control of the client SDN controller on the virtual network that has been provided by the server SDN controller (i.e., the scope of control relates to the partitioned provider resources allocated to that particular client). &#xD;
+The NCD provides the scope of naming space for identifying objects representing the virtual resources within the virtual network.</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_yl3LUI2tEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqneVLNEeO75dO39GbF8Q" name="_forwardingDomainRefList" visibility="public" type="_oGql-FLNEeO75dO39GbF8Q" aggregation="shared" association="_oGqnhVLNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_UU5fkGaREeWrX_JIGzXlSg" annotatedElement="_oGqneVLNEeO75dO39GbF8Q">
+              <body>The FDs accessible via the NCD.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqne1LNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnelLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqnf1LNEeO75dO39GbF8Q" name="_linkRefList" visibility="public" type="_oGqnjVLNEeO75dO39GbF8Q" aggregation="shared" association="_oGqnzVLNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_kD16IGaQEeWrX_JIGzXlSg" annotatedElement="_oGqnf1LNEeO75dO39GbF8Q">
+              <body>The links accessible in the scope of the NCD. &#xD;
+The domain is bounded by off-network links.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqngVLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqngFLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqnfFLNEeO75dO39GbF8Q" name="_networkElementRefList" visibility="public" type="_oGqnr1LNEeO75dO39GbF8Q" aggregation="composite" association="_oGqnx1LNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_GpVj8GaQEeWrX_JIGzXlSg" annotatedElement="_oGqnfFLNEeO75dO39GbF8Q">
+              <body>The network elements within the scope of the NCD where each NE is within one and only one domain.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnflLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnfVLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_oGqnjVLNEeO75dO39GbF8Q" name="Link">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qWxW8GZzEeWrX_JIGzXlSg" annotatedElement="_oGqnjVLNEeO75dO39GbF8Q">
+            <body>The Link object class models effective adjacency between two or more ForwardingDomains (FD). &#xD;
+In its basic form (i.e., point-to-point Link) it associates a set of LTP clients on one FD with an equivalent set of LTP clients on another FD. &#xD;
+Like the FC, the Link has ports (LinkPort) which take roles relevant to the constraints on flows offered by the Link (e.g., Root role or leaf role for a Link that has a constrained Tree configuration). &#xD;
+&#xD;
+The Link is a Forwarding entity.</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_JT5CcI2uEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+          <generalization xmi:type="uml:Generalization" xmi:id="_RvF1oJ2IEeSQBuaNnP_LbA" general="_MROewJ2IEeSQBuaNnP_LbA"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqnkFLNEeO75dO39GbF8Q" name="layerProtocolNameList" visibility="public" type="_P-Hp8MD4EeSoNOrYOfaryg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_FNK8MGZ1EeWrX_JIGzXlSg" annotatedElement="_oGqnkFLNEeO75dO39GbF8Q">
+              <body>The Link can support multiple transport layer protocols via the associated LTP object. &#xD;
+For implementation optimization, where appropriate, multiple layer-specific links can be merged and represented as a single Link instance as the Link can represent a list of layer protocols.&#xD;
+A link may support different layer protocols at each Port when it is a transitional link.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnklLNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnkVLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqnk1LNEeO75dO39GbF8Q" name="_fdRefList" visibility="public" type="_oGql-FLNEeO75dO39GbF8Q" association="_oGqnu1LNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_c2YpMGZ1EeWrX_JIGzXlSg" annotatedElement="_oGqnk1LNEeO75dO39GbF8Q">
+              <body>The Link associates with two or more FDs. &#xD;
+This association provides a direct summarization of the association via LinkPort and LTP.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnlVLNEeO75dO39GbF8Q" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnlFLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqnllLNEeO75dO39GbF8Q" name="_linkPortList" visibility="public" type="_H7c0oIgjEeOIkJV2fkx5ZA" aggregation="composite" association="_oGqnwVLNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vVInAGZ2EeWrX_JIGzXlSg" annotatedElement="_oGqnllLNEeO75dO39GbF8Q">
+              <body>The association of the Link to LTPs is made via LinkPort (essentially the ports of the Link).</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnmFLNEeO75dO39GbF8Q" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnl1LNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_DjfvMKNSEeS9Obpdy8FCjA" name="_linkSpecRef" type="_-Npr4KNREeS9Obpdy8FCjA" association="_DjpgMKNSEeS9Obpdy8FCjA">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_fVjIYGZ3EeWrX_JIGzXlSg" annotatedElement="_DjfvMKNSEeS9Obpdy8FCjA">
+              <body>References the specification that describes the capability and internal structure of of the Link (e.g. asymmetric flows between points).&#xD;
+The specification allows interpretation of LinkPort role and switch configurations etc.&#xD;
+See also ForwardingConstruct.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DjfvMaNSEeS9Obpdy8FCjA" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DjfvMqNSEeS9Obpdy8FCjA" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_RtwvMKT3EeS9Obpdy8FCjA" name="_aggregatedLink" type="_oGqnjVLNEeO75dO39GbF8Q" aggregation="shared" association="_Rt55IKT3EeS9Obpdy8FCjA">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_RTIEkGZ5EeWrX_JIGzXlSg" annotatedElement="_RtwvMKT3EeS9Obpdy8FCjA">
+              <body>A link may formed from subordinate links (similar FD formations from subordiate FDs). This association is intended to cover concepts such as serial compound links. </body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RtwvMaT3EeS9Obpdy8FCjA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RtwvMqT3EeS9Obpdy8FCjA" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_yfYoEEC8EeWxhL2B6Peg6A" name="linkDirection" visibility="public" type="_dV67AEC8EeWxhL2B6Peg6A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_ZLLHYGdUEeWmgIwAIZlYKQ" annotatedElement="_yfYoEEC8EeWxhL2B6Peg6A">
+              <body>The directionality of the Link. &#xD;
+Is applicable to simple Links where all LinkPorts are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). &#xD;
+Is not present in more complex cases.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0ZK0MEC8EeWxhL2B6Peg6A"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0Zb58EC8EeWxhL2B6Peg6A" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_oGqnr1LNEeO75dO39GbF8Q" name="NetworkElement">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqnsFLNEeO75dO39GbF8Q" annotatedElement="_oGqnr1LNEeO75dO39GbF8Q">
+            <body>The Network Element (NE) object class represents a network element (traditional NE) in the data plane.&#xD;
+A data plane network element is essentially a consolidation of capabilities that can be viewed and controlled through a &quot;single&quot; management-control port.&#xD;
+In the direct interface from an SDN controller to a network element in the data plane, the NetworkElement object defines the scope of control for the resources within the network element&#xD;
+For example internal transfer of user information between the external terminations (ports of the NE), encapsulation, multiplexing/demultiplexing, and OAM functions, etc. &#xD;
+The NetworkElement provides the scope of the naming space for identifying objects representing the resources within the data plane network element.&#xD;
+&#xD;
+NE is really a product bundling or some view of management scope, management access, session. &#xD;
+The NE is not directly part of topology but brings meaning to the FD context and the LTP context (and hence the links). </body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_1AQxMI2tEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqnslLNEeO75dO39GbF8Q" name="_fdRefList" visibility="public" type="_oGql-FLNEeO75dO39GbF8Q" aggregation="composite" association="_oGqn01LNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_j4rTUGaNEeWrX_JIGzXlSg" annotatedElement="_oGqnslLNEeO75dO39GbF8Q">
+              <body>Represents the FD that is completely within the boundary of the NE.&#xD;
+At a low level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). &#xD;
+Note that an NE can encompass multiple switch matrices (FDs) and the FD representing the switch matrix can be further partitioned.&#xD;
+Where an FD is referenced by the NeEncompassesFd association, any FDs that it encompasses (i.e., that are associated with it by HigherLevelFdEncompassesLowerLevelFds), must also be encompassed by the NE and hence must have the NeEncompassesFd association.&#xD;
+</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqntFLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqns1LNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqntVLNEeO75dO39GbF8Q" name="_ltppList" visibility="public" aggregation="composite">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_D-WEsGaNEeWrX_JIGzXlSg" annotatedElement="_oGqntVLNEeO75dO39GbF8Q">
+              <body>OBSOLETE. Was reference to LtpPool. The pool has now been subsumed into the LTP.&#xD;
+This will be deleted in the next release.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnt1LNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqntlLNEeO75dO39GbF8Q" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_DyAG8FYmEeOVGaP4lO41SQ" name="_ltpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" aggregation="composite" association="_DyIp0FYmEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_2O5nQGaOEeWrX_JIGzXlSg" annotatedElement="_DyAG8FYmEeOVGaP4lO41SQ">
+              <body>An NE has associated LTPs that are at its boundary.&#xD;
+The NeEncompassesFd association occurs for FDs that are within the bounds of the NetworkElement definition such that the FD is bounded by LTPs, all of which are on the boundary of the NetworkElement or are within the NetworkElement. &#xD;
+An LTP can be independent of an NE.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DyAG8VYmEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DyAG8lYmEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_oGqoB1LNEeO75dO39GbF8Q" name="SdnController" isAbstract="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Zm4WkGaREeWrX_JIGzXlSg" annotatedElement="_oGqoB1LNEeO75dO39GbF8Q">
+            <body>Represents the SDN controller.</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_KLgm8I2uEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_b_lUAFYgEeOVGaP4lO41SQ" name="FcPort">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_1C1FsGXeEeWrX_JIGzXlSg" annotatedElement="_b_lUAFYgEeOVGaP4lO41SQ">
+            <body>The association of the FC to LTPs is made via FcPorts.&#xD;
+The FcPort object class models the access to the FC function. &#xD;
+The traffic forwarding between the associated FcPorts of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  &#xD;
+In cases where there is resilience the FcPort may convey the resilience role of the access to the FC. &#xD;
+It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.&#xD;
+The FcPort replaces the Protection Unit of a traditional protection model. &#xD;
+The ForwadingConstruct can be considered as a component and the FcPort as a Port on that component</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_YKPO0I2yEeO38ZmbECnvbg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_IxS2AFYnEeOVGaP4lO41SQ" name="_ltpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_Ixb_8FYnEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_bMP-cGZ8EeWrX_JIGzXlSg" annotatedElement="_IxS2AFYnEeOVGaP4lO41SQ">
+              <body>The FcPort may be associated with more than one LTP when the FcPort is bidirectional and the LTPs are unidirectional.&#xD;
+Multiple Ltp&#xD;
+- Bidirectional FcPort to two Uni Ltps&#xD;
+Zero Ltp&#xD;
+- BreakBeforeMake transition&#xD;
+- Planned Ltp not yet in place&#xD;
+- Off-network LTP referenced through other mechanism</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IxS2AVYnEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IxS2AlYnEeOVGaP4lO41SQ" value="2"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_Ykm6QFeGEeOVGaP4lO41SQ" name="role" visibility="public" type="_DUU_sGZ_EeWrX_JIGzXlSg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_y3OwkGZ9EeWrX_JIGzXlSg" annotatedElement="_Ykm6QFeGEeOVGaP4lO41SQ">
+              <body>Each FcPort of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Y9kz4FeGEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Y915oFeGEeOVGaP4lO41SQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_1HbEgEDAEeWQeOKbNUpP9A" name="fcPortDirection" visibility="public" type="_2WpC8EC7EeWxhL2B6Peg6A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_diIzMGY5EeWrX_JIGzXlSg" annotatedElement="_1HbEgEDAEeWQeOKbNUpP9A">
+              <body>The orientation of defined flow at the FcPort.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Dd7akEDCEeWQeOKbNUpP9A" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DeNHYEDCEeWQeOKbNUpP9A" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_gROecFYXEeOVGaP4lO41SQ" name="LayerProtocol">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_IX_aMFlqEeSUSuWjwt7kSQ" annotatedElement="_gROecFYXEeOVGaP4lO41SQ">
+            <body>Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. &#xD;
+It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. &#xD;
+Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. </body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_XUDNsI2yEeO38ZmbECnvbg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_OwauQFeEEeOVGaP4lO41SQ" name="layerProtocolName" visibility="public" type="_P-Hp8MD4EeSoNOrYOfaryg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_hDARUGXKEeWWhJGy6csBUQ" annotatedElement="_OwauQFeEEeOVGaP4lO41SQ">
+              <body>Indicate the specific layer-protocol described by the LayerProtocol entity.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OwauQVeEEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OwauQleEEeOVGaP4lO41SQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_zbRdEBiZEeSh8KVgZCMyDw" name="_lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_zbrFsBiZEeSh8KVgZCMyDw">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_a8fOUGYzEeWrX_JIGzXlSg" annotatedElement="_zbRdEBiZEeSh8KVgZCMyDw">
+              <body>The LpSpec identifies the interna structure of the LP explaining internal flexibilities, degree of termination and degree of adaptation on both client and server side.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zbRdERiZEeSh8KVgZCMyDw" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zbRdEhiZEeSh8KVgZCMyDw" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_CUJD4BicEeSh8KVgZCMyDw" name="configuredClientCapacity" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pSv2sGaKEeWrX_JIGzXlSg" annotatedElement="_CUJD4BicEeSh8KVgZCMyDw">
+              <body>Provides a summarized view of the client capacity that is configurable for use.&#xD;
+Note the cleint LTP association should provide all necessary detail hence this attribute is questionable.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C4-PQBicEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C5X34BicEeSh8KVgZCMyDw" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_GuuSYEDBEeWQeOKbNUpP9A" name="lpDirection" visibility="public" type="_RWILYEDAEeWQeOKbNUpP9A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_kuahEGdUEeWmgIwAIZlYKQ" annotatedElement="_GuuSYEDBEeWQeOKbNUpP9A">
+              <body>The overall directionality of the LP. &#xD;
+- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.&#xD;
+- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows&#xD;
+- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HFnvcEDBEeWQeOKbNUpP9A" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HF-UwEDBEeWQeOKbNUpP9A" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_p2YfoGeEEeWmgIwAIZlYKQ" name="terminationState">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_3UayEGeEEeWmgIwAIZlYKQ" annotatedElement="_p2YfoGeEEeWmgIwAIZlYKQ">
+              <body>Indicates whether the layer is terminated and if so how.</body>
+            </ownedComment>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_eEpDMFX4EeOVGaP4lO41SQ" name="LogicalTerminationPoint">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_O_KOIHR-EeO4pZvobs-yIg" annotatedElement="_eEpDMFX4EeOVGaP4lO41SQ">
+            <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
+The structure of LTP supports all transport protocols including circuit and packet forms.</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_4XUzoI2tEeO38ZmbECnvbg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_D4N9IFX5EeOVGaP4lO41SQ" name="_serverLtpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" aggregation="composite" association="_D4V48FX5EeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_otFNMGYvEeWrX_JIGzXlSg" annotatedElement="_D4N9IFX5EeOVGaP4lO41SQ">
+              <body>References contained LTPs representing servers of this LTP in an inverse multiplexing configuration (e.g. VCAT).</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_D4OkMFX5EeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_D4OkMVX5EeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_3Y4zAFYWEeOVGaP4lO41SQ" name="_clientLtpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" aggregation="shared" association="_3ZB88FYWEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_9A4dkGYvEeWrX_JIGzXlSg" annotatedElement="_3Y4zAFYWEeOVGaP4lO41SQ">
+              <body>References contained LTPs representing client traffic of this LTP for normal cases of multiplexing.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3Y4zAVYWEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3Y4zAlYWEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_lvFOQFYXEeOVGaP4lO41SQ" name="_lpList" type="_gROecFYXEeOVGaP4lO41SQ" isOrdered="true" aggregation="composite" association="_lvO_QFYXEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_cEQPAGYwEeWrX_JIGzXlSg" annotatedElement="_lvFOQFYXEeOVGaP4lO41SQ">
+              <body>Ordered list of LayerProtocols that this LTP is comprised of where the first entry in the list is the lowest server layer (e.g. physical)</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lvFOQVYXEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lvFOQlYXEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_CHM6YFYYEeOVGaP4lO41SQ" name="_connectedLtpRef" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_CHToEFYYEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_qRR48GYxEeWrX_JIGzXlSg" annotatedElement="_CHM6YFYYEeOVGaP4lO41SQ">
+              <body>Applicable in a simple context where two LTPs are associated via a non-adjustable enabled forwarding.&#xD;
+Reduces clutter removing the need for two additional LTPs and an FC with a pair of FcPorts.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CHM6YVYYEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CHM6YlYYEeOVGaP4lO41SQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_TkuhMFYYEeOVGaP4lO41SQ" name="_peerLtpRef" type="_eEpDMFX4EeOVGaP4lO41SQ" aggregation="composite" association="_Tk5gUFYYEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_-sn7wGYxEeWrX_JIGzXlSg" annotatedElement="_TkuhMFYYEeOVGaP4lO41SQ">
+              <body>References contained LTPs representing the reversal of orientation of flow where two LTPs are associated via a non-adjustable enabled forwarding and where the referenced LTP is fully dependent on the this LTP.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TkuhMVYYEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TkuhMlYYEeOVGaP4lO41SQ" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_5tEV0BiaEeSh8KVgZCMyDw" name="_ltpSpec" type="_BIroQBiaEeSh8KVgZCMyDw" association="_5ta7IBiaEeSh8KVgZCMyDw">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_tAitcGXiEeWrX_JIGzXlSg" annotatedElement="_5tEV0BiaEeSh8KVgZCMyDw">
+              <body>The specification of the LTP defines internal structure of the LTP.&#xD;
+The specification allows interpretation of organisatoon of LPs making up the LTP and also identifies which inter-LTP associations are valid.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5tEV0RiaEeSh8KVgZCMyDw" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5tEV0hiaEeSh8KVgZCMyDw" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_RLDi4BieEeSh8KVgZCMyDw" name="physicalPortReference" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_88FkIGXiEeWrX_JIGzXlSg" annotatedElement="_RLDi4BieEeSh8KVgZCMyDw">
+              <body>One or more text labels for the unmodelled physical port associated with the LTP.&#xD;
+In many cases there is no associated physical port</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_R6bxYBieEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_R61aABieEeSh8KVgZCMyDw" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_vq1NIBigEeSh8KVgZCMyDw" name="_ltpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_vrCogBigEeSh8KVgZCMyDw">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_qvPK0GYyEeWrX_JIGzXlSg" annotatedElement="_vq1NIBigEeSh8KVgZCMyDw">
+              <body>References one or more LTPs in other views that represent this LTP. &#xD;
+The referencing LTP is the rovider of capability.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vq1NIRigEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vq1NIhigEeSh8KVgZCMyDw" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_S811EEDBEeWQeOKbNUpP9A" name="ltpDirection" visibility="public" type="_RWILYEDAEeWQeOKbNUpP9A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_g606sGdUEeWmgIwAIZlYKQ" annotatedElement="_S811EEDBEeWQeOKbNUpP9A">
+              <body>The overall directionality of the LTP. &#xD;
+- A BIDIRECTIONAL LTP must have at least some LPs that are BIDIRECTIONAL but may also have some SINK and/or SOURCE LPs.&#xD;
+- A SINK LTP can only contain SINK LPs&#xD;
+- A SOURCE LTP can only contain SOURCE LPs</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TbSEkEDBEeWQeOKbNUpP9A" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TbijQEDBEeWQeOKbNUpP9A" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_9UVusFYfEeOVGaP4lO41SQ" name="FcRoute">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Rsz_EFlrEeSUSuWjwt7kSQ" annotatedElement="_9UVusFYfEeOVGaP4lO41SQ">
+            <body>The FC Route (FcRoute) object class models the individual routes of an FC. The route is an alternative view of the internal structure of the FC.&#xD;
+The route of an FC object is represented by a list of FCs at a lower level with the implicit understanding that unmodelled link connections are interleaved between the lower level FCs. &#xD;
+Note that depending on the service supported by an FC, an the FC can have multiple routes.&#xD;
+Also applicable where NE level ForwardingDomain may be decomposed into subordinate ForwardingDomains. Applies to both virtual and real NE cases.</body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_Y17QII2yEeO38ZmbECnvbg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_CadNIFaSEeOVGaP4lO41SQ" name="_fcList" type="_oGqmC1LNEeO75dO39GbF8Q" aggregation="composite" association="_Cakh4FaSEeOVGaP4lO41SQ">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_chP0AGXjEeWrX_JIGzXlSg" annotatedElement="_CadNIFaSEeOVGaP4lO41SQ">
+              <body>The list of FCs describing the route of an FC.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CadNIVaSEeOVGaP4lO41SQ" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CadNIlaSEeOVGaP4lO41SQ" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_a97NQFYhEeOVGaP4lO41SQ" name="FcSwitch">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_TOCGsHcNEeO5z_IJj67BhQ" annotatedElement="_a97NQFYhEeOVGaP4lO41SQ">
+            <body></body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_ZiVDII2yEeO38ZmbECnvbg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqn6FLNEeO75dO39GbF8Q" name="holdOffTime" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_oGqn6VLNEeO75dO39GbF8Q" annotatedElement="_oGqn6FLNEeO75dO39GbF8Q">
+              <body>This attribute indicates the time, in seconds, between declaration of unacceptable quality of signal on the currently selected FcPort, and the initialization of the protection switching algorithm. </body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqn5lLNEeO75dO39GbF8Q" name="waitToRestoreTime" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_oGqn51LNEeO75dO39GbF8Q" annotatedElement="_oGqn5lLNEeO75dO39GbF8Q">
+              <body>If the protection system is revertive, this attribute specifies the amount of time, in seconds, to wait after the preferred FcPort returns to an acceptable state of operaion (e.g a fault has cleared) before restoring traffic to that preferred FcPort. </body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqn6lLNEeO75dO39GbF8Q" name="protType" visibility="public" type="_c3Hu8Gb3EeWrX_JIGzXlSg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_oGqn61LNEeO75dO39GbF8Q" annotatedElement="_oGqn6lLNEeO75dO39GbF8Q">
+              <body>Indicates the protection scheme that is used for the ProtectionGroup.</body>
+            </ownedComment>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oGqn41LNEeO75dO39GbF8Q" name="operType" visibility="public" type="_oGqjf1LNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_oGqn5FLNEeO75dO39GbF8Q" annotatedElement="_oGqn41LNEeO75dO39GbF8Q">
+              <body>This attribute whether or not the protection scheme is revertive or non-revertive. </body>
+            </ownedComment>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_oGqn5VLNEeO75dO39GbF8Q" name="REVERTIVE" type="_oGqjf1LNEeO75dO39GbF8Q" instance="_oGqjgVLNEeO75dO39GbF8Q"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_2PdiYI8lEeOw_ste-s6RrA" name="_selectedFcPortRefList" type="_b_lUAFYgEeOVGaP4lO41SQ" association="_2QhSUI8lEeOw_ste-s6RrA">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_nSVYYGYtEeWrX_JIGzXlSg" annotatedElement="_2PdiYI8lEeOw_ste-s6RrA">
+              <body>Indicates which points are selected by the switch.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2PdiYY8lEeOw_ste-s6RrA" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2PdiYo8lEeOw_ste-s6RrA" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_DEWvsJozEeOyHKqw-cQ_eg" name="_profileProxyRefList" type="_rgdnkJoyEeOyHKqw-cQ_eg" association="_DEn1cJozEeOyHKqw-cQ_eg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lR8-8GaDEeWrX_JIGzXlSg" annotatedElement="_DEWvsJozEeOyHKqw-cQ_eg">
+              <body>Provides a set of predefined values for switch control in place of the direct values avaiable via the FcSwitch or via _configurationAndSwitchControl </body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DEWvsZozEeOyHKqw-cQ_eg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DEWvspozEeOyHKqw-cQ_eg" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_1EKuQJo5EeOyHKqw-cQ_eg" name="_configurationAndSwitchControlRef" type="_k1gHQJo5EeOyHKqw-cQ_eg" association="_1EVGUJo5EeOyHKqw-cQ_eg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_FA9ZQGaCEeWrX_JIGzXlSg" annotatedElement="_1EKuQJo5EeOyHKqw-cQ_eg">
+              <body>A multi-switch controller external to the FcSwitch.&#xD;
+The multi-switch controller coordinates multiple switches in the same FC or across multple FCs</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1EKuQZo5EeOyHKqw-cQ_eg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1EKuQpo5EeOyHKqw-cQ_eg" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_tbetAJ4HEeOO3om500DFKg" name="_configurationAndSwitchControl" type="_k1gHQJo5EeOyHKqw-cQ_eg" aggregation="composite" association="_tboeAJ4HEeOO3om500DFKg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_LAwYgGaCEeWrX_JIGzXlSg" annotatedElement="_tbetAJ4HEeOO3om500DFKg">
+              <body>A switch controller encapsulated in the FcSwitch.&#xD;
+</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tbetAZ4HEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tbetAp4HEeOO3om500DFKg" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_H7c0oIgjEeOIkJV2fkx5ZA" name="LinkPort">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_g5HvwGZ-EeWrX_JIGzXlSg" annotatedElement="_H7c0oIgjEeOIkJV2fkx5ZA">
+            <body></body>
+          </ownedComment>
+          <generalization xmi:type="uml:Generalization" xmi:id="_aG2sgI2yEeO38ZmbECnvbg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_XipL8IgjEeOIkJV2fkx5ZA" name="_ltpp">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_LnPvwGaNEeWrX_JIGzXlSg" annotatedElement="_XipL8IgjEeOIkJV2fkx5ZA">
+              <body>OBSOLETE. Was reference to LtpPool. The pool has now been subsumed into the LTP.&#xD;
+This will be deleted in the next release.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XipL8YgjEeOIkJV2fkx5ZA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XipL8ogjEeOIkJV2fkx5ZA" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_br9TQBNjEeS1heseQTA6lw" name="_ltpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_buzL4BNjEeS1heseQTA6lw">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_GZg54GZ9EeWrX_JIGzXlSg" annotatedElement="_br9TQBNjEeS1heseQTA6lw">
+              <body>The LinkPort may be associated with more than one LTP when the LinkPort is bidirectional and the LTPs are unidirectional.&#xD;
+Multiple Ltp&#xD;
+- Bidirectional LinkPort to two Uni Ltps&#xD;
+Zero Ltp&#xD;
+- BreakBeforeMake transition&#xD;
+- Planned Ltp not yet in place&#xD;
+- Off-network LTP referenced through other mechanism</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_br9TQRNjEeS1heseQTA6lw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_br9TQhNjEeS1heseQTA6lw" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_sz8KcBieEeSh8KVgZCMyDw" name="role" visibility="public" type="_DUU_sGZ_EeWrX_JIGzXlSg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_-pF_oGZ-EeWrX_JIGzXlSg" annotatedElement="_sz8KcBieEeSh8KVgZCMyDw">
+              <body>Each LinkPort of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. </body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wVT_cBieEeSh8KVgZCMyDw" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wVzusBieEeSh8KVgZCMyDw" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_m79KEJ2KEeSQBuaNnP_LbA" name="offNetworkAddress" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_DlqK0GaAEeWrX_JIGzXlSg" annotatedElement="_m79KEJ2KEeSQBuaNnP_LbA">
+              <body>A freeform opportunity to express a reference for an Port of the Link that is not outside the scope of the control domain.&#xD;
+This attribute is expected to convey a foreign identifier/name/address or a shared reference for some mid-span point at the boundary between two administrative domains.&#xD;
+This attribute is used when an LTP cannot be referenced.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pW14IJ2KEeSQBuaNnP_LbA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pXG94J2KEeSQBuaNnP_LbA" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_NfrbEEC8EeWxhL2B6Peg6A" name="linkPortDirection" visibility="public" type="_2WpC8EC7EeWxhL2B6Peg6A">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_dax7YGdUEeWmgIwAIZlYKQ" annotatedElement="_NfrbEEC8EeWxhL2B6Peg6A">
+              <body>The orientation of defined flow at the LinkPort.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_SQrE4EC8EeWxhL2B6Peg6A" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_SQ8xsEC8EeWxhL2B6Peg6A" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_KsslQL7XEeSdssyZX-p90g" name="TopologyPacs">
+          <packagedElement xmi:type="uml:Class" xmi:id="_GCL5wJywEeSaHrTY93cYuA" name="TransferCost_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_nEnuEGaREeWrX_JIGzXlSg" annotatedElement="_GCL5wJywEeSaHrTY93cYuA _ny1ZoJ2IEeSQBuaNnP_LbA">
+              <body>The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. &#xD;
+They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity&#xD;
+There may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. &#xD;
+Using an entity will incur a cost. </body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_y7uSYKNWEeS9Obpdy8FCjA" name="costCharacteristicList" visibility="public" type="_6LJtgKNWEeS9Obpdy8FCjA">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_s_Ao4GaREeWrX_JIGzXlSg" annotatedElement="_y7uSYKNWEeS9Obpdy8FCjA">
+                <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3G8VoKNWEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3HOpgKNWEeS9Obpdy8FCjA" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_W79L4JyzEeSaHrTY93cYuA" name="RiskParameter_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_1aqmkGaREeWrX_JIGzXlSg" annotatedElement="_W79L4JyzEeSaHrTY93cYuA _eH6McJ2IEeSQBuaNnP_LbA">
+              <body>The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. &#xD;
+The risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.&#xD;
+A TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.&#xD;
+The realization can be partitioned into segments which have some relevant common failure modes.&#xD;
+There is a risk of failure/degradation of each segment of the underlying realization.&#xD;
+Each segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).&#xD;
+Disruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.&#xD;
+Any TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.&#xD;
+The identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.&#xD;
+A segment has one or more risk characteristic.&#xD;
+Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.&#xD;
+Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_xudDYKQZEeS9Obpdy8FCjA" name="riskCharacteristicList" visibility="public" type="_dCtNEKQZEeS9Obpdy8FCjA">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_-3SSAGaREeWrX_JIGzXlSg" annotatedElement="_xudDYKQZEeS9Obpdy8FCjA">
+                <body>A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yM0aYKQZEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yNFgIKQZEeS9Obpdy8FCjA" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_d6GCsJyzEeSaHrTY93cYuA" name="LayerProtocolTransition_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_rY2cAGaUEeWrX_JIGzXlSg" annotatedElement="_d6GCsJyzEeSaHrTY93cYuA _f9upIJ2JEeSQBuaNnP_LbA">
+              <body>Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. &#xD;
+This abstraction is relevant when considering multi-layer routing. &#xD;
+The layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.&#xD;
+This Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.&#xD;
+Links that included details in this Pac are often referred to as Transitional Links.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_egyYAK4GEeSXJ6XI-2nsRw" name="transitionedLayerProtocolList" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_4Bjo8GaUEeWrX_JIGzXlSg" annotatedElement="_egyYAK4GEeSXJ6XI-2nsRw">
+                <body>Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fFtC8K4GEeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fGAk8K4GEeSXJ6XI-2nsRw" value="*"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_yN3iELA0EeSXJ6XI-2nsRw" name="_ltpRefList" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_yODvULA0EeSXJ6XI-2nsRw">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_A9__gGaVEeWrX_JIGzXlSg" annotatedElement="_yN3iELA0EeSXJ6XI-2nsRw">
+                <body>Lists the LTPs that define the layer protocol transition of the transitional link.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yN3iEbA0EeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yN3iErA0EeSXJ6XI-2nsRw" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_sVcR8JyzEeSaHrTY93cYuA" name="TransferTiming_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_JUwPEGaVEeWrX_JIGzXlSg" annotatedElement="_sVcR8JyzEeSaHrTY93cYuA _woOF8J2IEeSQBuaNnP_LbA">
+              <body>A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_HkibYKNVEeS9Obpdy8FCjA" name="fixedLatencyCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_R3K8EGaVEeWrX_JIGzXlSg" annotatedElement="_HkibYKNVEeS9Obpdy8FCjA">
+                <body>A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IHGV4KNVEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IHXboKNVEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_QcR4IKNVEeS9Obpdy8FCjA" name="jitterCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_WOHHIGaVEeWrX_JIGzXlSg" annotatedElement="_QcR4IKNVEeS9Obpdy8FCjA">
+                <body>High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.&#xD;
+Applies to TDM systems (and not packet).</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TZf3MKNVEeS9Obpdy8FCjA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TZyLEKNVEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ZID8gKNVEeS9Obpdy8FCjA" name="wanderCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_a6hy8GaVEeWrX_JIGzXlSg" annotatedElement="_ZID8gKNVEeS9Obpdy8FCjA">
+                <body>Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.&#xD;
+Applies to TDM systems (and not packet).</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_a2plQKNVEeS9Obpdy8FCjA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_a27SEKNVEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_4ySjcK3mEeSXJ6XI-2nsRw" name="queuingLatencyList" visibility="public" type="_OK-YkLFmEeSZUdYfPSdgew">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_fYcvwGaVEeWrX_JIGzXlSg" annotatedElement="_4ySjcK3mEeSXJ6XI-2nsRw">
+                <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8iqdwK3mEeSXJ6XI-2nsRw"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8jAcAK3mEeSXJ6XI-2nsRw" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_wuhLAJyzEeSaHrTY93cYuA" name="TransferIntegrity_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pA0YMGaVEeWrX_JIGzXlSg" annotatedElement="_wuhLAJyzEeSaHrTY93cYuA _QLzBcJ2JEeSQBuaNnP_LbA">
+              <body>Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.&#xD;
+It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.&#xD;
+Note that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_VIujsKNWEeS9Obpdy8FCjA" name="errorCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_tYuMkGaVEeWrX_JIGzXlSg" annotatedElement="_VIujsKNWEeS9Obpdy8FCjA">
+                <body>Describes the degree to which the signal propagated can be errored. &#xD;
+Applies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_X3MVEKNWEeS9Obpdy8FCjA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_X3da0KNWEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ZuWrAKNWEeS9Obpdy8FCjA" name="lossCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_yJUNwGaVEeWrX_JIGzXlSg" annotatedElement="_ZuWrAKNWEeS9Obpdy8FCjA">
+                <body>Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.&#xD;
+Applies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bH_XcKNWEeS9Obpdy8FCjA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bIQdMKNWEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_bVjSUKNWEeS9Obpdy8FCjA" name="repeatDeliveryCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_2ao5AGaVEeWrX_JIGzXlSg" annotatedElement="_bVjSUKNWEeS9Obpdy8FCjA">
+                <body>Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). &#xD;
+It can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cdzT0KNWEeS9Obpdy8FCjA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ceFnsKNWEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_hGi0wL7aEeSdssyZX-p90g" name="deliveryOrderCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_6gKj8GaVEeWrX_JIGzXlSg" annotatedElement="_hGi0wL7aEeSdssyZX-p90g">
+                <body>Describes the degree to which packets will be delivered out of sequence.&#xD;
+Does not apply to TDM as the TDM protocols maintain strict order.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hiuacL7aEeSdssyZX-p90g"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hjG08L7aEeSdssyZX-p90g" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_9tZgcL7aEeSdssyZX-p90g" name="unavailableTimeCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_-rD3EGaVEeWrX_JIGzXlSg" annotatedElement="_9tZgcL7aEeSdssyZX-p90g">
+                <body>Describes the duration for which there may be no valid signal propagated.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-FG10L7aEeSdssyZX-p90g" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-Fa-4L7aEeSdssyZX-p90g" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_piS5EL7aEeSdssyZX-p90g" name="serverIntegrityProcessCharacteristic" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_DOMrEGaWEeWrX_JIGzXlSg" annotatedElement="_piS5EL7aEeSdssyZX-p90g">
+                <body>Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qpM2wL7aEeSdssyZX-p90g"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qpgYwL7aEeSdssyZX-p90g" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_1EYYAJyzEeSaHrTY93cYuA" name="TransferCapacity_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_H4hFIGaWEeWrX_JIGzXlSg" annotatedElement="_1EYYAJyzEeSaHrTY93cYuA _CEGuAJ2JEeSQBuaNnP_LbA">
+              <body>The TopologicalEntity derives capacity from the underlying realization. &#xD;
+A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.&#xD;
+A TopologicalEntity may be directly used in the view or may be assigned to another view for use.&#xD;
+The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.&#xD;
+Represents the capacity available to user (client) along with client interaction and usage. &#xD;
+A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_FFQqkKQbEeS9Obpdy8FCjA" name="totalPotentialCapacity" visibility="public" type="_CxSZ0K4AEeSXJ6XI-2nsRw">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_LuQAkGaWEeWrX_JIGzXlSg" annotatedElement="_FFQqkKQbEeS9Obpdy8FCjA">
+                <body>An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FvhvkKQbEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Fvy1UKQbEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_INhcAKQbEeS9Obpdy8FCjA" name="availableCapacity" visibility="public" type="_CxSZ0K4AEeSXJ6XI-2nsRw">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_R89lkGaWEeWrX_JIGzXlSg" annotatedElement="_INhcAKQbEeS9Obpdy8FCjA">
+                <body>Capacity available to be assigned.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KCVokKQbEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KCmuUKQbEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_Nhv4QK3rEeSXJ6XI-2nsRw" name="capacityAssignedToUserView" visibility="public" type="_CxSZ0K4AEeSXJ6XI-2nsRw">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_VMxJcGaWEeWrX_JIGzXlSg" annotatedElement="_Nhv4QK3rEeSXJ6XI-2nsRw">
+                <body>Capacity already assigned</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OAC90K3rEeSXJ6XI-2nsRw"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OAcmcK3rEeSXJ6XI-2nsRw" value="*"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_kZMnkKQbEeS9Obpdy8FCjA" name="capacityInteractionAlgorithm" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_fiLeEGaWEeWrX_JIGzXlSg" annotatedElement="_kZMnkKQbEeS9Obpdy8FCjA">
+                <body>A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_k-MyEKQbEeS9Obpdy8FCjA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_k-d30KQbEeS9Obpdy8FCjA" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_MROewJ2IEeSQBuaNnP_LbA" name="TopologicalEntity" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_lzGCgGaWEeWrX_JIGzXlSg" annotatedElement="_MROewJ2IEeSQBuaNnP_LbA">
+              <body>A TopologicalEntity is an abstract representation of the emergent effect of the combined functioning of an arrangement of components (running hardware, software running on hardware etc). &#xD;
+The effect can be considered as the realization of the potential for apparent communication adjacency for entities that are bound to the terminations at the boundary of the TopologicalEntity.&#xD;
+The TopologicalEntity enables the creation of constrained forwarding to achieve the apparent adjacency.&#xD;
+The apparent adjacency has intended performance degraded from perfect adjacency and a statement of that degradation is conveyed via the attributes of the packages associated with this class.&#xD;
+In the model both ForwardingDomain and Link are TopologicalEntities. &#xD;
+This abstract class is used as a modeling approach to apply packages of attributes to both Link and ForwardingDomain. Link and ForwardingDomain are the key TopologicalEntities.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_eH6McJ2IEeSQBuaNnP_LbA" name="_riskParameter_Pac" type="_W79L4JyzEeSaHrTY93cYuA" aggregation="composite" association="_eIDWYJ2IEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eH6McZ2IEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eH6Mcp2IEeSQBuaNnP_LbA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ny1ZoJ2IEeSQBuaNnP_LbA" name="_transferCost_Pac" type="_GCL5wJywEeSaHrTY93cYuA" aggregation="composite" association="_ny-jkJ2IEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ny1ZoZ2IEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ny1Zop2IEeSQBuaNnP_LbA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_woOF8J2IEeSQBuaNnP_LbA" name="_transferTiming_Pac" type="_sVcR8JyzEeSaHrTY93cYuA" aggregation="composite" association="_woXP4J2IEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_woOF8Z2IEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_woOF8p2IEeSQBuaNnP_LbA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_CEGuAJ2JEeSQBuaNnP_LbA" name="_transferCapacity_Pac" type="_1EYYAJyzEeSaHrTY93cYuA" aggregation="composite" association="_CEPQ4J2JEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CEGuAZ2JEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CEGuAp2JEeSQBuaNnP_LbA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_QLzBcJ2JEeSQBuaNnP_LbA" name="_transferIntegrity_Pac" type="_wuhLAJyzEeSaHrTY93cYuA" aggregation="composite" association="_QL8LYJ2JEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QLzBcZ2JEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QLzBcp2JEeSQBuaNnP_LbA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_h8bfkJ2LEeSQBuaNnP_LbA" name="_validation_Pac" type="_dDyVoJ2LEeSQBuaNnP_LbA" aggregation="composite" association="_h8kpgJ2LEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_h8bfkZ2LEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_h8bfkp2LEeSQBuaNnP_LbA" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_f9upIJ2JEeSQBuaNnP_LbA" name="_layerTransition_Pac" type="_d6GCsJyzEeSaHrTY93cYuA" aggregation="composite" association="_f93zEJ2JEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_f9upIZ2JEeSQBuaNnP_LbA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_f9upIp2JEeSQBuaNnP_LbA" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_dDyVoJ2LEeSQBuaNnP_LbA" name="Validation_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_dvBo8GaXEeWrX_JIGzXlSg" annotatedElement="_dDyVoJ2LEeSQBuaNnP_LbA _h8bfkJ2LEeSQBuaNnP_LbA">
+              <body>Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="__L6xcK4GEeSXJ6XI-2nsRw" name="validationMechanismList" visibility="public" type="_HSrdMK4HEeSXJ6XI-2nsRw">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_ymIasGaXEeWrX_JIGzXlSg" annotatedElement="__L6xcK4GEeSXJ6XI-2nsRw">
+                <body>Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__h5BcK4GEeSXJ6XI-2nsRw" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__iPmwK4GEeSXJ6XI-2nsRw" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_oGqwB1LNEeO75dO39GbF8Q" name="Diagrams">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_OdhAUJozEeOyHKqw-cQ_eg">
+          <body>Suggest adding profile to the base class for all to inherit and then inheriting from all classes so this picks up all attributes.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Gck6kCOtEeSoB4Ln_aUF6w" annotatedElement="_8SDrEHk5EeO5z_IJj67BhQ">
+          <body>Fc may be part of a route or a member of a ForwardingDomain. Note that there may be efficiencies where a single representation covers both</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ceQCACOtEeSoB4Ln_aUF6w" annotatedElement="_jEQe8COoEeSoB4Ln_aUF6w">
+          <body>There may be ForwardingDomains below the one contained in the NE .</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ZSaakEDCEeWQeOKbNUpP9A">
+          <body>All additions covering directionality shown in red</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iyGBEEDCEeWQeOKbNUpP9A">
+          <body>Need to cover contradirectionality.&#xD;
+Suggest coDirectional Boolean set to false with a default of true allowing absensce.&#xD;
+Suggest adding CONTRA_DIRECTION_SINK and CONTRA_DIRECTION_SOURCE to TerminationDirection for use only in LP internal stuff or having an ExtendedTerminationDirection that includes CONTRA_.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_WhF3kEDEEeWQeOKbNUpP9A">
+          <body>Note that an alternative to linkDirectio being 0..1 would be to have a ForwardingDirection of COMPLEX.</body>
+        </ownedComment>
+        <packagedElement xmi:type="uml:Package" xmi:id="_PpZIwL7XEeSdssyZX-p90g" name="TopologyPacs">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_muJzIJzQEeSaHrTY93cYuA">
+            <body>and ForwardingDomains. Note that there are pure ForwardingDomain and link cases and hybrids that start on FD and end on Link to varios degrees. Note that the simple composition is not sufficient in itself and there need to be rules that explain that the Link and FDs encompassed are related.</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lMthgKNSEeS9Obpdy8FCjA">
+            <body>Need to add directionality to classes</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_YcO9QKVCEeS9Obpdy8FCjA">
+            <body>LtpRelatesToLtpInOtherView provides full virtualization capability. This relationship would be omitted when a view LTP is opaque (i.e only the relationship from the originator to the view would be supported and not the other way round</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qBHToKePEeS9Obpdy8FCjA">
+            <body>Suggest add &quot;purpose&quot; to topological entity where purpose can be connectivity, property rules, hybrid. FC can have explicit route though FD subordinates may be not specific (If there are &quot;two ways through&quot; then it may need to be specific. Same for Link.</body>
+          </ownedComment>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_tyBQYBirEeSh8KVgZCMyDw" name="Associations">
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqm3FLNEeO75dO39GbF8Q" name="FdContainsFcs" memberEnd="_oGql_1LNEeO75dO39GbF8Q _oGqm31LNEeO75dO39GbF8Q">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oGqm3VLNEeO75dO39GbF8Q" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oGqm3lLNEeO75dO39GbF8Q" key="names"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqm31LNEeO75dO39GbF8Q" name="forwardingDomain" visibility="private" type="_oGql-FLNEeO75dO39GbF8Q" association="_oGqm3FLNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqm4VLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqm4FLNEeO75dO39GbF8Q" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqnhVLNEeO75dO39GbF8Q" name="NcdControlsFds" memberEnd="_oGqneVLNEeO75dO39GbF8Q _oGqnilLNEeO75dO39GbF8Q">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oGqnhlLNEeO75dO39GbF8Q" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oGqnh1LNEeO75dO39GbF8Q" key="Kam: naming?"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqnilLNEeO75dO39GbF8Q" name="" visibility="private" type="_oGqneFLNEeO75dO39GbF8Q" association="_oGqnhVLNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnjFLNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqni1LNEeO75dO39GbF8Q" value="2"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqnu1LNEeO75dO39GbF8Q" name="LinkHasAssociatedFds" memberEnd="_oGqnk1LNEeO75dO39GbF8Q _oGqnvlLNEeO75dO39GbF8Q">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqnvlLNEeO75dO39GbF8Q" name="_link" visibility="private" type="_oGqnjVLNEeO75dO39GbF8Q" association="_oGqnu1LNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnwFLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnv1LNEeO75dO39GbF8Q" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqnwVLNEeO75dO39GbF8Q" name="LinkHasLinkPorts" memberEnd="_oGqnllLNEeO75dO39GbF8Q _oGqnxFLNEeO75dO39GbF8Q">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqnxFLNEeO75dO39GbF8Q" name="_link" visibility="private" type="_oGqnjVLNEeO75dO39GbF8Q" association="_oGqnwVLNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnxlLNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqnxVLNEeO75dO39GbF8Q" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqnx1LNEeO75dO39GbF8Q" name="NcdControlsNes" memberEnd="_oGqnfFLNEeO75dO39GbF8Q _oGqnylLNEeO75dO39GbF8Q">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oGqnyFLNEeO75dO39GbF8Q" source="http://www.eclipse.org/uml2/2.0.0/UML">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oGqnyVLNEeO75dO39GbF8Q" key="Kam: naming?"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqnylLNEeO75dO39GbF8Q" name="" visibility="private" type="_oGqneFLNEeO75dO39GbF8Q" association="_oGqnx1LNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqnzFLNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqny1LNEeO75dO39GbF8Q" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqnzVLNEeO75dO39GbF8Q" name="NcdAccessesLinks" memberEnd="_oGqnf1LNEeO75dO39GbF8Q _oGqn0FLNEeO75dO39GbF8Q">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqn0FLNEeO75dO39GbF8Q" name="_ncd" visibility="private" type="_oGqneFLNEeO75dO39GbF8Q" association="_oGqnzVLNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqn0lLNEeO75dO39GbF8Q" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqn0VLNEeO75dO39GbF8Q" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqn01LNEeO75dO39GbF8Q" name="NeEncompassesFds" memberEnd="_oGqnslLNEeO75dO39GbF8Q _oGqn2FLNEeO75dO39GbF8Q">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqn2FLNEeO75dO39GbF8Q" name="_nE" visibility="private" type="_oGqnr1LNEeO75dO39GbF8Q" association="_oGqn01LNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqn2lLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqn2VLNEeO75dO39GbF8Q" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqoD1LNEeO75dO39GbF8Q" name="HigherLevelFdEncompassesLowerLevelFds" memberEnd="_oGqmBVLNEeO75dO39GbF8Q _oGqoEFLNEeO75dO39GbF8Q">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqoEFLNEeO75dO39GbF8Q" name="_upperLevelFd" visibility="private" type="_oGql-FLNEeO75dO39GbF8Q" association="_oGqoD1LNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqoElLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqoEVLNEeO75dO39GbF8Q" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_i7cIUFYfEeOVGaP4lO41SQ" name="FcHasLowerLevelFcs" memberEnd="_i7cIUVYfEeOVGaP4lO41SQ _i7UzkFYfEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_i7cIUVYfEeOVGaP4lO41SQ" name="_containingFc" type="_oGqmC1LNEeO75dO39GbF8Q" association="_i7cIUFYfEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_i7cIUlYfEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_i7cIU1YfEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_A8YzcFYgEeOVGaP4lO41SQ" name="FcHasRoutes" memberEnd="_A8YzcVYgEeOVGaP4lO41SQ _A8SFwFYgEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_A8YzcVYgEeOVGaP4lO41SQ" name="_fc" type="_oGqmC1LNEeO75dO39GbF8Q" association="_A8YzcFYgEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_A8YzclYgEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_A8Yzc1YgEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_gqbSgFYgEeOVGaP4lO41SQ" name="FcHasFcPorts" memberEnd="_gqbSgVYgEeOVGaP4lO41SQ _gqUk0FYgEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_gqbSgVYgEeOVGaP4lO41SQ" name="_fc" type="_oGqmC1LNEeO75dO39GbF8Q" association="_gqbSgFYgEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gqbSglYgEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gqbSg1YgEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_d_lncFYhEeOVGaP4lO41SQ" name="FcEncapsulatesSwitches" memberEnd="_d_lncVYhEeOVGaP4lO41SQ _d_droFYhEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_d_lncVYhEeOVGaP4lO41SQ" name="_fc" type="_oGqmC1LNEeO75dO39GbF8Q" association="_d_lncFYhEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d_lnclYhEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d_lnc1YhEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_2EZj8FYkEeOVGaP4lO41SQ" name="FdAggregatesLtps" memberEnd="_2EZj8VYkEeOVGaP4lO41SQ _2ES2QFYkEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_2EZj8VYkEeOVGaP4lO41SQ" name="_forwardingDomain" type="_oGql-FLNEeO75dO39GbF8Q" association="_2EZj8FYkEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2EZj8lYkEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2EZj81YkEeOVGaP4lO41SQ" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_DyIp0FYmEeOVGaP4lO41SQ" name="NeIncludesLtps" memberEnd="_DyIp0VYmEeOVGaP4lO41SQ _DyAG8FYmEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_DyIp0VYmEeOVGaP4lO41SQ" name="_neList" type="_oGqnr1LNEeO75dO39GbF8Q" association="_DyIp0FYmEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DyIp0lYmEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DyIp01YmEeOVGaP4lO41SQ" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_CHToEFYYEeOVGaP4lO41SQ" name="LtpConnectsToPeerLtp" memberEnd="_CHToEVYYEeOVGaP4lO41SQ _CHM6YFYYEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_CHToEVYYEeOVGaP4lO41SQ" name="_connectingLtp" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_CHToEFYYEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CHToElYYEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CHToE1YYEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_3ZB88FYWEeOVGaP4lO41SQ" name="LtpHasClientLtps" memberEnd="_3ZB88VYWEeOVGaP4lO41SQ _3Y4zAFYWEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_3ZB88VYWEeOVGaP4lO41SQ" name="_containingServerLtp" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_3ZB88FYWEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3ZB88lYWEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3ZB881YWEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Tk5gUFYYEeOVGaP4lO41SQ" name="LtpHasPeerLtp" memberEnd="_Tk5gUVYYEeOVGaP4lO41SQ _TkuhMFYYEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_Tk5gUVYYEeOVGaP4lO41SQ" name="_containingPeerLtp" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_Tk5gUFYYEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Tk5gUlYYEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Tk5gU1YYEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_D4V48FX5EeOVGaP4lO41SQ" name="LtpHasServerLtps" memberEnd="_D4V48VX5EeOVGaP4lO41SQ _D4N9IFX5EeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_D4V48VX5EeOVGaP4lO41SQ" name="_containingClientLtp" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_D4V48FX5EeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_D4V48lX5EeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_D4V481X5EeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_lvO_QFYXEeOVGaP4lO41SQ" name="LtpIncludesLayerProtocols" memberEnd="_lvO_QVYXEeOVGaP4lO41SQ _lvFOQFYXEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_lvO_QVYXEeOVGaP4lO41SQ" name="_logicalTerminationPoint" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_lvO_QFYXEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lvO_QlYXEeOVGaP4lO41SQ" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lvO_Q1YXEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Cakh4FaSEeOVGaP4lO41SQ" name="RouteIsDescribedByFcs" memberEnd="_Cakh4VaSEeOVGaP4lO41SQ _CadNIFaSEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_Cakh4VaSEeOVGaP4lO41SQ" name="_fcRoute" type="_9UVusFYfEeOVGaP4lO41SQ" association="_Cakh4FaSEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Cakh4laSEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Cakh41aSEeOVGaP4lO41SQ" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Ixb_8FYnEeOVGaP4lO41SQ" name="FcPortConnectedToLtp" memberEnd="_Ixb_8VYnEeOVGaP4lO41SQ _IxS2AFYnEeOVGaP4lO41SQ">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_Ixb_8VYnEeOVGaP4lO41SQ" name="_fcPort" type="_b_lUAFYgEeOVGaP4lO41SQ" association="_Ixb_8FYnEeOVGaP4lO41SQ">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ixb_8lYnEeOVGaP4lO41SQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ixb_81YnEeOVGaP4lO41SQ" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_2QhSUI8lEeOw_ste-s6RrA" name="FcSwitchSelectsFcPorts" memberEnd="_2QhSUY8lEeOw_ste-s6RrA _2PdiYI8lEeOw_ste-s6RrA">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_2QhSUY8lEeOw_ste-s6RrA" name="fcSwitch" type="_a97NQFYhEeOVGaP4lO41SQ" association="_2QhSUI8lEeOw_ste-s6RrA">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2QhSUo8lEeOw_ste-s6RrA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2QhSU48lEeOw_ste-s6RrA" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_DEn1cJozEeOyHKqw-cQ_eg" name="FcSwitchInfluencedByProfileProxy" memberEnd="_DEn1cZozEeOyHKqw-cQ_eg _DEWvsJozEeOyHKqw-cQ_eg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_DEn1cZozEeOyHKqw-cQ_eg" name="fcSwitch?" type="_a97NQFYhEeOVGaP4lO41SQ" association="_DEn1cJozEeOyHKqw-cQ_eg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DEn1cpozEeOyHKqw-cQ_eg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DEn1c5ozEeOyHKqw-cQ_eg" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_1EVGUJo5EeOyHKqw-cQ_eg" name="FcSwitchCoordinatedByControl" memberEnd="_1EVGUZo5EeOyHKqw-cQ_eg _1EKuQJo5EeOyHKqw-cQ_eg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_1EVGUZo5EeOyHKqw-cQ_eg" name="fcSwitch?" type="_a97NQFYhEeOVGaP4lO41SQ" association="_1EVGUJo5EeOyHKqw-cQ_eg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1EVGUpo5EeOyHKqw-cQ_eg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1EVGU5o5EeOyHKqw-cQ_eg" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_tboeAJ4HEeOO3om500DFKg" name="FcSwitchCoordinatedByInternalControl" memberEnd="_tboeAZ4HEeOO3om500DFKg _tbetAJ4HEeOO3om500DFKg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_tboeAZ4HEeOO3om500DFKg" name="fcSwitch" type="_a97NQFYhEeOVGaP4lO41SQ" association="_tboeAJ4HEeOO3om500DFKg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tboeAp4HEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tboeA54HEeOO3om500DFKg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_v6VYQJ4LEeOO3om500DFKg" name="FcSwitchesInFdCoordinatedBySwitchCoordinator" memberEnd="_v6VYQZ4LEeOO3om500DFKg _v6GHsJ4LEeOO3om500DFKg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_v6VYQZ4LEeOO3om500DFKg" name="forwardingConstruct" type="_oGqmC1LNEeO75dO39GbF8Q" association="_v6VYQJ4LEeOO3om500DFKg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_v6VYQp4LEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_v6VYQ54LEeOO3om500DFKg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_buzL4BNjEeS1heseQTA6lw" name="LinkPortTerminatesOnLtps" memberEnd="_buzL4RNjEeS1heseQTA6lw _br9TQBNjEeS1heseQTA6lw">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_buzL4RNjEeS1heseQTA6lw" name="linkPort" type="_H7c0oIgjEeOIkJV2fkx5ZA" association="_buzL4BNjEeS1heseQTA6lw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_buzL4hNjEeS1heseQTA6lw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_buzL4xNjEeS1heseQTA6lw" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_dnWM0BiQEeSh8KVgZCMyDw" name="FdEncompassesLinks" memberEnd="_dnWM0RiQEeSh8KVgZCMyDw _dm_ngBiQEeSh8KVgZCMyDw">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_dnWM0RiQEeSh8KVgZCMyDw" name="forwardingDomain" type="_oGql-FLNEeO75dO39GbF8Q" association="_dnWM0BiQEeSh8KVgZCMyDw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dnWM0hiQEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dnWM0xiQEeSh8KVgZCMyDw" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_zbrFsBiZEeSh8KVgZCMyDw" name="LayerProtocolHasLpSpec" memberEnd="_zbrFsRiZEeSh8KVgZCMyDw _zbRdEBiZEeSh8KVgZCMyDw">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_zbrFsRiZEeSh8KVgZCMyDw" name="layerProtocol" type="_gROecFYXEeOVGaP4lO41SQ" association="_zbrFsBiZEeSh8KVgZCMyDw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zbrFshiZEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zbrFsxiZEeSh8KVgZCMyDw" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_5ta7IBiaEeSh8KVgZCMyDw" name="LogicalTerminationPointHasLtpSpec" memberEnd="_5ta7IRiaEeSh8KVgZCMyDw _5tEV0BiaEeSh8KVgZCMyDw">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_5ta7IRiaEeSh8KVgZCMyDw" name="logicalTerminationPoint" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_5ta7IBiaEeSh8KVgZCMyDw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5ta7IhiaEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5ta7IxiaEeSh8KVgZCMyDw" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Dependency" xmi:id="_zPk24JzREeSaHrTY93cYuA" name="LinkPortIsToLp" client="_H7c0oIgjEeOIkJV2fkx5ZA" supplier="_gROecFYXEeOVGaP4lO41SQ"/>
+        <packagedElement xmi:type="uml:Association" xmi:id="_oGqoCFLNEeO75dO39GbF8Q" name="SdnControlerHasNcds" memberEnd="_oGqoDFLNEeO75dO39GbF8Q _oGqoCVLNEeO75dO39GbF8Q">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqoCVLNEeO75dO39GbF8Q" name="" visibility="private" type="_oGqoB1LNEeO75dO39GbF8Q" association="_oGqoCFLNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqoC1LNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqoClLNEeO75dO39GbF8Q" value="*"/>
+          </ownedEnd>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_oGqoDFLNEeO75dO39GbF8Q" name="" visibility="private" type="_oGqneFLNEeO75dO39GbF8Q" association="_oGqoCFLNEeO75dO39GbF8Q">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_oGqoDlLNEeO75dO39GbF8Q"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_oGqoDVLNEeO75dO39GbF8Q" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_vrCogBigEeSh8KVgZCMyDw" name="LtpRelatestToLtpInOtherView" memberEnd="_vrCogRigEeSh8KVgZCMyDw _vq1NIBigEeSh8KVgZCMyDw">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_vrCogRigEeSh8KVgZCMyDw" name="logicalTerminationPoint" type="_eEpDMFX4EeOVGaP4lO41SQ" association="_vrCogBigEeSh8KVgZCMyDw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vrCoghigEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vrCogxigEeSh8KVgZCMyDw" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_SEAxEL7XEeSdssyZX-p90g" name="TopologyPacs">
+          <packagedElement xmi:type="uml:Association" xmi:id="_eIDWYJ2IEeSQBuaNnP_LbA" name="TopologicalEntityHasRiskCharacterisics" memberEnd="_eIDWYZ2IEeSQBuaNnP_LbA _eH6McJ2IEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_eIDWYZ2IEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_eIDWYJ2IEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eIDWYp2IEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eIDWY52IEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_ny-jkJ2IEeSQBuaNnP_LbA" name="TopologicalEntityHasCostCharacteristics" memberEnd="_ny-jkZ2IEeSQBuaNnP_LbA _ny1ZoJ2IEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_ny-jkZ2IEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_ny-jkJ2IEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ny-jkp2IEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ny-jk52IEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_woXP4J2IEeSQBuaNnP_LbA" name="TopologicalEntityHasTimingCharacteristics" memberEnd="_woXP4Z2IEeSQBuaNnP_LbA _woOF8J2IEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_woXP4Z2IEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_woXP4J2IEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_woXP4p2IEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_woXP452IEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_CEPQ4J2JEeSQBuaNnP_LbA" name="TopologicalEntityHasCapacityCharacteristics" memberEnd="_CEPQ4Z2JEeSQBuaNnP_LbA _CEGuAJ2JEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_CEPQ4Z2JEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_CEPQ4J2JEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CEPQ4p2JEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CEPQ452JEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_QL8LYJ2JEeSQBuaNnP_LbA" name="TopologicalEntityHasIntegrityCharacteristics" memberEnd="_QL8LYZ2JEeSQBuaNnP_LbA _QLzBcJ2JEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_QL8LYZ2JEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_QL8LYJ2JEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QL8LYp2JEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QL8LY52JEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_f93zEJ2JEeSQBuaNnP_LbA" name="TopologicalEntityHasLayerTransition" memberEnd="_f93zEZ2JEeSQBuaNnP_LbA _f9upIJ2JEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_f93zEZ2JEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_f93zEJ2JEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_f93zEp2JEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_f93zE52JEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_h8kpgJ2LEeSQBuaNnP_LbA" name="TopologicalEntityHasValidation" memberEnd="_h8kpgZ2LEeSQBuaNnP_LbA _h8bfkJ2LEeSQBuaNnP_LbA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_h8kpgZ2LEeSQBuaNnP_LbA" name="topologicalEntity" type="_MROewJ2IEeSQBuaNnP_LbA" association="_h8kpgJ2LEeSQBuaNnP_LbA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_h8kpgp2LEeSQBuaNnP_LbA" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_h8kpg52LEeSQBuaNnP_LbA" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_yODvULA0EeSXJ6XI-2nsRw" name="LayerTransitionAbstractsLtps" memberEnd="_yODvUbA0EeSXJ6XI-2nsRw _yN3iELA0EeSXJ6XI-2nsRw">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_yODvUbA0EeSXJ6XI-2nsRw" name="layerTransition_Pac" type="_d6GCsJyzEeSaHrTY93cYuA" association="_yODvULA0EeSXJ6XI-2nsRw">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yODvUrA0EeSXJ6XI-2nsRw"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yODvU7A0EeSXJ6XI-2nsRw" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_vG5YsKK3EeOfSYroU9Javw" name="Rules">
+        <packagedElement xmi:type="uml:Constraint" xmi:id="_8SDrEHk5EeO5z_IJj67BhQ" name="AlternativeFcCompositionParent" constrainedElement="_oGqm3FLNEeO75dO39GbF8Q _Cakh4FaSEeOVGaP4lO41SQ">
+          <specification xmi:type="uml:LiteralString" xmi:id="_8SV-8Hk5EeO5z_IJj67BhQ" name="" value="xor"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Constraint" xmi:id="_eiKr8HoDEeO2-YDhAjVilg" name="AlternativeTpePeerAssociations" constrainedElement="_Tk5gUFYYEeOVGaP4lO41SQ _CHToEFYYEeOVGaP4lO41SQ">
+          <specification xmi:type="uml:LiteralString" xmi:id="_eilisHoDEeO2-YDhAjVilg" value="xor"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Constraint" xmi:id="_jEQe8COoEeSoB4Ln_aUF6w" name="NeContainsFd" constrainedElement="_oGqn01LNEeO75dO39GbF8Q">
+          <specification xmi:type="uml:LiteralString" xmi:id="_jUZzwCOoEeSoB4Ln_aUF6w" value="ForwardingDomain is only bounded by LTPs that bound a single NE"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Constraint" xmi:id="_5wJOwCOtEeSoB4Ln_aUF6w" name="AlternativeFdGrouping" constrainedElement="_oGqnhVLNEeO75dO39GbF8Q _oGqoD1LNEeO75dO39GbF8Q _svdPkCPBEeSoB4Ln_aUF6w">
+          <specification xmi:type="uml:LiteralString" xmi:id="_5wiQUCOtEeSoB4Ln_aUF6w" value="xor"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Constraint" xmi:id="_svdPkCPBEeSoB4Ln_aUF6w" name="FdInNcd" constrainedElement="_oGqnhVLNEeO75dO39GbF8Q">
+          <specification xmi:type="uml:LiteralString" xmi:id="_s8m6wCPBEeSoB4Ln_aUF6w" name="" value="Only highest level ForwardingDomain"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Constraint" xmi:id="_gsh30K37EeSXJ6XI-2nsRw" name="MultiplicityOfTarget" constrainedElement="_oGqnwVLNEeO75dO39GbF8Q">
+          <specification xmi:type="uml:LiteralString" xmi:id="_gs0ywK37EeSXJ6XI-2nsRw" name="Multiplicity" value="2 &#xD;&#xA;3..* &lt;&lt;preliminary>>"/>
+        </packagedElement>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_SQqTgBizEeSh8KVgZCMyDw" name="CoreFoundationModule">
+      <packagedElement xmi:type="uml:Package" xmi:id="_oGqi1FLNEeO75dO39GbF8Q" name="TypeDefinitions">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_oGqi1VLNEeO75dO39GbF8Q" annotatedElement="_oGqi1FLNEeO75dO39GbF8Q">
+          <body>This package contains all type definitions that are common to all UML interface specifications in SG 15.</body>
+        </ownedComment>
+        <packagedElement xmi:type="uml:DataType" xmi:id="_oGqi1lLNEeO75dO39GbF8Q" name="DateAndTime">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqi11LNEeO75dO39GbF8Q" annotatedElement="_oGqi1lLNEeO75dO39GbF8Q">
+            <body>This primitive type defines the date and time according to the following structure:&#xD;
+&quot;yyyyMMddhhmmss.s[Z|{+|-}HHMm]&quot; where:&#xD;
+yyyy	&quot;0000&quot;..&quot;9999&quot;	year&#xD;
+MM		&quot;01&quot;..&quot;12&quot;			month&#xD;
+dd		&quot;01&quot;..&quot;31&quot;			day&#xD;
+hh		&quot;00&quot;..&quot;23&quot;			hour&#xD;
+mm		&quot;00&quot;..&quot;59&quot;			minute&#xD;
+ss		&quot;00&quot;..&quot;59&quot;			second&#xD;
+s		&quot;.0&quot;..&quot;.9&quot;			tenth of second (set to &quot;.0&quot; if EMS or NE cannot support this granularity)&#xD;
+Z		&quot;Z&quot;					indicates UTC (rather than local time)&#xD;
+{+|-}	&quot;+&quot; or &quot;-&quot;			delta from UTC&#xD;
+HH		&quot;00&quot;..&quot;23&quot;			time zone difference in hours&#xD;
+Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_oGqi2FLNEeO75dO39GbF8Q" name="BitString">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqi2VLNEeO75dO39GbF8Q" annotatedElement="_oGqi2FLNEeO75dO39GbF8Q">
+            <body>This primitive type defines a bit oriented string.&#xD;
+The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).&#xD;
+The semantic of each bit position will be defined in the Documentation field of the attribute.</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_oGqi2lLNEeO75dO39GbF8Q" name="Real">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oGqi21LNEeO75dO39GbF8Q" annotatedElement="_oGqi2lLNEeO75dO39GbF8Q">
+            <body>This primitive type maps to the &quot;realnumber&quot; defined in Recommendation X.680.</body>
+          </ownedComment>
+        </packagedElement>
+        <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_oGqlf1LNEeO75dO39GbF8Q" name="PrintableString">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_eGOsEGgYEeWmgIwAIZlYKQ" annotatedElement="_oGqlf1LNEeO75dO39GbF8Q">
+            <body>A string that only includes printable characters</body>
+          </ownedComment>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_AE1rMI2pEeO38ZmbECnvbg" name="SuperClassesAndCommonPackages">
+        <packagedElement xmi:type="uml:Package" xmi:id="_oDOn8BizEeSh8KVgZCMyDw" name="ObjectClasses">
+          <packagedElement xmi:type="uml:Class" xmi:id="_BUcVEI2tEeO38ZmbECnvbg" name="Name" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_e18ZIGgVEeWmgIwAIZlYKQ" annotatedElement="_BUcVEI2tEeO38ZmbECnvbg">
+              <body>Name: A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ajjMYI2uEeO38ZmbECnvbg" name="nameList" visibility="public" type="_y7oy8I3tEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_jHCa4GgVEeWmgIwAIZlYKQ" annotatedElement="_ajjMYI2uEeO38ZmbECnvbg">
+                <body>List of names.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_csyJwI2uEeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ctHg8I2uEeO38ZmbECnvbg" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_iVJ1kI2wEeO38ZmbECnvbg" name="GlobalClass" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_MTeuEGgWEeWmgIwAIZlYKQ" annotatedElement="_iVJ1kI2wEeO38ZmbECnvbg">
+              <body>Represents a type of thing (an Entity) that has instances which can exist in their own right (independently of any others).&#xD;
+&#xD;
+Entity: Has identity, defined boundary, properties, functionality and lifecycle in a global context.&#xD;
+&#xD;
+(consider in the context of an Object Class: (usage) The representation of a thing that may be an entity or an inseparable Entity Feature)</body>
+            </ownedComment>
+            <generalization xmi:type="uml:Generalization" xmi:id="_d4GJgI2yEeO38ZmbECnvbg" general="_BUcVEI2tEeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_ekZ14I2yEeO38ZmbECnvbg" general="_u0HQoI2wEeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_hPrzkI22EeO38ZmbECnvbg" general="_bCi74I22EeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_hNiEULE2EeSZUdYfPSdgew" general="_RG6VILEtEeSZUdYfPSdgew"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_w39joI3wEeO38ZmbECnvbg" name="localIdList" visibility="public" type="_y7oy8I3tEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_TzLZ0GgWEeWmgIwAIZlYKQ" annotatedElement="_w39joI3wEeO38ZmbECnvbg">
+                <body>An identifier that is unique in the context of some scope that is less than the global scope.&#xD;
+&#xD;
+(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself unique, and immutable. The identifier therefore represents the identity of the entity/role. An identifier carries no semantics with respect to the purpose of the entity.)</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xTUC4I3wEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xT__YI3wEeO38ZmbECnvbg" value="*"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_IEiZwI22EeO38ZmbECnvbg" name="uuid" visibility="public" type="_SU3Q4I30EeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_ZiNZMGgWEeWmgIwAIZlYKQ" annotatedElement="_IEiZwI22EeO38ZmbECnvbg">
+                <body>UUID: An identifier that is universally unique&#xD;
+&#xD;
+(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IpxNwI22EeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IqKPUI22EeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_k5nWYI2wEeO38ZmbECnvbg" name="LocalClass" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_fGPCcGgWEeWmgIwAIZlYKQ" annotatedElement="_k5nWYI2wEeO38ZmbECnvbg">
+              <body>A LocalClass represents a Feature of an Entity. It is inseparable from a GlobalClass but is a distinct feature of that GlobalClass such that the instances of LocalClass are able to have associations to other instances..&#xD;
+Feature of an Entity: An inseparable, externally distinguishable part of an entity.&#xD;
+The mandatory LocalId of the LocalClass instance is unique in the context of the GlobalClass from which it is inseparable.&#xD;
+(consider in the context of an Object Class: (usage) The representation of a thing that may be an entity or an inseparable feature of an entity)&#xD;
+</body>
+            </ownedComment>
+            <generalization xmi:type="uml:Generalization" xmi:id="_fcvzII2yEeO38ZmbECnvbg" general="_BUcVEI2tEeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_gKRAcI2yEeO38ZmbECnvbg" general="_u0HQoI2wEeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_69cLMI22EeO38ZmbECnvbg" general="_bCi74I22EeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_gigKULE2EeSZUdYfPSdgew" general="_RG6VILEtEeSZUdYfPSdgew"/>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_RMJegI22EeO38ZmbECnvbg" name="localIdList" visibility="public" type="_y7oy8I3tEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_kBhQsGgWEeWmgIwAIZlYKQ" annotatedElement="_RMJegI22EeO38ZmbECnvbg">
+                <body>An identifier that is unique in the context of some scope that is less than the global scope.&#xD;
+&#xD;
+(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself unique, and immutable. The identifier therefore represents the identity of the entity/role. An identifier carries no semantics with respect to the purpose of the entity.)</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GzHo0I3wEeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GzfcQI3wEeO38ZmbECnvbg" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_u0HQoI2wEeO38ZmbECnvbg" name="Label" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_pz--kGgWEeWmgIwAIZlYKQ" annotatedElement="_u0HQoI2wEeO38ZmbECnvbg">
+              <body>A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_olrqYI2uEeO38ZmbECnvbg" name="labelList" visibility="public" type="_y7oy8I3tEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_wQE4QGgWEeWmgIwAIZlYKQ" annotatedElement="_olrqYI2uEeO38ZmbECnvbg">
+                <body>List of labels.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pEqFYI2uEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pFBRwI2uEeO38ZmbECnvbg" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_bCi74I22EeO38ZmbECnvbg" name="Extension" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_1fwpMGgWEeWmgIwAIZlYKQ" annotatedElement="_bCi74I22EeO38ZmbECnvbg">
+              <body>Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_uQqu4I28EeO38ZmbECnvbg" name="extensionList" visibility="public" type="_y7oy8I3tEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_8h5PMGgWEeWmgIwAIZlYKQ" annotatedElement="_uQqu4I28EeO38ZmbECnvbg">
+                <body>List of simple name-value extentions</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uskAsI28EeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_us2UkI28EeO38ZmbECnvbg" value="*"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_StA-4I23EeO38ZmbECnvbg" name="UniversalIdAuthority" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_CdttYGgXEeWmgIwAIZlYKQ" annotatedElement="_StA-4I23EeO38ZmbECnvbg">
+              <body>Represents the authority that controls the allocation of UUIDs.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="__JGxMI30EeO38ZmbECnvbg" name="uuid" visibility="public" type="_SU3Q4I30EeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_FzsxwGgXEeWmgIwAIZlYKQ" annotatedElement="__JGxMI30EeO38ZmbECnvbg">
+                <body>The UUID for the UUID authority.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__JGxMY30EeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__JGxMo30EeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_ulDtsI3AEeO38ZmbECnvbg" name="NameAndValueAuthority" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_J5sWwGgXEeWmgIwAIZlYKQ" annotatedElement="_ulDtsI3AEeO38ZmbECnvbg">
+              <body>Represents the authority that controls the legal valuse for the names and values of a name/value attribute.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_U1tnkI31EeO38ZmbECnvbg" name="uuid" visibility="public" type="_SU3Q4I30EeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_PBXbMGgXEeWmgIwAIZlYKQ" annotatedElement="_U1tnkI31EeO38ZmbECnvbg">
+                <body>The UUID for the NameValueAuthority.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VM-4EI31EeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VNUPQI31EeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_-ZWVQJP0EeOqfpp-ZJSmaA" name="ConditionalPackage" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_UmfQoGgXEeWmgIwAIZlYKQ" annotatedElement="_-ZWVQJP0EeOqfpp-ZJSmaA">
+              <body>The base class for conditional packages.</body>
+            </ownedComment>
+            <generalization xmi:type="uml:Generalization" xmi:id="_JIYq0JP1EeOqfpp-ZJSmaA" general="_bCi74I22EeO38ZmbECnvbg"/>
+            <generalization xmi:type="uml:Generalization" xmi:id="_5Zv80JP2EeOqfpp-ZJSmaA" general="_u0HQoI2wEeO38ZmbECnvbg"/>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_5hoYgBizEeSh8KVgZCMyDw" name="TypeDefinitions">
+          <packagedElement xmi:type="uml:DataType" xmi:id="_y7oy8I3tEeO38ZmbECnvbg" name="NameAndValue">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_d6mgUGgXEeWmgIwAIZlYKQ" annotatedElement="_y7oy8I3tEeO38ZmbECnvbg">
+              <body>A scoped name-value pair</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_77PyQI3tEeO38ZmbECnvbg" name="valueName" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_kloN4GgXEeWmgIwAIZlYKQ" annotatedElement="_77PyQI3tEeO38ZmbECnvbg">
+                <body>The name of the value. The value need not have a name.</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8XjTwI3tEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8X2OsI3tEeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ZUyfII3uEeO38ZmbECnvbg" name="value" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_oJBcIGgXEeWmgIwAIZlYKQ" annotatedElement="_ZUyfII3uEeO38ZmbECnvbg">
+                <body>The value</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Z3im4I3uEeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Z31h0I3uEeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_pXXx8Y3uEeO38ZmbECnvbg" name="_nameAndValueAuthorityRef" type="_ulDtsI3AEeO38ZmbECnvbg" association="_pXXx8I3uEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_ryyYIGgXEeWmgIwAIZlYKQ" annotatedElement="_pXXx8Y3uEeO38ZmbECnvbg">
+                <body>The authority that defines the named value.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pXXx8o3uEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pXXx843uEeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_bhg_8Y3vEeO38ZmbECnvbg" name="_globalClassRef" type="_iVJ1kI2wEeO38ZmbECnvbg" association="_bhg_8I3vEeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_vjBIgGgXEeWmgIwAIZlYKQ" annotatedElement="_bhg_8Y3vEeO38ZmbECnvbg">
+                <body>The scope of the name uniqueness</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bhg_8o3vEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bhg_843vEeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_NIlTsI28EeO38ZmbECnvbg" name="_localClassRef" type="_k5nWYI2wEeO38ZmbECnvbg" association="_NIvrwI28EeO38ZmbECnvbg">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_xxGJoGgXEeWmgIwAIZlYKQ" annotatedElement="_NIlTsI28EeO38ZmbECnvbg">
+                <body>The scope of the name uniqueness</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NIlTsY28EeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NIlTso28EeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:DataType" xmi:id="_SU3Q4I30EeO38ZmbECnvbg" name="UniversalId">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_PZfK0GgYEeWmgIwAIZlYKQ" annotatedElement="_SU3Q4I30EeO38ZmbECnvbg">
+              <body>The univeral ID value where the mechanism for generation is defned by some authority not directly referenced in the structure.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_cbx2gI30EeO38ZmbECnvbg" name="value" visibility="public">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_TIgaQGgYEeWmgIwAIZlYKQ" annotatedElement="_cbx2gI30EeO38ZmbECnvbg">
+                <body>The specific value of the universal id</body>
+              </ownedComment>
+              <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c3s9gI30EeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c4IbUI30EeO38ZmbECnvbg" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_Eh1WkBi0EeSh8KVgZCMyDw" name="Assocations">
+          <packagedElement xmi:type="uml:Association" xmi:id="_mZyWYI21EeO38ZmbECnvbg" name="LocalClassInstanceIsLifecycleBoundedByGlobalClassInstance" memberEnd="_mZyWYY21EeO38ZmbECnvbg _mZnXQI21EeO38ZmbECnvbg" navigableOwnedEnd="_mZyWYY21EeO38ZmbECnvbg">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_mZyWYY21EeO38ZmbECnvbg" name="_globalClass" type="_iVJ1kI2wEeO38ZmbECnvbg" association="_mZyWYI21EeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mZyWYo21EeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mZyWY421EeO38ZmbECnvbg" value="1"/>
+            </ownedEnd>
+            <ownedEnd xmi:type="uml:Property" xmi:id="_mZnXQI21EeO38ZmbECnvbg" name="_localClass" type="_k5nWYI2wEeO38ZmbECnvbg" association="_mZyWYI21EeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mZnXQY21EeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mZnXQo21EeO38ZmbECnvbg" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_NIvrwI28EeO38ZmbECnvbg" name="NameAndValueIsUniqueInScopeOfLocalClassInstance" memberEnd="_NIvrwY28EeO38ZmbECnvbg _NIlTsI28EeO38ZmbECnvbg">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_NIvrwY28EeO38ZmbECnvbg" name="nameElement" type="_y7oy8I3tEeO38ZmbECnvbg" association="_NIvrwI28EeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NIvrwo28EeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NIvrw428EeO38ZmbECnvbg" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_pXXx8I3uEeO38ZmbECnvbg" name="NameAndValueHasNameAndValueAuthority" memberEnd="_pXXx9I3uEeO38ZmbECnvbg _pXXx8Y3uEeO38ZmbECnvbg">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_pXXx9I3uEeO38ZmbECnvbg" name="nameElement" type="_y7oy8I3tEeO38ZmbECnvbg" association="_pXXx8I3uEeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pXXx9Y3uEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pXXx9o3uEeO38ZmbECnvbg" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_bhg_8I3vEeO38ZmbECnvbg" name="NameAndValueIsUniqueInScopeOfGlobalClassInstance" memberEnd="_bhg_9I3vEeO38ZmbECnvbg _bhg_8Y3vEeO38ZmbECnvbg">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_bhg_9I3vEeO38ZmbECnvbg" name="nameElement" type="_y7oy8I3tEeO38ZmbECnvbg" association="_bhg_8I3vEeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bhg_9Y3vEeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bhg_9o3vEeO38ZmbECnvbg" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_e2gXEI31EeO38ZmbECnvbg" name="GlobalIdHasGlobalIdAuthority" memberEnd="_e2gXFI31EeO38ZmbECnvbg _e2gXEY31EeO38ZmbECnvbg" navigableOwnedEnd="_e2gXEY31EeO38ZmbECnvbg">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_e2gXEY31EeO38ZmbECnvbg" name="_gLobalIdAuthorityRef" type="_StA-4I23EeO38ZmbECnvbg" association="_e2gXEI31EeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e2gXEo31EeO38ZmbECnvbg" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e2gXE431EeO38ZmbECnvbg" value="1"/>
+            </ownedEnd>
+            <ownedEnd xmi:type="uml:Property" xmi:id="_e2gXFI31EeO38ZmbECnvbg" name="globalId" type="_SU3Q4I30EeO38ZmbECnvbg" association="_e2gXEI31EeO38ZmbECnvbg">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e2gXFY31EeO38ZmbECnvbg"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e2gXFo31EeO38ZmbECnvbg" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_K2aTABi0EeSh8KVgZCMyDw" name="Diagrams">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_VhoiwJJxEeO03KWNhYntEQ">
+            <body>Need to define mechanism to move from extension to standard.</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_g6GT4JPyEeOqfpp-ZJSmaA">
+            <body>Does not need an identifier as there is always 0..1 and hence the package instance is unique in the context of the instance of the class that it is a package of.</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6Xh-QJP3EeOqfpp-ZJSmaA">
+            <body>Showing example of results of inheritence</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_y6YawJP4EeOqfpp-ZJSmaA">
+            <body>Need to add the actual conditional packages</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_nBHw8JP8EeOqfpp-ZJSmaA">
+            <body>Need to add local classes such as OTUk_NonIntrusiveMonitiring</body>
+          </ownedComment>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_6eJYgLEsEeSZUdYfPSdgew" name="StateModel">
+        <packagedElement xmi:type="uml:Package" xmi:id="_rmrNwGgiEeWmgIwAIZlYKQ" name="ObjectClasses">
+          <packagedElement xmi:type="uml:Class" xmi:id="_RG6VILEtEeSZUdYfPSdgew" name="State_Pac" isAbstract="true">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_ZvtTkGgfEeWmgIwAIZlYKQ" annotatedElement="_RG6VILEtEeSZUdYfPSdgew">
+              <body>Provides general state attributes.</body>
+            </ownedComment>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_dO6owLEtEeSZUdYfPSdgew" name="operationalState" visibility="public" type="_lNclkLEtEeSZUdYfPSdgew" isReadOnly="true">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_vNL24GghEeWmgIwAIZlYKQ" annotatedElement="_dO6owLEtEeSZUdYfPSdgew">
+                <body>The operational state is used to indicate whether or not the resource is installed and working</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dzbrELEtEeSZUdYfPSdgew"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dz1TsLEtEeSZUdYfPSdgew" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_7gqwALEtEeSZUdYfPSdgew" name="administrativeControl" visibility="public" type="_-xPeALEvEeSZUdYfPSdgew">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_CTlx8GggEeWmgIwAIZlYKQ" annotatedElement="_7gqwALEtEeSZUdYfPSdgew">
+                <body>The administrativeControl state provides control of the availability of specific resources without modification to the provisioning of those resources.&#xD;
+The value is the current control target. The actual administrativeState may or may not be at target.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9PLgQLEtEeSZUdYfPSdgew" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9PmXALEtEeSZUdYfPSdgew" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_AjGvILEuEeSZUdYfPSdgew" name="adminsatratveState" visibility="public" type="_KSKOYLEuEeSZUdYfPSdgew" isReadOnly="true">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_58sKsGgaEeWmgIwAIZlYKQ" annotatedElement="_AjGvILEuEeSZUdYfPSdgew">
+                <body>Shows whether or not the client has permission to use or has a prohibition against using the resource.&#xD;
+The administrative state expresses usage permissions for specific resources without modification to the provisioning of those resources.</body>
+              </ownedComment>
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DWakQLEuEeSZUdYfPSdgew" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DWzl0LEuEeSZUdYfPSdgew" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_PzqZ0GgiEeWmgIwAIZlYKQ" name="lifecycleState" type="_YSsboGgiEeWmgIwAIZlYKQ">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_mbN1gGgiEeWmgIwAIZlYKQ" annotatedElement="_PzqZ0GgiEeWmgIwAIZlYKQ">
+                <body>Used to track the planned deployment, allocation to clients and withdrawal of resources. </body>
+              </ownedComment>
+            </ownedAttribute>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_ynb6wGgiEeWmgIwAIZlYKQ" name="TypeDefinitions">
+          <packagedElement xmi:type="uml:Enumeration" xmi:id="_lNclkLEtEeSZUdYfPSdgew" name="OperationalState">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_EAMLwGgiEeWmgIwAIZlYKQ" annotatedElement="_lNclkLEtEeSZUdYfPSdgew">
+              <body>The possible values of the operationalState.</body>
+            </ownedComment>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oVoegLEtEeSZUdYfPSdgew" name="DISABLED">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_71BhIGghEeWmgIwAIZlYKQ" annotatedElement="_oVoegLEtEeSZUdYfPSdgew">
+                <body>The resource is unable to meet the SLA of the user of the resource. If no (explicit) SLA is defined the resource is disabled if it is totally inoperable and unable to provide service to the user.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_p90kULEtEeSZUdYfPSdgew" name="ENABLED">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_14MWUGghEeWmgIwAIZlYKQ" annotatedElement="_p90kULEtEeSZUdYfPSdgew">
+                <body>The resource is partially or fully operable and available for use</body>
+              </ownedComment>
+            </ownedLiteral>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Enumeration" xmi:id="_KSKOYLEuEeSZUdYfPSdgew" name="AdministrativeState">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Rfe34GghEeWmgIwAIZlYKQ" annotatedElement="_KSKOYLEuEeSZUdYfPSdgew">
+              <body>The possible values of the administrativeState.</body>
+            </ownedComment>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_OLEZoLEuEeSZUdYfPSdgew" name="LOCKED">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_VYOEAGghEeWmgIwAIZlYKQ" annotatedElement="_OLEZoLEuEeSZUdYfPSdgew">
+                <body>Users are administratively prohibited from making use of the resource.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PIgSQLEuEeSZUdYfPSdgew" name="UNLOCKED">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_fZqTwGghEeWmgIwAIZlYKQ" annotatedElement="_PIgSQLEuEeSZUdYfPSdgew">
+                <body>Users are allowed to use the resource</body>
+              </ownedComment>
+            </ownedLiteral>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Enumeration" xmi:id="_-xPeALEvEeSZUdYfPSdgew" name="AdministrativeControl">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_5_rJUMPvEeSkD7NQ5om7rQ">
+              <body>Reflects the current control action when the entity is not in the desired state.</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Q_HyQGggEeWmgIwAIZlYKQ" annotatedElement="_-xPeALEvEeSZUdYfPSdgew">
+              <body>The possible values of the current target administrative state.</body>
+            </ownedComment>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vaxN0LEwEeSZUdYfPSdgew" name="UNLOCK">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_mb7SEGggEeWmgIwAIZlYKQ" annotatedElement="_vaxN0LEwEeSZUdYfPSdgew">
+                <body>The intention is for the entity to become unlocked.&#xD;
+The entity may already be UNLOCKED.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_NTzvkLEwEeSZUdYfPSdgew" name="LOCK_PASSIVE">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_tzVkgGggEeWmgIwAIZlYKQ" annotatedElement="_NTzvkLEwEeSZUdYfPSdgew">
+                <body>The intention is for the entity to become locked but no effort is expected to move to the Locked state (the state will be achieved once all users stop using the resource). &#xD;
+The entity may be LOCKED</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_uWUxcLE0EeSZUdYfPSdgew" name="LOCK_ACTIVE">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_7F8qEGggEeWmgIwAIZlYKQ" annotatedElement="_uWUxcLE0EeSZUdYfPSdgew">
+                <body>The intention is for the entity to become locked and it is expected that effort will be made to move to the Locked state (users will be actively removed). &#xD;
+The entity may already be LOCKED.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_a69wUGggEeWmgIwAIZlYKQ" name="LOCK_IMMEDIATE">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_HKL4AGghEeWmgIwAIZlYKQ" annotatedElement="_a69wUGggEeWmgIwAIZlYKQ">
+                <body>The intention is for the entity to become locked and it is expected to move to the Locked state immediately (users will be force removed). &#xD;
+The entity may already be LOCKED.</body>
+              </ownedComment>
+            </ownedLiteral>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Enumeration" xmi:id="_McyhcGgeEeWmgIwAIZlYKQ" name="ExtendedAdminState">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_vc_ikGgjEeWmgIwAIZlYKQ" annotatedElement="_McyhcGgeEeWmgIwAIZlYKQ">
+              <body>Possible extentions to AdministrativeState</body>
+            </ownedComment>
+            <generalization xmi:type="uml:Generalization" xmi:id="_TWEtcGgeEeWmgIwAIZlYKQ" general="_KSKOYLEuEeSZUdYfPSdgew"/>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_QAuTsLEuEeSZUdYfPSdgew" name="SHUTTING_DOWN_ACTIVE">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_oW5poGgjEeWmgIwAIZlYKQ" annotatedElement="_QAuTsLEuEeSZUdYfPSdgew">
+                <body>The entity is administratively restricted to existing instances of use only. There are specific actions to remove existing uses. There may be no new instances of use enabled. This corresponds to a control of LOCK_ACTIVE.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iIYN4LE0EeSZUdYfPSdgew" name="SHUTTING_DOWN_PASSIVE">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_rWXEYGgjEeWmgIwAIZlYKQ" annotatedElement="_iIYN4LE0EeSZUdYfPSdgew">
+                <body>The entity is administratively restricted to existing instances of use only. There may be no new instances of use enabled. This corresponds to a control of LOCK_PASSIVE.</body>
+              </ownedComment>
+            </ownedLiteral>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Enumeration" xmi:id="_YSsboGgiEeWmgIwAIZlYKQ" name="LifecycleState">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_kD5jYGgjEeWmgIwAIZlYKQ" annotatedElement="_YSsboGgiEeWmgIwAIZlYKQ">
+              <body>The possible values of the lifecycleState.</body>
+            </ownedComment>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_9FvssGgiEeWmgIwAIZlYKQ" name="PLANNED">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_C8MisGgjEeWmgIwAIZlYKQ" annotatedElement="_9FvssGgiEeWmgIwAIZlYKQ">
+                <body>The resource is planned but is not present in the network.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_DuF5sGgjEeWmgIwAIZlYKQ" name="POTENTIAL">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_O4Ee0GgjEeWmgIwAIZlYKQ" annotatedElement="_DuF5sGgjEeWmgIwAIZlYKQ">
+                <body>The supporting resources are present in the network but are shared with other clients; or require further configuration before they can be used; or both.&#xD;
+o	When a potential resource is configured and allocated to a client it is moved to the “installed” state for that client.&#xD;
+o	If the potential resource has been consumed (e.g. allocated to another client) it is moved to the “planned” state for all other clients.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ql5SkGgjEeWmgIwAIZlYKQ" name="INSTALLED">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_UmEjcGgjEeWmgIwAIZlYKQ" annotatedElement="_Ql5SkGgjEeWmgIwAIZlYKQ">
+                <body>The resource is present in the network and is capable of providing the service expected.</body>
+              </ownedComment>
+            </ownedLiteral>
+            <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XbZx0GgjEeWmgIwAIZlYKQ" name="PENDING_REMOVAL">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_cnmJ4GgjEeWmgIwAIZlYKQ" annotatedElement="_XbZx0GgjEeWmgIwAIZlYKQ">
+                <body>The resource has been marked for removal</body>
+              </ownedComment>
+            </ownedLiteral>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_2AdsEGgiEeWmgIwAIZlYKQ" name="Diagrams">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_dzFRIGgZEeWmgIwAIZlYKQ">
+            <body>These states are derived from the definitions in ITU-T Recommendation X.731 “Information Technology – Open Systems Interconnection – Systems Management: State Management Function” including amendments 1 and 2. This Recommendation and its amendments are available from: &#xD;
+http://www.itu.int/rec/T-REC-X.731/en&#xD;
+</body>
+          </ownedComment>
+        </packagedElement>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_cCVB4BizEeSh8KVgZCMyDw" name="CoreModelEnhancements">
+      <packagedElement xmi:type="uml:Package" xmi:id="_BQT2IKKtEeOfSYroU9Javw" name="FcSwitchEnhancements-Developed">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_r9ZDABBFEeS-tqfHkf_O5w">
+          <body>Accounts for both ingress (=1) and egress (= 1..*)</body>
+        </ownedComment>
+        <packagedElement xmi:type="uml:Class" xmi:id="_rgdnkJoyEeOyHKqw-cQ_eg" name="ProfileProxy">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_tgFPQGj6EeWI2vxwuJqrJA" annotatedElement="_rgdnkJoyEeOyHKqw-cQ_eg">
+            <body>A lightweight sketch placeholder for the profile model.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_v77tUJoyEeOyHKqw-cQ_eg" name="profileProxyMode" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="__8CNMGj6EeWI2vxwuJqrJA" annotatedElement="_v77tUJoyEeOyHKqw-cQ_eg">
+              <body>A parameter profile may be used in a number of different ways:&#xD;
+- Forces the values on the target with no opportunity to see or override the values in the target&#xD;
+- Sets the values on the target that can be seen on the target&#xD;
+- Sets the values on the target and supports override on the target so the target can be set away from the value in the profile&#xD;
+- etc</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xR2XYJoyEeOyHKqw-cQ_eg" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xSOx4JoyEeOyHKqw-cQ_eg" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_xZiBgJ4IEeOO3om500DFKg" name="_controlParameters" type="_T5-osJ4HEeOO3om500DFKg" aggregation="composite" association="_xZrLcJ4IEeOO3om500DFKg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_M1JNoGj7EeWI2vxwuJqrJA" annotatedElement="_xZiBgJ4IEeOO3om500DFKg">
+              <body>The control parameters that can be set int the profile and applied to the target.&#xD;
+Not all parameters need be selected and applied.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xZiBgZ4IEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xZiBgp4IEeOO3om500DFKg" value="1"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_k1gHQJo5EeOyHKqw-cQ_eg" name="ConfigurationAndSwitchController">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_gBIhYGj7EeWI2vxwuJqrJA" annotatedElement="_k1gHQJo5EeOyHKqw-cQ_eg">
+            <body>Sketch representation of a cntroller with basic capability to control switched and add/delete/modify FCs.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_oxb_EJo-EeOyHKqw-cQ_eg" name="SwichRule" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_rAnGsGj7EeWI2vxwuJqrJA" annotatedElement="_oxb_EJo-EeOyHKqw-cQ_eg">
+              <body>A sketch of the presence of complex rules governing the switch behavior.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GJxyEJo_EeOyHKqw-cQ_eg" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GKFUEJo_EeOyHKqw-cQ_eg" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_8-3vcJpDEeOyHKqw-cQ_eg" name="_fcSwitchRefList" type="_a97NQFYhEeOVGaP4lO41SQ" association="_8_BgcJpDEeOyHKqw-cQ_eg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_uVZRMGj7EeWI2vxwuJqrJA" annotatedElement="_8-3vcJpDEeOyHKqw-cQ_eg">
+              <body>The switch being controlled.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8-3vcZpDEeOyHKqw-cQ_eg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8-3vcppDEeOyHKqw-cQ_eg" value="*"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_YzzeYJ4HEeOO3om500DFKg" name="_controlParameters" type="_T5-osJ4HEeOO3om500DFKg" aggregation="composite" association="_Y0HAYJ4HEeOO3om500DFKg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_-E0-gGj7EeWI2vxwuJqrJA" annotatedElement="_YzzeYJ4HEeOO3om500DFKg">
+              <body>The control parameters to be aplied if local parameters are used rather than profiles</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YzzeYZ4HEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YzzeYp4HEeOO3om500DFKg" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_Ec0FMJ4JEeOO3om500DFKg" name="_profileProxyRef" type="_rgdnkJoyEeOyHKqw-cQ_eg" association="_Ec9PIJ4JEeOO3om500DFKg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_Bg-8UGj8EeWI2vxwuJqrJA" annotatedElement="_Ec0FMJ4JEeOO3om500DFKg">
+              <body>Applied profiles.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ec0FMZ4JEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ec0FMp4JEeOO3om500DFKg" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_8_BgcJpDEeOyHKqw-cQ_eg" name="controlChoosesSwitchPosition" memberEnd="_8_BgcZpDEeOyHKqw-cQ_eg _8-3vcJpDEeOyHKqw-cQ_eg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_8_BgcZpDEeOyHKqw-cQ_eg" name="switchCoordinator" type="_k1gHQJo5EeOyHKqw-cQ_eg" association="_8_BgcJpDEeOyHKqw-cQ_eg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8_BgcppDEeOyHKqw-cQ_eg" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8_Bgc5pDEeOyHKqw-cQ_eg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_T5-osJ4HEeOO3om500DFKg" name="ControlParameters">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_g578MGj8EeWI2vxwuJqrJA" annotatedElement="_T5-osJ4HEeOO3om500DFKg">
+            <body>A list of control parameters to apply to a switch</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_eSmM4J4IEeOO3om500DFKg" name="operType" visibility="public" type="_oGqjf1LNEeO75dO39GbF8Q">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eSmM4Z4IEeOO3om500DFKg" annotatedElement="_eSmM4J4IEeOO3om500DFKg">
+              <body>This attribute whether or not the protection scheme is revertive or non-revertive. </body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ty_wkGj7EeWI2vxwuJqrJA"/>
+            <defaultValue xmi:type="uml:InstanceValue" xmi:id="_eSmM4p4IEeOO3om500DFKg" name="REVERTIVE" type="_oGqjf1LNEeO75dO39GbF8Q" instance="_oGqjgVLNEeO75dO39GbF8Q"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_eSxzEJ4IEeOO3om500DFKg" name="waitToRestoreTime" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eSxzEZ4IEeOO3om500DFKg" annotatedElement="_eSxzEJ4IEeOO3om500DFKg">
+              <body>If the protection system is revertive, this attribute specifies the amount of time, in seconds, to wait after a fault clears before restoring traffic to the protected protectionUnit that initiated the switching. Valid values for this attribute are integers.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U9BTsGj7EeWI2vxwuJqrJA"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_eS7kEJ4IEeOO3om500DFKg" name="protType" visibility="public" type="_c3Hu8Gb3EeWrX_JIGzXlSg">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eS7kEZ4IEeOO3om500DFKg" annotatedElement="_eS7kEJ4IEeOO3om500DFKg">
+              <body>Indicates the protection scheme that is used for the ProtectionGroup.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VyLaEGj7EeWI2vxwuJqrJA"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_eTFVEJ4IEeOO3om500DFKg" name="holdOffTime" visibility="public">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eTFVEZ4IEeOO3om500DFKg" annotatedElement="_eTFVEJ4IEeOO3om500DFKg">
+              <body>This attribute indicates the time, in seconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm. Valid values are integers in units of seconds.</body>
+            </ownedComment>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WaWNUGj7EeWI2vxwuJqrJA"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Y0HAYJ4HEeOO3om500DFKg" name="SwitchCoordinatorOwnsControlParameters" memberEnd="_Y0HAYZ4HEeOO3om500DFKg _YzzeYJ4HEeOO3om500DFKg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_Y0HAYZ4HEeOO3om500DFKg" name="switchCoordinator" type="_k1gHQJo5EeOyHKqw-cQ_eg" association="_Y0HAYJ4HEeOO3om500DFKg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Y0HAYp4HEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Y0HAY54HEeOO3om500DFKg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_xZrLcJ4IEeOO3om500DFKg" name="ProfileProxyOwnsControlParameters" memberEnd="_xZrLcZ4IEeOO3om500DFKg _xZiBgJ4IEeOO3om500DFKg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_xZrLcZ4IEeOO3om500DFKg" name="profileProxy" type="_rgdnkJoyEeOyHKqw-cQ_eg" association="_xZrLcJ4IEeOO3om500DFKg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xZrLcp4IEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xZrLc54IEeOO3om500DFKg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Ec9PIJ4JEeOO3om500DFKg" name="switchCoordinatorHasProfileProxy" memberEnd="_Ec9PIZ4JEeOO3om500DFKg _Ec0FMJ4JEeOO3om500DFKg">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_Ec9PIZ4JEeOO3om500DFKg" name="switchCoordinator" type="_k1gHQJo5EeOyHKqw-cQ_eg" association="_Ec9PIJ4JEeOO3om500DFKg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ec9PIp4JEeOO3om500DFKg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ec9PI54JEeOO3om500DFKg" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_Tvr28BBHEeS-tqfHkf_O5w" name="ConfigurationGroup">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pCLOoGj8EeWI2vxwuJqrJA" annotatedElement="_Tvr28BBHEeS-tqfHkf_O5w">
+            <body>Represents a scope of control for one or more Controllers</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_sseEoBBHEeS-tqfHkf_O5w" name="_configurationAndSwitchControlRefList" type="_k1gHQJo5EeOyHKqw-cQ_eg" aggregation="composite" association="_ss6wkBBHEeS-tqfHkf_O5w">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_sgyDgGj8EeWI2vxwuJqrJA" annotatedElement="_sseEoBBHEeS-tqfHkf_O5w">
+              <body>A controller operating in the scope defined.</body>
+            </ownedComment>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sseEoRBHEeS-tqfHkf_O5w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sseEohBHEeS-tqfHkf_O5w" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_ss6wkBBHEeS-tqfHkf_O5w" name="configurationGroup_configurationAndSwitchControl_1" memberEnd="_ss6wkRBHEeS-tqfHkf_O5w _sseEoBBHEeS-tqfHkf_O5w">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_ss6wkRBHEeS-tqfHkf_O5w" name="configurationGroup" type="_Tvr28BBHEeS-tqfHkf_O5w" association="_ss6wkBBHEeS-tqfHkf_O5w">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ss6wkhBHEeS-tqfHkf_O5w"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ss6wkxBHEeS-tqfHkf_O5w" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_byGkAMrUEeOt57ZaJqAnzg" name="ProfilesTemplatesAndSpecificationsModule">
+        <packagedElement xmi:type="uml:Package" xmi:id="_opnrsOvTEeOE19T_GJuRHg" name="FcCapability-Developed">
+          <packagedElement xmi:type="uml:Package" xmi:id="_dP5FkL7VEeSdssyZX-p90g" name="ObjectClasses">
+            <packagedElement xmi:type="uml:Class" xmi:id="_nzCmUMrUEeOt57ZaJqAnzg" name="MultiSwitchedUniFlow">
+              <generalization xmi:type="uml:Generalization" xmi:id="_zejxgEv-EeWXgvUwfkuadg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_DDTSgMrVEeOt57ZaJqAnzg" name="_ingressFcPort" type="_vk9qgMrUEeOt57ZaJqAnzg" aggregation="composite" association="_DDgt4MrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DDTSgcrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DDTSgsrVEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_D2itUMrVEeOt57ZaJqAnzg" name="_egressFcPort" type="_x2_-kMrUEeOt57ZaJqAnzg" aggregation="composite" association="_D2uTgMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_D2itUcrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_D2itUsrVEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_rBXuEMrVEeOt57ZaJqAnzg" name="switchControl" type="_4MF4YMrUEeOt57ZaJqAnzg" aggregation="composite" association="_rBjUQMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rBXuEcrVEeOt57ZaJqAnzg"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rBXuEsrVEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_d6lKsM96EeOwEItOulyh6w" name="ingressFcPortSet" type="_vk9qgMrUEeOt57ZaJqAnzg" association="_d8DKUM96EeOwEItOulyh6w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d7PSAM96EeOwEItOulyh6w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d7jbEM96EeOwEItOulyh6w" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_Q4JwgBBEEeS-tqfHkf_O5w" name="egressFcPortSet" type="_x2_-kMrUEeOt57ZaJqAnzg" association="_Q575MBBEEeS-tqfHkf_O5w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Q5MSUBBEEeS-tqfHkf_O5w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Q5fNQBBEEeS-tqfHkf_O5w" value="1"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_vk9qgMrUEeOt57ZaJqAnzg" name="IngressFcPortSet">
+              <generalization xmi:type="uml:Generalization" xmi:id="_0Cdv0Ev-EeWXgvUwfkuadg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_x2_-kMrUEeOt57ZaJqAnzg" name="EgressFcPortSet">
+              <generalization xmi:type="uml:Generalization" xmi:id="_0jGXsEv-EeWXgvUwfkuadg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_4MF4YMrUEeOt57ZaJqAnzg" name="ConfigurationAndSwitchControl">
+              <generalization xmi:type="uml:Generalization" xmi:id="_8FsmcEv-EeWXgvUwfkuadg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_eej4UMrWEeOt57ZaJqAnzg" name="switchControlRule" type="_BC32YMrWEeOt57ZaJqAnzg" aggregation="composite" association="_eexTsMrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eej4UcrWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eej4UsrWEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_tGhwcM96EeOwEItOulyh6w" name="switch" type="_d8DKUM96EeOwEItOulyh6w" association="_tGsvkM96EeOwEItOulyh6w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tGhwcc96EeOwEItOulyh6w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tGhwcs96EeOwEItOulyh6w" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_q_7KoBBEEeS-tqfHkf_O5w" name="egressSelection" type="_Q575MBBEEeS-tqfHkf_O5w" association="_rAOFkBBEEeS-tqfHkf_O5w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_q_7KoRBEEeS-tqfHkf_O5w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_q_7KohBEEeS-tqfHkf_O5w" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_huOHsMrVEeOt57ZaJqAnzg" name="FcSpec">
+              <generalization xmi:type="uml:Generalization" xmi:id="_62-wkEv-EeWXgvUwfkuadg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_lyVdYMrVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow" type="_nzCmUMrUEeOt57ZaJqAnzg" aggregation="composite" association="_lygcgMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lyVdYcrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lyVdYsrVEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_tRU-gMrVEeOt57ZaJqAnzg" name="switchControl" type="_4MF4YMrUEeOt57ZaJqAnzg" aggregation="composite" association="_tRgksMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tRU-gcrVEeOt57ZaJqAnzg"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tRU-gsrVEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_F4DcoMrWEeOt57ZaJqAnzg" name="fcPortSpec" type="_EL4OsMrWEeOt57ZaJqAnzg" aggregation="composite" association="_F4ObwMrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_F4DcocrWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_F4DcosrWEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_o5PVMMrbEeOt57ZaJqAnzg" name="fcSwitchGroupSpec" type="_vxoYEMrVEeOt57ZaJqAnzg" association="_o5aUUMrbEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o5PVMcrbEeOt57ZaJqAnzg"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o5PVMsrbEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_ArJEIMrcEeOt57ZaJqAnzg" name="ltpAssociationRule" type="_xI3CAMrbEeOt57ZaJqAnzg" aggregation="composite" association="_ArUDQMrcEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ArJEIcrcEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ArJEIsrcEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_vxoYEMrVEeOt57ZaJqAnzg" name="ConfigurationGroupSpec">
+              <generalization xmi:type="uml:Generalization" xmi:id="_54hkQEv-EeWXgvUwfkuadg" general="_iVJ1kI2wEeO38ZmbECnvbg"/>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_zevjAMrVEeOt57ZaJqAnzg" name="switchControl" type="_4MF4YMrUEeOt57ZaJqAnzg" aggregation="composite" association="_ze8-YMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_zevjAcrVEeOt57ZaJqAnzg"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_zevjAsrVEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_15tJkMrVEeOt57ZaJqAnzg" name="fcSpec" type="_huOHsMrVEeOt57ZaJqAnzg" aggregation="composite" association="_154IsMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_15tJkcrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_15tJksrVEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_6ZBl0MrbEeOt57ZaJqAnzg" name="ltpAssociationRule" type="_xI3CAMrbEeOt57ZaJqAnzg" aggregation="composite" association="_6ZMk8MrbEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6ZBl0crbEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6ZBl0srbEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_BC32YMrWEeOt57ZaJqAnzg" name="ControlRule">
+              <generalization xmi:type="uml:Generalization" xmi:id="_5NiGgEv-EeWXgvUwfkuadg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_pSR5kMrWEeOt57ZaJqAnzg" name="switchControl_switch_1">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pSR5kcrWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pSR5ksrWEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_EL4OsMrWEeOt57ZaJqAnzg" name="FcPortSetSpec">
+              <generalization xmi:type="uml:Generalization" xmi:id="_3zYcsEv-EeWXgvUwfkuadg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_K1oJ4MrWEeOt57ZaJqAnzg" name="ingressFcPortSet" type="_vk9qgMrUEeOt57ZaJqAnzg" association="_K1zJAMrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_K1oJ4crWEeOt57ZaJqAnzg"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_K1oJ4srWEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_MqxtoMrWEeOt57ZaJqAnzg" name="egressFcPortSet" type="_x2_-kMrUEeOt57ZaJqAnzg" association="_Mq-h8MrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MqxtocrWEeOt57ZaJqAnzg"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MqxtosrWEeOt57ZaJqAnzg" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_1kdDkMrbEeOt57ZaJqAnzg" name="ltpAssociationRule" type="_xI3CAMrbEeOt57ZaJqAnzg" association="_1krGAMrbEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1kdDkcrbEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1kdDksrbEeOt57ZaJqAnzg" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_LfY8APFLEeOb0bs-xqaPmA" name="role" visibility="public">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_L_ZRwPFLEeOb0bs-xqaPmA" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_L_uB4PFLEeOb0bs-xqaPmA" value="1"/>
+                <defaultValue xmi:type="uml:LiteralString" xmi:id="_MAdowPFLEeOb0bs-xqaPmA">
+                  <value xsi:nil="true"/>
+                </defaultValue>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_xI3CAMrbEeOt57ZaJqAnzg" name="LtpAssociationRule">
+              <generalization xmi:type="uml:Generalization" xmi:id="_1M1RMEv-EeWXgvUwfkuadg" general="_k5nWYI2wEeO38ZmbECnvbg"/>
+            </packagedElement>
+            <packagedElement xmi:type="uml:AssociationClass" xmi:id="_d8DKUM96EeOwEItOulyh6w" name="IngressSwitchSelection" memberEnd="_d8DKUc96EeOwEItOulyh6w _d6lKsM96EeOwEItOulyh6w">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_rz8d8PFKEeOb0bs-xqaPmA" name="setMember" visibility="public">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wIHo4PFKEeOb0bs-xqaPmA" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wIsQoPFKEeOb0bs-xqaPmA" value="1"/>
+                <defaultValue xmi:type="uml:LiteralString" xmi:id="_wJpS4PFKEeOb0bs-xqaPmA">
+                  <value xsi:nil="true"/>
+                </defaultValue>
+              </ownedAttribute>
+              <ownedEnd xmi:type="uml:Property" xmi:id="_d8DKUc96EeOwEItOulyh6w" name="multiswitcheduniflow" type="_nzCmUMrUEeOt57ZaJqAnzg" association="_d8DKUM96EeOwEItOulyh6w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_d8DKUs96EeOwEItOulyh6w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_d8DKU896EeOwEItOulyh6w" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_KWXB8PFMEeOb0bs-xqaPmA" name="SwitchPropertySpec-Pac"/>
+            <packagedElement xmi:type="uml:Class" xmi:id="_ZDdvkPFMEeOb0bs-xqaPmA" name="IngressFcPortSetSpec-Pac"/>
+            <packagedElement xmi:type="uml:AssociationClass" xmi:id="_Q575MBBEEeS-tqfHkf_O5w" name="EgressSwitchSelection" memberEnd="_Q575MRBEEeS-tqfHkf_O5w _Q4JwgBBEEeS-tqfHkf_O5w">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_1OgVMBvOEeSzeoKP7VQE4w" name="setMember" visibility="public">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1OgVMRvOEeSzeoKP7VQE4w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1OgVMhvOEeSzeoKP7VQE4w" value="*"/>
+                <defaultValue xmi:type="uml:LiteralString" xmi:id="_1OgVMxvOEeSzeoKP7VQE4w">
+                  <value xsi:nil="true"/>
+                </defaultValue>
+              </ownedAttribute>
+              <ownedEnd xmi:type="uml:Property" xmi:id="_Q575MRBEEeS-tqfHkf_O5w" name="multiswitcheduniflow" type="_nzCmUMrUEeOt57ZaJqAnzg" association="_Q575MBBEEeS-tqfHkf_O5w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Q575MhBEEeS-tqfHkf_O5w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Q575MxBEEeS-tqfHkf_O5w" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Package" xmi:id="_iXRPEL7VEeSdssyZX-p90g" name="Associations">
+            <packagedElement xmi:type="uml:Association" xmi:id="_DDgt4MrVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow_ingressFcPort_1" memberEnd="_DDgt4crVEeOt57ZaJqAnzg _DDTSgMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_DDgt4crVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow" type="_nzCmUMrUEeOt57ZaJqAnzg" association="_DDgt4MrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DDgt4srVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DDgt48rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_D2uTgMrVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow_egressFcPort_1" memberEnd="_D2uTgcrVEeOt57ZaJqAnzg _D2itUMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_D2uTgcrVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow" type="_nzCmUMrUEeOt57ZaJqAnzg" association="_D2uTgMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_D2uTgsrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_D2uTg8rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_lygcgMrVEeOt57ZaJqAnzg" name="fcSpec_multiSwitchedUniFlow_1" memberEnd="_lygcgcrVEeOt57ZaJqAnzg _lyVdYMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_lygcgcrVEeOt57ZaJqAnzg" name="fcSpec" type="_huOHsMrVEeOt57ZaJqAnzg" association="_lygcgMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lygcgsrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lygcg8rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_rBjUQMrVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow_switchControl_1" memberEnd="_rBjUQcrVEeOt57ZaJqAnzg _rBXuEMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_rBjUQcrVEeOt57ZaJqAnzg" name="multiSwitchedUniFlow" type="_nzCmUMrUEeOt57ZaJqAnzg" association="_rBjUQMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rBjUQsrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rBjUQ8rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_tRgksMrVEeOt57ZaJqAnzg" name="fcSpec_switchControl_1" memberEnd="_tRgkscrVEeOt57ZaJqAnzg _tRU-gMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_tRgkscrVEeOt57ZaJqAnzg" name="fcSpec" type="_huOHsMrVEeOt57ZaJqAnzg" association="_tRgksMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tRgkssrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tRgks8rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_ze8-YMrVEeOt57ZaJqAnzg" name="fcAssemblySpec_switchControl_1" memberEnd="_ze8-YcrVEeOt57ZaJqAnzg _zevjAMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_ze8-YcrVEeOt57ZaJqAnzg" name="fcAssemblySpec" type="_vxoYEMrVEeOt57ZaJqAnzg" association="_ze8-YMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ze8-YsrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ze8-Y8rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_154IsMrVEeOt57ZaJqAnzg" name="fcAssemblySpec_fcSpec_1" memberEnd="_154IscrVEeOt57ZaJqAnzg _15tJkMrVEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_154IscrVEeOt57ZaJqAnzg" name="fcAssemblySpec" type="_vxoYEMrVEeOt57ZaJqAnzg" association="_154IsMrVEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_154IssrVEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_154Is8rVEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_F4ObwMrWEeOt57ZaJqAnzg" name="fcSpec_fcPortSpec_1" memberEnd="_F4ObwcrWEeOt57ZaJqAnzg _F4DcoMrWEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_F4ObwcrWEeOt57ZaJqAnzg" name="fcSpec" type="_huOHsMrVEeOt57ZaJqAnzg" association="_F4ObwMrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_F4ObwsrWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_F4Obw8rWEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_K1zJAMrWEeOt57ZaJqAnzg" name="fcPortSetSpec_ingressFcPortSet_1" memberEnd="_K1zJAcrWEeOt57ZaJqAnzg _K1oJ4MrWEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_K1zJAcrWEeOt57ZaJqAnzg" name="fcPortSetSpec" type="_EL4OsMrWEeOt57ZaJqAnzg" association="_K1zJAMrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_K1zJAsrWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_K1zJA8rWEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_Mq-h8MrWEeOt57ZaJqAnzg" name="fcPortSetSpec_egressPortSet_1" memberEnd="_Mq-h8crWEeOt57ZaJqAnzg _MqxtoMrWEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_Mq-h8crWEeOt57ZaJqAnzg" name="fcPortSetSpec" type="_EL4OsMrWEeOt57ZaJqAnzg" association="_Mq-h8MrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Mq-h8srWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Mq-h88rWEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_eexTsMrWEeOt57ZaJqAnzg" name="switchControl_switchControlRule_1" memberEnd="_eexTscrWEeOt57ZaJqAnzg _eej4UMrWEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_eexTscrWEeOt57ZaJqAnzg" name="switchControl" type="_4MF4YMrUEeOt57ZaJqAnzg" association="_eexTsMrWEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eexTssrWEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eexTs8rWEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_o5aUUMrbEeOt57ZaJqAnzg" name="fcSpec_fcSwitchGroupSpec_1" memberEnd="_o5aUUcrbEeOt57ZaJqAnzg _o5PVMMrbEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_o5aUUcrbEeOt57ZaJqAnzg" name="fcSpec" type="_huOHsMrVEeOt57ZaJqAnzg" association="_o5aUUMrbEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o5aUUsrbEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o5aUU8rbEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_1krGAMrbEeOt57ZaJqAnzg" name="fcPortSetSpec_ltpAssociationRule_1" memberEnd="_1krGAcrbEeOt57ZaJqAnzg _1kdDkMrbEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_1krGAcrbEeOt57ZaJqAnzg" name="fcPortSetSpec" type="_EL4OsMrWEeOt57ZaJqAnzg" association="_1krGAMrbEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1krGAsrbEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1krGA8rbEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_6ZMk8MrbEeOt57ZaJqAnzg" name="fcSwitchGroupSpec_ltpAssociationRule_1" memberEnd="_6ZMk8crbEeOt57ZaJqAnzg _6ZBl0MrbEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_6ZMk8crbEeOt57ZaJqAnzg" name="fcSwitchGroupSpec" type="_vxoYEMrVEeOt57ZaJqAnzg" association="_6ZMk8MrbEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6ZMk8srbEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6ZMk88rbEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_ArUDQMrcEeOt57ZaJqAnzg" name="fcSpec_ltpAssociationRule_1" memberEnd="_ArUDQcrcEeOt57ZaJqAnzg _ArJEIMrcEeOt57ZaJqAnzg">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_ArUDQcrcEeOt57ZaJqAnzg" name="fcSpec" type="_huOHsMrVEeOt57ZaJqAnzg" association="_ArUDQMrcEeOt57ZaJqAnzg">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ArUDQsrcEeOt57ZaJqAnzg" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ArUDQ8rcEeOt57ZaJqAnzg" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_tGsvkM96EeOwEItOulyh6w" name="switchControl_switch_1" memberEnd="_tGsvkc96EeOwEItOulyh6w _tGhwcM96EeOwEItOulyh6w">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_tGsvkc96EeOwEItOulyh6w" name="switchControl" type="_4MF4YMrUEeOt57ZaJqAnzg" association="_tGsvkM96EeOwEItOulyh6w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tGsvks96EeOwEItOulyh6w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tGsvk896EeOwEItOulyh6w" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_rAOFkBBEEeS-tqfHkf_O5w" name="switchControl_egressSelection_1" memberEnd="_rAOFkRBEEeS-tqfHkf_O5w _q_7KoBBEEeS-tqfHkf_O5w">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_rAOFkRBEEeS-tqfHkf_O5w" name="switchControl" type="_4MF4YMrUEeOt57ZaJqAnzg" association="_rAOFkBBEEeS-tqfHkf_O5w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rAOFkhBEEeS-tqfHkf_O5w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rAOFkxBEEeS-tqfHkf_O5w" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_7SNfsAgoEeSbuczmw5yq0A" name="ForwardingConstructHasFcSpec" memberEnd="_7SNfsQgoEeSbuczmw5yq0A _7R-PIAgoEeSbuczmw5yq0A">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_7SNfsQgoEeSbuczmw5yq0A" name="forwardingConstruct" type="_oGqmC1LNEeO75dO39GbF8Q" association="_7SNfsAgoEeSbuczmw5yq0A">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7SNfsggoEeSbuczmw5yq0A"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7SNfswgoEeSbuczmw5yq0A" value="*"/>
+              </ownedEnd>
+            </packagedElement>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Package" xmi:id="_ks0xML7VEeSdssyZX-p90g" name="Diagrams">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_ILMHcMrXEeOt57ZaJqAnzg">
+              <body>Switch will state reversion rules and options and ranges of delays allowed etc. Parameters will be ranges</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_e7qOkMrXEeOt57ZaJqAnzg">
+              <body>Ingress FcPort set will identify range of instances of this FcPort per FC of the type, optional priorities and the roles etc of the FcPort. Also expresses lock-out options.</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_7UvukMrYEeOt57ZaJqAnzg">
+              <body>Fundamental behavior for ingress switch is traffic from ingress selected by switch passes through switchto all egresses.</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_aE2McMreEeOt57ZaJqAnzg">
+              <body>SwitchControl provides control options for the switch and  or switch set and indicates whether the switch can be locked etc.</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_oVtqAMreEeOt57ZaJqAnzg">
+              <body>Rules such as:&#xD;
+- Always on&#xD;
+- No constraint&#xD;
+- If sw1 is on sw2 is null, if sw2 is on sw1 is null &#xD;
+- if sw1 in fcspec x is on then sw1 in fcspec y is off (in fcSwitchGroupSpec)&#xD;
+- if sw1 in fcspec x is selecting FcPortSet a member I then ...&#xD;
+</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_wTm_cMxkEeONyOeN2Mx8mQ">
+              <body>MSUF is essentially the switch!</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_qi9IEMxnEeONyOeN2Mx8mQ">
+              <body>0..1 for con&#xD;
+0..* for conless</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_yX_H0PFMEeOb0bs-xqaPmA">
+              <body>FcSwitchGroupSpec is likely to become scoped by a specific FD</body>
+            </ownedComment>
+            <ownedComment xmi:type="uml:Comment" xmi:id="_f7_1EBBCEeS-tqfHkf_O5w">
+              <body>SwitchControl goes beyond just switching and should really be ConfigurationAndSwitchingControl</body>
+            </ownedComment>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_zpR3MOvTEeOE19T_GJuRHg" name="LtpCapability-Developed">
+          <packagedElement xmi:type="uml:Package" xmi:id="_wokSEGsxEeSf07IfAG7CZg" name="ObjectClasses">
+            <packagedElement xmi:type="uml:Class" xmi:id="_FU2nYBiSEeSh8KVgZCMyDw" name="LpSpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_gQy-gBiUEeSh8KVgZCMyDw" name="_adapterSpec" type="_bJaN8BiUEeSh8KVgZCMyDw" aggregation="composite" association="_gRHHkBiUEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gQy-gRiUEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gQy-ghiUEeSh8KVgZCMyDw" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_stER8BiUEeSh8KVgZCMyDw" name="_terminationSpec" type="_JH4XoBiTEeSh8KVgZCMyDw" aggregation="composite" association="_stRGQBiUEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_stER8RiUEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_stER8hiUEeSh8KVgZCMyDw" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_DYs8YBiVEeSh8KVgZCMyDw" name="_adapterPropertySpecList" type="_OGNS0BiTEeSh8KVgZCMyDw" aggregation="composite" association="_DY7l4BiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DYs8YRiVEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DYs8YhiVEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_KhSoUBiYEeSh8KVgZCMyDw" name="_providerViewSpec" type="_GntusBiYEeSh8KVgZCMyDw" aggregation="composite" association="_Khe1kBiYEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KhSoURiYEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KhSoUhiYEeSh8KVgZCMyDw" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_QIRpgBiZEeSh8KVgZCMyDw" name="_serverSpecList" type="_MVTuMBiZEeSh8KVgZCMyDw" aggregation="composite" association="_QImZoBiZEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QIRpgRiZEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QIRpghiZEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_K6G_sBiSEeSh8KVgZCMyDw" name="ClientSpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_gzlQkBiWEeSh8KVgZCMyDw" name="_mappingInteractionRuleRefList" type="_-M4psBiSEeSh8KVgZCMyDw" association="_gz8c8BiWEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gzlQkRiWEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gzlQkhiWEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_-M4psBiSEeSh8KVgZCMyDw" name="MappingInteractionRule"/>
+            <packagedElement xmi:type="uml:Class" xmi:id="_JH4XoBiTEeSh8KVgZCMyDw" name="TerminationSpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_3I3icBiUEeSh8KVgZCMyDw" name="_connectionSpec" type="_We3KYBiUEeSh8KVgZCMyDw" aggregation="composite" association="_3JNgsBiUEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3I3icRiUEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3I3ichiUEeSh8KVgZCMyDw" value="1"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_OGNS0BiTEeSh8KVgZCMyDw" name="AdapterPropertySpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_Ub4wkBiVEeSh8KVgZCMyDw" name="_poolPropertySpecList" type="_cWBngBiTEeSh8KVgZCMyDw" aggregation="composite" association="_UcKdYBiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ub4wkRiVEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ub4wkhiVEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_izZosBiVEeSh8KVgZCMyDw" name="_mappingInteractionRuleRefList" type="_-M4psBiSEeSh8KVgZCMyDw" association="_izo5QBiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_izZosRiVEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_izZoshiVEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_GuNDIBiWEeSh8KVgZCMyDw" name="_mappingInteractionRuleList" type="_-M4psBiSEeSh8KVgZCMyDw" aggregation="composite" association="_GubFkBiWEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GuNDIRiWEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GuNDIhiWEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_cWBngBiTEeSh8KVgZCMyDw" name="PoolPropertySpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_tYhNQBiVEeSh8KVgZCMyDw" name="_clientSpec" type="_K6G_sBiSEeSh8KVgZCMyDw" aggregation="composite" association="_tYwd0BiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tYhNQRiVEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tYhNQhiVEeSh8KVgZCMyDw" value="1"/>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_BiVlwBiXEeSh8KVgZCMyDw" name="clientCapacity" visibility="public">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FkelgBiXEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Fk41MBiXEeSh8KVgZCMyDw" value="1"/>
+                <defaultValue xmi:type="uml:LiteralString" xmi:id="_FySYABiXEeSh8KVgZCMyDw">
+                  <value xsi:nil="true"/>
+                </defaultValue>
+              </ownedAttribute>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_psjm8BiXEeSh8KVgZCMyDw" name="_adapterPropertySpecRefList" type="_OGNS0BiTEeSh8KVgZCMyDw" association="_ps3wABiXEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_psjm8RiXEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_psjm8hiXEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_We3KYBiUEeSh8KVgZCMyDw" name="ConnectionSpec"/>
+            <packagedElement xmi:type="uml:Class" xmi:id="_bJaN8BiUEeSh8KVgZCMyDw" name="ConnectionPointAndAdapterSpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_RB90QBmOEeSzeoKP7VQE4w" name="_connectionSpec" type="_We3KYBiUEeSh8KVgZCMyDw" association="_RCTLcBmOEeSzeoKP7VQE4w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RB90QRmOEeSzeoKP7VQE4w"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RB90QhmOEeSzeoKP7VQE4w" value="1"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_GntusBiYEeSh8KVgZCMyDw" name="ProviderViewSpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_bc2xkBiYEeSh8KVgZCMyDw" name="_poolPropertySpecList" type="_cWBngBiTEeSh8KVgZCMyDw" association="_bdIeYBiYEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bc2xkRiYEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bc2xkhiYEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Class" xmi:id="_MVTuMBiZEeSh8KVgZCMyDw" name="ServerSpec"/>
+            <packagedElement xmi:type="uml:Class" xmi:id="_BIroQBiaEeSh8KVgZCMyDw" name="LtpSpec">
+              <ownedAttribute xmi:type="uml:Property" xmi:id="_HPhqsBiaEeSh8KVgZCMyDw" name="_lpSpecList" type="_FU2nYBiSEeSh8KVgZCMyDw" isOrdered="true" aggregation="shared" association="_HP3B4BiaEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HPhqsRiaEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HPhqshiaEeSh8KVgZCMyDw" value="*"/>
+              </ownedAttribute>
+            </packagedElement>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Package" xmi:id="_x9rq4GsxEeSf07IfAG7CZg" name="Associations">
+            <packagedElement xmi:type="uml:Association" xmi:id="_gRHHkBiUEeSh8KVgZCMyDw" name="LpSpecHasAdapterSpec" memberEnd="_gRHHkRiUEeSh8KVgZCMyDw _gQy-gBiUEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_gRHHkRiUEeSh8KVgZCMyDw" name="lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_gRHHkBiUEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gRHHkhiUEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gRHHkxiUEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_stRGQBiUEeSh8KVgZCMyDw" name="LpSpecHasTerminationSpec" memberEnd="_stRGQRiUEeSh8KVgZCMyDw _stER8BiUEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_stRGQRiUEeSh8KVgZCMyDw" name="lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_stRGQBiUEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_stRGQhiUEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_stRGQxiUEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_3JNgsBiUEeSh8KVgZCMyDw" name="TerminationSpecHasConnectionSpec" memberEnd="_3JNgsRiUEeSh8KVgZCMyDw _3I3icBiUEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_3JNgsRiUEeSh8KVgZCMyDw" name="terminationSpec" type="_JH4XoBiTEeSh8KVgZCMyDw" association="_3JNgsBiUEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3JNgshiUEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3JNgsxiUEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_DY7l4BiVEeSh8KVgZCMyDw" name="LpSpecAdapterHasPropertySpec" memberEnd="_DY7l4RiVEeSh8KVgZCMyDw _DYs8YBiVEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_DY7l4RiVEeSh8KVgZCMyDw" name="lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_DY7l4BiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DY7l4hiVEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DY7l4xiVEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_UcKdYBiVEeSh8KVgZCMyDw" name="LpSpecHasPoolPropertySpec" memberEnd="_UcLEcBiVEeSh8KVgZCMyDw _Ub4wkBiVEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_UcLEcBiVEeSh8KVgZCMyDw" name="lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_UcKdYBiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UcLEcRiVEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UcLEchiVEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_izo5QBiVEeSh8KVgZCMyDw" name="AdapterPropertySpecConstrainedByMappingInteractionRule" memberEnd="_izo5QRiVEeSh8KVgZCMyDw _izZosBiVEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_izo5QRiVEeSh8KVgZCMyDw" name="adapterPropertySpec" type="_OGNS0BiTEeSh8KVgZCMyDw" association="_izo5QBiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_izo5QhiVEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_izo5QxiVEeSh8KVgZCMyDw" value="*"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_tYwd0BiVEeSh8KVgZCMyDw" name="PoolPropertySpecScalesClientSpec" memberEnd="_tYwd0RiVEeSh8KVgZCMyDw _tYhNQBiVEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_tYwd0RiVEeSh8KVgZCMyDw" name="poolPropertySpec" type="_cWBngBiTEeSh8KVgZCMyDw" association="_tYwd0BiVEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tYwd0hiVEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tYwd0xiVEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_GubFkBiWEeSh8KVgZCMyDw" name="AdapterPropertySpecHasMappingInteractionRule" memberEnd="_GubFkRiWEeSh8KVgZCMyDw _GuNDIBiWEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_GubFkRiWEeSh8KVgZCMyDw" name="adapterPropertySpec" type="_OGNS0BiTEeSh8KVgZCMyDw" association="_GubFkBiWEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GubFkhiWEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GubFkxiWEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_gz8c8BiWEeSh8KVgZCMyDw" name="PoolPropertySpecAffectedByMappingInteractionRule" memberEnd="_gz8c8RiWEeSh8KVgZCMyDw _gzlQkBiWEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_gz8c8RiWEeSh8KVgZCMyDw" name="poolPropertySpec" type="_cWBngBiTEeSh8KVgZCMyDw" association="_gz8c8BiWEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gz8c8hiWEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gz8c8xiWEeSh8KVgZCMyDw" value="*"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_ps3wABiXEeSh8KVgZCMyDw" name="PoolPropertySpecGovernedByAdapterPropertySpec" memberEnd="_ps3wARiXEeSh8KVgZCMyDw _psjm8BiXEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_ps3wARiXEeSh8KVgZCMyDw" name="poolPropertySpec" type="_cWBngBiTEeSh8KVgZCMyDw" association="_ps3wABiXEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ps3wAhiXEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ps3wAxiXEeSh8KVgZCMyDw" value="*"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_Khe1kBiYEeSh8KVgZCMyDw" name="LpSpecHasProviderViewSpec" memberEnd="_Khe1kRiYEeSh8KVgZCMyDw _KhSoUBiYEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_Khe1kRiYEeSh8KVgZCMyDw" name="lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_Khe1kBiYEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Khe1khiYEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Khe1kxiYEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_bdIeYBiYEeSh8KVgZCMyDw" name="ProviderViewSpecGivesRiseToPoolPropertySpec" memberEnd="_bdIeYRiYEeSh8KVgZCMyDw _bc2xkBiYEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_bdIeYRiYEeSh8KVgZCMyDw" name="providerViewSpec" type="_GntusBiYEeSh8KVgZCMyDw" association="_bdIeYBiYEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bdIeYhiYEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bdIeYxiYEeSh8KVgZCMyDw" value="*"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_QImZoBiZEeSh8KVgZCMyDw" name="LpSpecHasServerSpec" memberEnd="_QImZoRiZEeSh8KVgZCMyDw _QIRpgBiZEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_QImZoRiZEeSh8KVgZCMyDw" name="lpSpec" type="_FU2nYBiSEeSh8KVgZCMyDw" association="_QImZoBiZEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QImZohiZEeSh8KVgZCMyDw" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QImZoxiZEeSh8KVgZCMyDw" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_HP3B4BiaEeSh8KVgZCMyDw" name="LtpSpecArrangesLpSpec" memberEnd="_HP3B4RiaEeSh8KVgZCMyDw _HPhqsBiaEeSh8KVgZCMyDw">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_HP3B4RiaEeSh8KVgZCMyDw" name="ltpSpec" type="_BIroQBiaEeSh8KVgZCMyDw" association="_HP3B4BiaEeSh8KVgZCMyDw">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HP3B4hiaEeSh8KVgZCMyDw"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HP3B4xiaEeSh8KVgZCMyDw" value="*"/>
+              </ownedEnd>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Association" xmi:id="_RCTLcBmOEeSzeoKP7VQE4w" name="ConnectionPointAndAdapterSpecHasConnectionSpec" memberEnd="_RCTLcRmOEeSzeoKP7VQE4w _RB90QBmOEeSzeoKP7VQE4w">
+              <ownedEnd xmi:type="uml:Property" xmi:id="_RCTLcRmOEeSzeoKP7VQE4w" name="connectionPointAndAdapterSpec" type="_bJaN8BiUEeSh8KVgZCMyDw" association="_RCTLcBmOEeSzeoKP7VQE4w">
+                <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RCTLchmOEeSzeoKP7VQE4w" value="1"/>
+                <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RCTLcxmOEeSzeoKP7VQE4w" value="1"/>
+              </ownedEnd>
+            </packagedElement>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Package" xmi:id="_y8I3MGsxEeSf07IfAG7CZg" name="Diagrams"/>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_4aFTwOvTEeOE19T_GJuRHg" name="ForwardingDomainCapability"/>
+        <packagedElement xmi:type="uml:Package" xmi:id="_gPeu4BifEeSh8KVgZCMyDw" name="LinkCapability-Sketch">
+          <packagedElement xmi:type="uml:Class" xmi:id="_-Npr4KNREeS9Obpdy8FCjA" name="LinkSpec">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_q3ZmoLA7EeSXJ6XI-2nsRw">
+              <body>Describes the capabilities of the Link focussing on link asymmetries and constraints.</body>
+            </ownedComment>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_DjpgMKNSEeS9Obpdy8FCjA" name="LinkHasLinkSpec" memberEnd="_DjpgMaNSEeS9Obpdy8FCjA _DjfvMKNSEeS9Obpdy8FCjA">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_DjpgMaNSEeS9Obpdy8FCjA" name="link" type="_oGqnjVLNEeO75dO39GbF8Q" association="_DjpgMKNSEeS9Obpdy8FCjA">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_DjpgMqNSEeS9Obpdy8FCjA"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_DjpgM6NSEeS9Obpdy8FCjA" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Package" xmi:id="_KjlfMJgMEeSjhfRBVH9_gQ" name="SpecAndProfile-Sketch">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yIySUJgNEeSjhfRBVH9_gQ">
+            <body>Class from core model etc</body>
+          </ownedComment>
+          <packagedElement xmi:type="uml:Class" xmi:id="_frIgsJgMEeSjhfRBVH9_gQ" name="AnyEntityInstance">
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_pKuAkJgMEeSjhfRBVH9_gQ" name="_profileRefList" type="_hXvMcJgMEeSjhfRBVH9_gQ" association="_pK3KgJgMEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pKuAkZgMEeSjhfRBVH9_gQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pKuAkpgMEeSjhfRBVH9_gQ" value="*"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="__XgL0JgMEeSjhfRBVH9_gQ" name="_specRef" type="_6l-WgJgMEeSjhfRBVH9_gQ" association="__XpVwJgMEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__XgL0ZgMEeSjhfRBVH9_gQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__XgL0pgMEeSjhfRBVH9_gQ" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_OunqUJgOEeSjhfRBVH9_gQ" name="_class" type="_Du1jAJgOEeSjhfRBVH9_gQ" association="_Ouw0QJgOEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OunqUZgOEeSjhfRBVH9_gQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OunqUpgOEeSjhfRBVH9_gQ" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_hXvMcJgMEeSjhfRBVH9_gQ" name="ProfileInstance">
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_blJtUJgNEeSjhfRBVH9_gQ" name="_specInstanceRef" type="_6l-WgJgMEeSjhfRBVH9_gQ" association="_blS3QJgNEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_blJtUZgNEeSjhfRBVH9_gQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_blJtUpgNEeSjhfRBVH9_gQ" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_ta7icJgVEeSeO5hX75xH1g" name="_profileClass" type="_j2VmwJgVEeSeO5hX75xH1g" association="_tbEFUJgVEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ta7icZgVEeSeO5hX75xH1g" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ta7icpgVEeSeO5hX75xH1g" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_1nVtwJgWEeSeO5hX75xH1g" name="_class" type="_Du1jAJgOEeSjhfRBVH9_gQ" association="_1nfewJgWEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1nVtwZgWEeSeO5hX75xH1g" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1nVtwpgWEeSeO5hX75xH1g" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_pK3KgJgMEeSjhfRBVH9_gQ" name="EntityInstanceBehaviorConstrainedByProfile" memberEnd="_pK3KgZgMEeSjhfRBVH9_gQ _pKuAkJgMEeSjhfRBVH9_gQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_pK3KgZgMEeSjhfRBVH9_gQ" name="entity" type="_frIgsJgMEeSjhfRBVH9_gQ" association="_pK3KgJgMEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pK3KgpgMEeSjhfRBVH9_gQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pK3Kg5gMEeSjhfRBVH9_gQ" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_6l-WgJgMEeSjhfRBVH9_gQ" name="SpecInstance">
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_PM8TIJgQEeSeO5hX75xH1g" name="specClass" type="_CqTR8JgQEeSeO5hX75xH1g" association="_PNGEIJgQEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PM8TIZgQEeSeO5hX75xH1g" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PM8TIpgQEeSeO5hX75xH1g" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_XymSoJgWEeSeO5hX75xH1g" name="_classRef" type="_Du1jAJgOEeSjhfRBVH9_gQ" association="_XyxRwJgWEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XymSoZgWEeSeO5hX75xH1g" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XymSopgWEeSeO5hX75xH1g" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="__XpVwJgMEeSjhfRBVH9_gQ" name="EntityInstaneCapabilityConstrainedBySpecInstance" memberEnd="__XpVwZgMEeSjhfRBVH9_gQ __XgL0JgMEeSjhfRBVH9_gQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="__XpVwZgMEeSjhfRBVH9_gQ" name="entity" type="_frIgsJgMEeSjhfRBVH9_gQ" association="__XpVwJgMEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__XpVwpgMEeSjhfRBVH9_gQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__XpVw5gMEeSjhfRBVH9_gQ" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_blS3QJgNEeSjhfRBVH9_gQ" name="ProfileAbidesBySpecInstanceThatConstrainsTheEntityToWhichThisProfileApplies" memberEnd="_blS3QZgNEeSjhfRBVH9_gQ _blJtUJgNEeSjhfRBVH9_gQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_blS3QZgNEeSjhfRBVH9_gQ" name="profile" type="_hXvMcJgMEeSjhfRBVH9_gQ" association="_blS3QJgNEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_blS3QpgNEeSjhfRBVH9_gQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_blS3Q5gNEeSjhfRBVH9_gQ" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_Du1jAJgOEeSjhfRBVH9_gQ" name="AnyEntityClass"/>
+          <packagedElement xmi:type="uml:Association" xmi:id="_Ouw0QJgOEeSjhfRBVH9_gQ" name="EntityInstanceConformsToClass" memberEnd="_Ouw0QZgOEeSjhfRBVH9_gQ _OunqUJgOEeSjhfRBVH9_gQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_Ouw0QZgOEeSjhfRBVH9_gQ" name="entity" type="_frIgsJgMEeSjhfRBVH9_gQ" association="_Ouw0QJgOEeSjhfRBVH9_gQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ouw0QpgOEeSjhfRBVH9_gQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ouw0Q5gOEeSjhfRBVH9_gQ" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_CqTR8JgQEeSeO5hX75xH1g" name="SpecClass">
+            <generalization xmi:type="uml:Generalization" xmi:id="_GKgCQJgQEeSeO5hX75xH1g" general="_Du1jAJgOEeSjhfRBVH9_gQ"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_PNGEIJgQEeSeO5hX75xH1g" name="SpecEntityInstanceConformsToSpecClass" memberEnd="_PNGEIZgQEeSeO5hX75xH1g _PM8TIJgQEeSeO5hX75xH1g">
+            <generalization xmi:type="uml:Generalization" xmi:id="_HSBcQJgWEeSeO5hX75xH1g" general="_Ouw0QJgOEeSjhfRBVH9_gQ"/>
+            <ownedEnd xmi:type="uml:Property" xmi:id="_PNGEIZgQEeSeO5hX75xH1g" name="spec" type="_6l-WgJgMEeSjhfRBVH9_gQ" association="_PNGEIJgQEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_PNGEIpgQEeSeO5hX75xH1g"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_PNGEI5gQEeSeO5hX75xH1g" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_j2VmwJgVEeSeO5hX75xH1g" name="ProfileClass">
+            <generalization xmi:type="uml:Generalization" xmi:id="_oX1cAJgVEeSeO5hX75xH1g" general="_Du1jAJgOEeSjhfRBVH9_gQ"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_tbEFUJgVEeSeO5hX75xH1g" name="ProfileInstanceConformsToProfileClass" memberEnd="_tbEFUZgVEeSeO5hX75xH1g _ta7icJgVEeSeO5hX75xH1g">
+            <generalization xmi:type="uml:Generalization" xmi:id="_JhTXQJgWEeSeO5hX75xH1g" general="_Ouw0QJgOEeSjhfRBVH9_gQ"/>
+            <ownedEnd xmi:type="uml:Property" xmi:id="_tbEFUZgVEeSeO5hX75xH1g" name="profile" type="_hXvMcJgMEeSjhfRBVH9_gQ" association="_tbEFUJgVEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tbEFUpgVEeSeO5hX75xH1g"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tbEFU5gVEeSeO5hX75xH1g" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_XyxRwJgWEeSeO5hX75xH1g" name="SpecInstaceAbidesByClassOfEntityInstanceToWhichItApplies" memberEnd="_XyxRwZgWEeSeO5hX75xH1g _XymSoJgWEeSeO5hX75xH1g">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_XyxRwZgWEeSeO5hX75xH1g" name="specInstance" type="_6l-WgJgMEeSjhfRBVH9_gQ" association="_XyxRwJgWEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XyxRwpgWEeSeO5hX75xH1g"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XyxRw5gWEeSeO5hX75xH1g" value="*"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_1nfewJgWEeSeO5hX75xH1g" name="ProfileInstaceAbidesByClassOfEntityInstanceToWhichItApplies" memberEnd="_1nfewZgWEeSeO5hX75xH1g _1nVtwJgWEeSeO5hX75xH1g">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_1nfewZgWEeSeO5hX75xH1g" name="profileInstance" type="_hXvMcJgMEeSjhfRBVH9_gQ" association="_1nfewJgWEeSeO5hX75xH1g">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1nfewpgWEeSeO5hX75xH1g" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1nfew5gWEeSeO5hX75xH1g" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_XdSnYCOeEeSoB4Ln_aUF6w" name="CoreModelComments">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_88knQCIoEeSoB4Ln_aUF6w" annotatedElement="_oGqnzVLNEeO75dO39GbF8Q">
+          <body>Need to discuss the NCD grouping of Links as opposed to always an FD. Suggest that Top Level FD eliminates some of the need but there are off-network links (i.e. NcdAccessLinks) that are clearly NOT in a FD visible to the NCD. Could however argue that there is an FD fragment that groups the links and hence not need the NCD.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_1fi3cBfUEeSh8KVgZCMyDw" annotatedElement="_2EZj8FYkEeOVGaP4lO41SQ">
+          <body> Should be server and actual layer... For discussion</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_xQdisOv0EeOE19T_GJuRHg" annotatedElement="_eEpDMFX4EeOVGaP4lO41SQ">
+          <body>Need to determine depth of physical model required.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_HDYBUCRcEeSaIcETw2aroA" annotatedElement="_3ZB88FYWEeOVGaP4lO41SQ">
+          <body>Should we highlight distinction between associations that represent information flow in the network and those that represent other things?</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_1R3MsCRJEeSaIcETw2aroA" name="ModelingEnhancements">
+        <packagedElement xmi:type="uml:Package" xmi:id="_6G0SACbREeSaIcETw2aroA" name="Rules">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jUcAACRYEeSaIcETw2aroA" annotatedElement="_2EZj8FYkEeOVGaP4lO41SQ">
+            <body>MuiltipleFd:&#xD;
+- LayerProtcols (one per layerProtocol)&#xD;
+- FdLevels (one per Level)&#xD;
+- Views (one per view)</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_OX7UYCRZEeSaIcETw2aroA" annotatedElement="_wZJrYCPHEeSoB4Ln_aUF6w">
+            <body>Replace with alternativeNavigation rule structure. BUT note that name is not ideal as this is really trying to emphasize a model constraint rather than a model use .&#xD;
+For each FcPort, if there is an FcSwitch it will be in the same FC as the FcPort. OR For each FcSwitch the FcPorts that it references Must be in the same FC as the FcSwitch.</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5W8_gCRZEeSaIcETw2aroA" annotatedElement="_Ixb_8FYnEeOVGaP4lO41SQ">
+            <body>Multiple Ltp&#xD;
+- Bidirectional FcPort to two Uni Ltps&#xD;
+Zero Ltp&#xD;
+- BreakBeforeMake transition (not good reason for zero)&#xD;
+- Planned Ltp not yet in place</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5FqlwCRaEeSaIcETw2aroA">
+            <body>All self composition and self aggregation are noLoop unless otherwise stated.</body>
+          </ownedComment>
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Kf4Z4CRbEeSaIcETw2aroA" annotatedElement="_oGqnx1LNEeO75dO39GbF8Q">
+            <body> This appears wrong - should be aggregation and should be 1..2? Need to work the NE and NCD more.</body>
+          </ownedComment>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_wZJrYCPHEeSoB4Ln_aUF6w" name="FcStructure" constrainedElement="_d_lncFYhEeOVGaP4lO41SQ _2QhSUI8lEeOw_ste-s6RrA _gqbSgFYgEeOVGaP4lO41SQ _OX7UYCRZEeSaIcETw2aroA">
+            <specification xmi:type="uml:LiteralString" xmi:id="_wpChgCPHEeSoB4Ln_aUF6w" value="loop"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_hIFr8CRSEeSaIcETw2aroA" name="FcRoute" constrainedElement="_A8YzcFYgEeOVGaP4lO41SQ _Cakh4FaSEeOVGaP4lO41SQ">
+            <specification xmi:type="uml:LiteralString" xmi:id="_hIhw0CRSEeSaIcETw2aroA" value="noLoop"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_kvovgCRUEeSaIcETw2aroA" name="LinkFd" constrainedElement="_dnWM0BiQEeSh8KVgZCMyDw _oGqnu1LNEeO75dO39GbF8Q">
+            <specification xmi:type="uml:LiteralString" xmi:id="_kwE0YCRUEeSaIcETw2aroA" value="noLoop"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_QdM7oCRVEeSaIcETw2aroA" name="LtpFdLinkNavigation" constrainedElement="_ZsqU0CRVEeSaIcETw2aroA _1dBdYCRVEeSaIcETw2aroA _eqfO0CRXEeSaIcETw2aroA">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_eqfO0CRXEeSaIcETw2aroA" annotatedElement="_QdM7oCRVEeSaIcETw2aroA">
+              <body>For any specific Ltp for each instances of NavigationLtpToLinkViaFd there will be a corresponding instance of NavigationLtpToLinkViaLinkPort that reaches the same Link. There will be no duplicates.</body>
+            </ownedComment>
+            <specification xmi:type="uml:LiteralString" xmi:id="_QdpnkCRVEeSaIcETw2aroA" value="alternativeNavigation"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_ZsqU0CRVEeSaIcETw2aroA" name="NavigationLtpToLinkViaFd" constrainedElement="_2EZj8FYkEeOVGaP4lO41SQ _oGqnu1LNEeO75dO39GbF8Q">
+            <specification xmi:type="uml:LiteralString" xmi:id="_ZtFyoCRVEeSaIcETw2aroA" value="reverseNavigation"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_1dBdYCRVEeSaIcETw2aroA" name="NavigationLtpToLinkViaLinkPort" constrainedElement="_oGqnwVLNEeO75dO39GbF8Q _buzL4BNjEeS1heseQTA6lw">
+            <specification xmi:type="uml:LiteralString" xmi:id="_1deJUCRVEeSaIcETw2aroA" value="reverseNavigation"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_QBaoYCeTEeSiY-Znd5RVtA" name="LinkToLtp" constrainedElement="_eEpDMFX4EeOVGaP4lO41SQ _oGqnjVLNEeO75dO39GbF8Q _2EZj8FYkEeOVGaP4lO41SQ _buzL4BNjEeS1heseQTA6lw _oGqnwVLNEeO75dO39GbF8Q _oGqnu1LNEeO75dO39GbF8Q _f_9d0CeVEeSiY-Znd5RVtA">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_f_9d0CeVEeSiY-Znd5RVtA">
+              <body>For any specific Link for each navigation via Le to Ltp there will be a navigation via Fd to the same Ltp.</body>
+            </ownedComment>
+            <specification xmi:type="uml:LiteralString" xmi:id="_QCGk4CeTEeSiY-Znd5RVtA" value="alternativeNavigation"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_r7fGkCeTEeSiY-Znd5RVtA" name="FcSwitchToFc" constrainedElement="_a97NQFYhEeOVGaP4lO41SQ _d_lncFYhEeOVGaP4lO41SQ _2QhSUI8lEeOw_ste-s6RrA _gqbSgFYgEeOVGaP4lO41SQ _oGqmC1LNEeO75dO39GbF8Q _dZoxQCeUEeSiY-Znd5RVtA">
+            <ownedComment xmi:type="uml:Comment" xmi:id="_dZoxQCeUEeSiY-Znd5RVtA">
+              <body>For each FcSwitch the FcPorts that it references Must be in the same FC as the FcSwitch.</body>
+            </ownedComment>
+            <specification xmi:type="uml:LiteralString" xmi:id="_r7_c4CeTEeSiY-Znd5RVtA" value="alternativeNavigation"/>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Constraint" xmi:id="_79te4J2FEeSQBuaNnP_LbA" name="FdEncompassesFdsAndLinks" constrainedElement="_oGqoD1LNEeO75dO39GbF8Q _dnWM0BiQEeSh8KVgZCMyDw">
+            <specification xmi:type="uml:LiteralString" xmi:id="_79_ywJ2FEeSQBuaNnP_LbA" value="Encompassed links and ForwardingDomains form a mesh"/>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_lyJ8sE-nEeSGXqgORzeAvQ" name="CoreOamModule"/>
+      <packagedElement xmi:type="uml:Package" xmi:id="_15jvAE-wEeSGXqgORzeAvQ" name="CoreManagementControlComponentModule"/>
+      <packagedElement xmi:type="uml:Package" xmi:id="_DckcAL7WEeSdssyZX-p90g" name="ViewAbstractionRule-Sketch">
+        <packagedElement xmi:type="uml:Class" xmi:id="_9bj8oBihEeSh8KVgZCMyDw" name="ViewAbstractionRules">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_9XvPAGaKEeWrX_JIGzXlSg" annotatedElement="_9bj8oBihEeSh8KVgZCMyDw">
+            <body>Provides rules and access to policies that govern and explain the view abstraction.&#xD;
+At this point it appears that this is not necessary however it has been left in the model as there is still some view abstraction work to be done.</body>
+          </ownedComment>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_-VM6YBihEeSh8KVgZCMyDw" name="__ltpRelatestToLtpInOtherView" type="_vrCogBigEeSh8KVgZCMyDw" association="_-VhDcBihEeSh8KVgZCMyDw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-VM6YRihEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-VM6YhihEeSh8KVgZCMyDw" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_-VhDcBihEeSh8KVgZCMyDw" name="ViewAbstractionRuleExplainssHowLtpRelatestToLtpInOtherView" memberEnd="_-VhDcRihEeSh8KVgZCMyDw _-VM6YBihEeSh8KVgZCMyDw">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_-VhDcRihEeSh8KVgZCMyDw" name="viewAbstractionRule" type="_9bj8oBihEeSh8KVgZCMyDw" association="_-VhDcBihEeSh8KVgZCMyDw">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-VhDchihEeSh8KVgZCMyDw"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-VhDcxihEeSh8KVgZCMyDw" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Rt55IKT3EeS9Obpdy8FCjA" name="LinkEncompassesLink" memberEnd="_Rt55IaT3EeS9Obpdy8FCjA _RtwvMKT3EeS9Obpdy8FCjA">
+          <ownedEnd xmi:type="uml:Property" xmi:id="_Rt55IaT3EeS9Obpdy8FCjA" name="link" type="_oGqnjVLNEeO75dO39GbF8Q" association="_Rt55IKT3EeS9Obpdy8FCjA">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rt55IqT3EeS9Obpdy8FCjA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rt55I6T3EeS9Obpdy8FCjA" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_EI7mABjCEeSzeoKP7VQE4w" name="InformationArchitectureAndPatterns">
+        <packagedElement xmi:type="uml:Package" xmi:id="_wo4dMFZ2EeOVGaP4lO41SQ" name="EssentialStructure-Sketch">
+          <packagedElement xmi:type="uml:Class" xmi:id="_3AVHcFZ2EeOVGaP4lO41SQ" name="Component">
+            <ownedAttribute xmi:type="uml:Property" xmi:id="__olWsFZ2EeOVGaP4lO41SQ" name="_port" type="_5GhX4FZ2EeOVGaP4lO41SQ" aggregation="composite" association="__otSgFZ2EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__olWsVZ2EeOVGaP4lO41SQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__olWslZ2EeOVGaP4lO41SQ" value="*"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_Qoxr0FZ4EeOVGaP4lO41SQ" name="_attributePackageList" type="_MZH0gFZ4EeOVGaP4lO41SQ" aggregation="composite" association="_Qo8q8FZ4EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Qoxr0VZ4EeOVGaP4lO41SQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Qoxr0lZ4EeOVGaP4lO41SQ" value="*"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_jCspcFZ4EeOVGaP4lO41SQ" name="_boundComponent" type="_3AVHcFZ2EeOVGaP4lO41SQ" association="_jC1MUFZ4EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jCspcVZ4EeOVGaP4lO41SQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jCspclZ4EeOVGaP4lO41SQ" value="1"/>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_c1f1cFZ6EeOVGaP4lO41SQ" name="_encapsulatedSystem" type="_VZ3RsFZ3EeOVGaP4lO41SQ" association="_c1o_YFZ6EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c1f1cVZ6EeOVGaP4lO41SQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c1f1clZ6EeOVGaP4lO41SQ" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_5GhX4FZ2EeOVGaP4lO41SQ" name="Port">
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_LXPWMFZ3EeOVGaP4lO41SQ" name="Role" visibility="public">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Mx0d0FZ3EeOVGaP4lO41SQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MyGKoFZ3EeOVGaP4lO41SQ" value="1"/>
+              <defaultValue xmi:type="uml:LiteralString" xmi:id="_Myt1sFZ3EeOVGaP4lO41SQ">
+                <value xsi:nil="true"/>
+              </defaultValue>
+            </ownedAttribute>
+            <ownedAttribute xmi:type="uml:Property" xmi:id="_S4YzcFZ3EeOVGaP4lO41SQ" name="_boundPort" type="_5GhX4FZ2EeOVGaP4lO41SQ" association="_S4h9YFZ3EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_S4YzcVZ3EeOVGaP4lO41SQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_S4YzclZ3EeOVGaP4lO41SQ" value="1"/>
+            </ownedAttribute>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="__otSgFZ2EeOVGaP4lO41SQ" name="ComponentHasPorts" memberEnd="__otSgVZ2EeOVGaP4lO41SQ __olWsFZ2EeOVGaP4lO41SQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="__otSgVZ2EeOVGaP4lO41SQ" name="component" type="_3AVHcFZ2EeOVGaP4lO41SQ" association="__otSgFZ2EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__otSglZ2EeOVGaP4lO41SQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__otSg1Z2EeOVGaP4lO41SQ" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_S4h9YFZ3EeOVGaP4lO41SQ" name="FcPortBindsToFcPort" memberEnd="_S4h9YVZ3EeOVGaP4lO41SQ _S4YzcFZ3EeOVGaP4lO41SQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_S4h9YVZ3EeOVGaP4lO41SQ" name="_bindingPort" type="_5GhX4FZ2EeOVGaP4lO41SQ" association="_S4h9YFZ3EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_S4h9YlZ3EeOVGaP4lO41SQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_S4h9Y1Z3EeOVGaP4lO41SQ" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Class" xmi:id="_VZ3RsFZ3EeOVGaP4lO41SQ" name="System"/>
+          <packagedElement xmi:type="uml:Class" xmi:id="_MZH0gFZ4EeOVGaP4lO41SQ" name="AttributePackage"/>
+          <packagedElement xmi:type="uml:Association" xmi:id="_Qo8q8FZ4EeOVGaP4lO41SQ" name="ComponentHasConditionalAttributes" memberEnd="_Qo8q8VZ4EeOVGaP4lO41SQ _Qoxr0FZ4EeOVGaP4lO41SQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_Qo8q8VZ4EeOVGaP4lO41SQ" name="component" type="_3AVHcFZ2EeOVGaP4lO41SQ" association="_Qo8q8FZ4EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Qo8q8lZ4EeOVGaP4lO41SQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Qo8q81Z4EeOVGaP4lO41SQ" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_jC1MUFZ4EeOVGaP4lO41SQ" name="ComponentBindsToComponent" memberEnd="_jC1MUVZ4EeOVGaP4lO41SQ _jCspcFZ4EeOVGaP4lO41SQ">
+            <generalization xmi:type="uml:Generalization" xmi:id="_0rt5IFZ5EeOVGaP4lO41SQ" general="_S4h9YFZ3EeOVGaP4lO41SQ">
+              <ownedComment xmi:type="uml:Comment" xmi:id="_GiaN4FZ6EeOVGaP4lO41SQ">
+                <body>Is compact form of general case</body>
+              </ownedComment>
+            </generalization>
+            <ownedEnd xmi:type="uml:Property" xmi:id="_jC1MUVZ4EeOVGaP4lO41SQ" name="_bindingComponent" type="_3AVHcFZ2EeOVGaP4lO41SQ" association="_jC1MUFZ4EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jC1MUlZ4EeOVGaP4lO41SQ"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jC1MU1Z4EeOVGaP4lO41SQ" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+          <packagedElement xmi:type="uml:Association" xmi:id="_c1o_YFZ6EeOVGaP4lO41SQ" name="ComponentIsViewOfEncapsulatedSystem" memberEnd="_c1o_YVZ6EeOVGaP4lO41SQ _c1f1cFZ6EeOVGaP4lO41SQ">
+            <ownedEnd xmi:type="uml:Property" xmi:id="_c1o_YVZ6EeOVGaP4lO41SQ" name="_encapsulatingComponent" type="_3AVHcFZ2EeOVGaP4lO41SQ" association="_c1o_YFZ6EeOVGaP4lO41SQ">
+              <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c1o_YlZ6EeOVGaP4lO41SQ" value="1"/>
+              <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c1o_Y1Z6EeOVGaP4lO41SQ" value="1"/>
+            </ownedEnd>
+          </packagedElement>
+        </packagedElement>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Package" xmi:id="_5dOpYFYEEeW5zoktRlwOmg" name="InterViewRelationships-Sketch">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_VPMpkFYHEeW5zoktRlwOmg">
+          <body>Should be more of an &quot;is&quot; statement</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_2WrLUFYIEeW5zoktRlwOmg">
+          <body>Only relates real things... Base XC and nodal LTP</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_5FqrsFYJEeW5zoktRlwOmg">
+          <body>Only applicable where there is a strict relationship that needs to be (is allowed to be) displayed</body>
+        </ownedComment>
+        <packagedElement xmi:type="uml:Class" xmi:id="_HvUO8FYFEeW5zoktRlwOmg" name="Sketch::FC">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_nbURMFYGEeW5zoktRlwOmg" name="_supportingFcInOtherViewRef" type="_HvUO8FYFEeW5zoktRlwOmg" association="_nbScAFYGEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1XlQYFYJEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1Xph0FYJEeW5zoktRlwOmg" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_GkqHwFYHEeW5zoktRlwOmg" name="_suportedFcInOtherView" type="_HvUO8FYFEeW5zoktRlwOmg" association="_Gko5oFYHEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_n5ZCYFYIEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_n5cFsFYIEeW5zoktRlwOmg" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Class" xmi:id="_JAQSYFYFEeW5zoktRlwOmg" name="Sketch::LTP">
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_QsLcQVYFEeW5zoktRlwOmg" name="_supportingLtpInOtherViewRef" type="_JAQSYFYFEeW5zoktRlwOmg" association="_QsIY8FYFEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gmdHoFYFEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_gminMFYFEeW5zoktRlwOmg" value="1"/>
+          </ownedAttribute>
+          <ownedAttribute xmi:type="uml:Property" xmi:id="_i38pIFYFEeW5zoktRlwOmg" name="_supportedLtpInOtherViewRef" type="_JAQSYFYFEeW5zoktRlwOmg" association="_i37bAFYFEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__eUhwFYHEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__eYMIFYHEeW5zoktRlwOmg" value="*"/>
+          </ownedAttribute>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_QsIY8FYFEeW5zoktRlwOmg" name="LtpSupportedByLtpInOtherView" memberEnd="_QsK1MFYFEeW5zoktRlwOmg _QsLcQVYFEeW5zoktRlwOmg">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QsKOIFYFEeW5zoktRlwOmg" source="org.eclipse.papyrus">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QsKOIVYFEeW5zoktRlwOmg" key="nature" value="UML_Nature"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_QsK1MFYFEeW5zoktRlwOmg" name="sketch::ltp" type="_JAQSYFYFEeW5zoktRlwOmg" association="_QsIY8FYFEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cqIKEFYHEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cqKmUFYHEeW5zoktRlwOmg" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_i37bAFYFEeW5zoktRlwOmg" name="LtpSupportsLtpInOtherView" memberEnd="_i38CEVYFEeW5zoktRlwOmg _i38pIFYFEeW5zoktRlwOmg">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_i37bAVYFEeW5zoktRlwOmg" source="org.eclipse.papyrus">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_i38CEFYFEeW5zoktRlwOmg" key="nature" value="UML_Nature"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_i38CEVYFEeW5zoktRlwOmg" name="sketch::ltp" type="_JAQSYFYFEeW5zoktRlwOmg" association="_i37bAFYFEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yGsrQFYFEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yGugcFYFEeW5zoktRlwOmg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_nbScAFYGEeW5zoktRlwOmg" name="FcSupportedByFcInOtherView" memberEnd="_nbTDEVYGEeW5zoktRlwOmg _nbURMFYGEeW5zoktRlwOmg">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nbScAVYGEeW5zoktRlwOmg" source="org.eclipse.papyrus">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nbTDEFYGEeW5zoktRlwOmg" key="nature" value="UML_Nature"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_nbTDEVYGEeW5zoktRlwOmg" name="sketch::fc" type="_HvUO8FYFEeW5zoktRlwOmg" association="_nbScAFYGEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rVTvoFYIEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rVWL4FYIEeW5zoktRlwOmg" value="*"/>
+          </ownedEnd>
+        </packagedElement>
+        <packagedElement xmi:type="uml:Association" xmi:id="_Gko5oFYHEeW5zoktRlwOmg" name="FcSupportsFcInOtherView" memberEnd="_GkpgslYHEeW5zoktRlwOmg _GkqHwFYHEeW5zoktRlwOmg">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_GkpgsFYHEeW5zoktRlwOmg" source="org.eclipse.papyrus">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_GkpgsVYHEeW5zoktRlwOmg" key="nature" value="UML_Nature"/>
+          </eAnnotations>
+          <ownedEnd xmi:type="uml:Property" xmi:id="_GkpgslYHEeW5zoktRlwOmg" name="sketch::fc" type="_HvUO8FYFEeW5zoktRlwOmg" association="_Gko5oFYHEeW5zoktRlwOmg">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_o8zKsFYJEeW5zoktRlwOmg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_o83cIFYJEeW5zoktRlwOmg" value="1"/>
+          </ownedEnd>
+        </packagedElement>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_kr10UEDrEeWHCPNn7aoIVw" name="ExplanatoryFiguresUsedIndDocumentsAndSlides"/>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_g738cPHhEeWwSoymEK8fCg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IC5i2h32EeaVEcfXx-aEqQ" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IC5i2x32EeaVEcfXx-aEqQ" key="Version" value="0.2.3"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IC5i3B32EeaVEcfXx-aEqQ" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IC5i3R32EeaVEcfXx-aEqQ" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IC5i3h32EeaVEcfXx-aEqQ" key="Date" value="2016-05-19"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IC5i3x32EeaVEcfXx-aEqQ" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_g738cfHhEeWwSoymEK8fCg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="OpenModel_Profile.profile.uml#_pvGcUTNuEea0Br-ajMxp_A"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Package>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FVmzwKNXEeS9Obpdy8FCjA" base_StructuralFeature="_FVmMsKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_x0nQ4KyMEeS5HuAudtqItw" base_Element="_FVmMsKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HVLe0aNXEeS9Obpdy8FCjA" base_StructuralFeature="_HVLe0KNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_1buhgKyMEeS5HuAudtqItw" base_Element="_HVLe0KNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_SI-YgaQbEeS9Obpdy8FCjA" base_StructuralFeature="_SI-YgKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_3anQEKyMEeS5HuAudtqItw" base_Element="_SI-YgKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kv5iQaQZEeS9Obpdy8FCjA" base_StructuralFeature="_kv5iQKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pVOuoKQZEeS9Obpdy8FCjA" base_StructuralFeature="_pVOHkKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_JsreoK4AEeSXJ6XI-2nsRw" base_StructuralFeature="_Jsq3kK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_K2XlAL7fEeSdssyZX-p90g" base_Element="_Jsq3kK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cF5RoK4AEeSXJ6XI-2nsRw" base_StructuralFeature="_cF4qkK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_NCoBML7fEeSdssyZX-p90g" base_Element="_cF4qkK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-GQIgL7eEeSdssyZX-p90g" base_StructuralFeature="_-GPhcL7eEeSdssyZX-p90g"/>
+  <OpenModel_Profile:Preliminary xmi:id="_WPJbIL7fEeSdssyZX-p90g" base_Element="_-GPhcL7eEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zMt-IMDWEeSoNOrYOfaryg" base_StructuralFeature="_zMhw4MDWEeSoNOrYOfaryg"/>
+  <OpenModel_Profile:Experimental xmi:id="_5FyDQMDWEeSoNOrYOfaryg" base_Element="_zMhw4MDWEeSoNOrYOfaryg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Otj6YK4HEeSXJ6XI-2nsRw" base_StructuralFeature="_OtjTUK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Experimental xmi:id="_gPijYK4HEeSXJ6XI-2nsRw" base_Element="_OtjTUK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Sx6goK4HEeSXJ6XI-2nsRw" base_StructuralFeature="_Sx55kK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Experimental xmi:id="_hUKpIK4HEeSXJ6XI-2nsRw" base_Element="_Sx55kK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bnwf8a4HEeSXJ6XI-2nsRw" base_StructuralFeature="_bnwf8K4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Experimental xmi:id="_ikjS8K4HEeSXJ6XI-2nsRw" base_Element="_bnwf8K4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kOFqcbFmEeSZUdYfPSdgew" base_StructuralFeature="_kOFqcLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_laNusL1AEeSTeMVkk1fdnQ" base_Element="_kOFqcLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sUoTwbFmEeSZUdYfPSdgew" base_StructuralFeature="_sUoTwLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_msTosL1AEeSTeMVkk1fdnQ" base_Element="_sUoTwLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aZMtAFg5EeOGT-4_Vdnb5w" base_Class="_oGql-FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_obOrkDK6EeS9t_pD0-sMng" base_Class="_oGql-FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aZmVoFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqmAlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_omlnADK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqmAlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aZwGoFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqmBVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ol31UDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqmBVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aaAlUFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGql_1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ojR0UDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGql_1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aaJvQFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_2ES2QFYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ogOgUDK6EeS9t_pD0-sMng" base_StructuralFeature="_2ES2QFYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dnAOkBiQEeSh8KVgZCMyDw" base_StructuralFeature="_dm_ngBiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_odShEDK6EeS9t_pD0-sMng" base_StructuralFeature="_dm_ngBiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aaiw0Fg5EeOGT-4_Vdnb5w" base_Class="_oGqmC1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oICp0DK6EeS9t_pD0-sMng" base_Class="_oGqmC1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_abB5AFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqmFVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oULoYDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqmFVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_abYeUFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_i7UzkFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oTedwDK6EeS9t_pD0-sMng" base_StructuralFeature="_i7UzkFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_abfMAFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_A8SFwFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oRfgwDK6EeS9t_pD0-sMng" base_StructuralFeature="_A8SFwFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_abl5sFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_gqUk0FYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oOsEYDK6EeS9t_pD0-sMng" base_StructuralFeature="_gqUk0FYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_absnYFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_d_droFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oNJzUDK6EeS9t_pD0-sMng" base_StructuralFeature="_d_droFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_v6GuwJ4LEeOO3om500DFKg" base_StructuralFeature="_v6GHsJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oKoq0DK6EeS9t_pD0-sMng" base_StructuralFeature="_v6GHsJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7R-PIwgoEeSbuczmw5yq0A" base_StructuralFeature="_7R-PIAgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:Preliminary xmi:id="_kYhScCPEEeSoB4Ln_aUF6w" base_Element="_7R-PIAgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oIsKEDK6EeS9t_pD0-sMng" base_StructuralFeature="_7R-PIAgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9_yzYEDAEeWQeOKbNUpP9A" base_StructuralFeature="_9_yMUEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ajFBwFg5EeOGT-4_Vdnb5w" base_Class="_oGqneFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_n_EUADK6EeS9t_pD0-sMng" base_Class="_oGqneFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_BUybgNIvEeS3iYmhnGQeUQ" base_Element="_oGqneFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ajMWgFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqneVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oEx6cDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqneVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ajTrQFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnf1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oEJoUDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqnf1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ajiUwFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnfFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oBeu0DK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqnfFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ajw-QFg5EeOGT-4_Vdnb5w" base_Class="_oGqnjVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_n40iEDK6EeS9t_pD0-sMng" base_Class="_oGqnjVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_akPfYFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnkFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n9rM4DK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqnkFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_akW0IFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnk1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n8_3cDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqnk1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_akdh0Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnllLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n8IUwDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqnllLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DjfvM6NSEeS9Obpdy8FCjA" base_StructuralFeature="_DjfvMKNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_YxxDwKNSEeS9Obpdy8FCjA" base_Element="_DjfvMKNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RtwvM6T3EeS9Obpdy8FCjA" base_StructuralFeature="_RtwvMKT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yfZPIEC8EeWxhL2B6Peg6A" base_StructuralFeature="_yfYoEEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aldAUFg5EeOGT-4_Vdnb5w" base_Class="_oGqnr1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_n0Nu4DK6EeS9t_pD0-sMng" base_Class="_oGqnr1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amCPIFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnslLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n3RC4DK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqnslLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amJj4Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqntVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n2lGYDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqntVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amW_QFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_DyAG8FYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n1-CYDK6EeS9t_pD0-sMng" base_StructuralFeature="_DyAG8FYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aocC4Fg5EeOGT-4_Vdnb5w" base_Class="_oGqoB1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_nzgkQDK6EeS9t_pD0-sMng" base_Class="_oGqoB1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_8_77INIuEeS3iYmhnGQeUQ" base_Element="_oGqoB1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aqf4YFg5EeOGT-4_Vdnb5w" base_Class="_b_lUAFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_nv0-IDK6EeS9t_pD0-sMng" base_Class="_b_lUAFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aqmmEFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_IxS2AFYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nyTqYDK6EeS9t_pD0-sMng" base_StructuralFeature="_IxS2AFYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aqzaYFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_Ykm6QFeGEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nwE1wDK6EeS9t_pD0-sMng" base_StructuralFeature="_Ykm6QFeGEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1HbrkEDAEeWQeOKbNUpP9A" base_StructuralFeature="_1HbEgEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aq6IEFg5EeOGT-4_Vdnb5w" base_Class="_gROecFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_nq1JYDK6EeS9t_pD0-sMng" base_Class="_gROecFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_arrkIFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_OwauQFeEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FZHBAFywEeOHhZKdZvU7vQ" base_StructuralFeature="_OwauQFeEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Hvis4FywEeOHhZKdZvU7vQ" base_StructuralFeature="_OwauQFeEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ntk7YDK6EeS9t_pD0-sMng" base_StructuralFeature="_OwauQFeEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zbSEIBiZEeSh8KVgZCMyDw" base_StructuralFeature="_zbRdEBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ns8pQDK6EeS9t_pD0-sMng" base_StructuralFeature="_zbRdEBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_CUJq8BicEeSh8KVgZCMyDw" base_StructuralFeature="_CUJD4BicEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nrBWoDK6EeS9t_pD0-sMng" base_StructuralFeature="_CUJD4BicEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_SEAzoLCKEeSXJ6XI-2nsRw" base_Element="_CUJD4BicEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GuuSYUDBEeWQeOKbNUpP9A" base_StructuralFeature="_GuuSYEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:Preliminary xmi:id="_wN4tQEDBEeWQeOKbNUpP9A" base_Element="_GuuSYEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_arBc0Fg5EeOGT-4_Vdnb5w" base_Class="_eEpDMFX4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mf8qoDK6EeS9t_pD0-sMng" base_Class="_eEpDMFX4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_arIxkFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_D4N9IFX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mtc7IDK6EeS9t_pD0-sMng" base_StructuralFeature="_D4N9IFX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_arPfQFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_3Y4zAFYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mroWMDK6EeS9t_pD0-sMng" base_StructuralFeature="_3Y4zAFYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_arWM8Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_lvFOQFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mptDkDK6EeS9t_pD0-sMng" base_StructuralFeature="_lvFOQFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ardhsFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_CHM6YFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mo-q0DK6EeS9t_pD0-sMng" base_StructuralFeature="_CHM6YFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ark2cFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_TkuhMFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnAU4DK6EeS9t_pD0-sMng" base_StructuralFeature="_TkuhMFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5tEV0xiaEeSh8KVgZCMyDw" base_StructuralFeature="_5tEV0BiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mknIMDK6EeS9t_pD0-sMng" base_StructuralFeature="_5tEV0BiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RLEJ8BieEeSh8KVgZCMyDw" base_StructuralFeature="_RLDi4BieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_f5hicBieEeSh8KVgZCMyDw" base_Element="_RLDi4BieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mir1kDK6EeS9t_pD0-sMng" base_StructuralFeature="_RLDi4BieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vq1NIxigEeSh8KVgZCMyDw" base_StructuralFeature="_vq1NIBigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pAQWEBihEeSh8KVgZCMyDw" base_StructuralFeature="_vq1NIBigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEKgDK6EeS9t_pD0-sMng" base_StructuralFeature="_vq1NIBigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_S811EUDBEeWQeOKbNUpP9A" base_StructuralFeature="_S811EEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aspNcFg5EeOGT-4_Vdnb5w" base_Class="_9UVusFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mcwzwDK6EeS9t_pD0-sMng" base_Class="_9UVusFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_asv7IFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_CadNIFaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mc8Z8DK6EeS9t_pD0-sMng" base_StructuralFeature="_CadNIFaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_as2BwFg5EeOGT-4_Vdnb5w" base_Class="_a97NQFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mUV3kDK6EeS9t_pD0-sMng" base_Class="_a97NQFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_anckYFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqn6FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5M_cIHcLEeO5z_IJj67BhQ" base_StructuralFeature="_oGqn6FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_660P4HcLEeO5z_IJj67BhQ" base_StructuralFeature="_oGqn6FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbN7oDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqn6FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_anVPoFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqn5lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ma2IMDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqn5lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_anjSEFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqn6lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_madtsDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqn6lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_anN64Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqn41LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mZ6UEDK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqn41LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2P4ZII8lEeOw_ste-s6RrA" base_StructuralFeature="_2PdiYI8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mZW6cDK6EeS9t_pD0-sMng" base_StructuralFeature="_2PdiYI8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DEXWwJozEeOyHKqw-cQ_eg" base_StructuralFeature="_DEWvsJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mYy5wDK6EeS9t_pD0-sMng" base_StructuralFeature="_DEWvsJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1EKuQ5o5EeOyHKqw-cQ_eg" base_StructuralFeature="_1EKuQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mXIs4DK6EeS9t_pD0-sMng" base_StructuralFeature="_1EKuQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tbfUEJ4HEeOO3om500DFKg" base_StructuralFeature="_tbetAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mVgVMDK6EeS9t_pD0-sMng" base_StructuralFeature="_tbetAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_H745gIgjEeOIkJV2fkx5ZA" base_Class="_H7c0oIgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mQbn8DK6EeS9t_pD0-sMng" base_Class="_H7c0oIgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XipzAIgjEeOIkJV2fkx5ZA" base_StructuralFeature="_XipL8IgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mSHC8DK6EeS9t_pD0-sMng" base_StructuralFeature="_XipL8IgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bsoosBNjEeS1heseQTA6lw" base_StructuralFeature="_br9TQBNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mRjpUDK6EeS9t_pD0-sMng" base_StructuralFeature="_br9TQBNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sz8xgBieEeSh8KVgZCMyDw" base_StructuralFeature="_sz8KcBieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mQn1MDK6EeS9t_pD0-sMng" base_StructuralFeature="_sz8KcBieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_m79xIJ2KEeSQBuaNnP_LbA" base_StructuralFeature="_m79KEJ2KEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:Experimental xmi:id="_q5cTUJ2KEeSQBuaNnP_LbA" base_Element="_m79KEJ2KEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NfrbEUC8EeWxhL2B6Peg6A" base_StructuralFeature="_NfrbEEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_GCjtMJywEeSaHrTY93cYuA" base_Class="_GCL5wJywEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_y7uSYaNWEeS9Obpdy8FCjA" base_StructuralFeature="_y7uSYKNWEeS9Obpdy8FCjA" condition=""/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_W79y8JyzEeSaHrTY93cYuA" base_Class="_W79L4JyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xudqcKQZEeS9Obpdy8FCjA" base_StructuralFeature="_xudDYKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_d6GCsZyzEeSaHrTY93cYuA" base_Class="_d6GCsJyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_egy_EK4GEeSXJ6XI-2nsRw" base_StructuralFeature="_egyYAK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_hnpa0L-XEeSdssyZX-p90g" base_Element="_egyYAK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yN4JILA0EeSXJ6XI-2nsRw" base_StructuralFeature="_yN3iELA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Experimental xmi:id="_sdGA0LA1EeSXJ6XI-2nsRw" base_Element="_yN3iELA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_sVcR8ZyzEeSaHrTY93cYuA" base_Class="_sVcR8JyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HkibYaNVEeS9Obpdy8FCjA" base_StructuralFeature="_HkibYKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QcR4IaNVEeS9Obpdy8FCjA" base_StructuralFeature="_QcR4IKNVEeS9Obpdy8FCjA" support="CONDITIONAL" condition="Present if jitterCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if jitterCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies to TDM."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZID8gaNVEeS9Obpdy8FCjA" base_StructuralFeature="_ZID8gKNVEeS9Obpdy8FCjA" support="CONDITIONAL" condition="Present if wanderCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if wanderCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies to TDM."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4ySjca3mEeSXJ6XI-2nsRw" base_StructuralFeature="_4ySjcK3mEeSXJ6XI-2nsRw" support="CONDITIONAL" condition="Present if queuingLatencyCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;There may be more than one instance if the queuing behavior depends upon traffic properties.&#xD;&#xA;Note that if queuingLatencyCharacteristics is relevant but consistent statement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies to packet system."/>
+  <OpenModel_Profile:Preliminary xmi:id="_I-nT8L1EEeSTeMVkk1fdnQ" base_Element="_4ySjcK3mEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_wuhLAZyzEeSaHrTY93cYuA" base_Class="_wuhLAJyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VIujsaNWEeS9Obpdy8FCjA" base_StructuralFeature="_VIujsKNWEeS9Obpdy8FCjA" support="CONDITIONAL" condition="Present if errorCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if errorCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies to TDM."/>
+  <OpenModel_Profile:Preliminary xmi:id="_UB9HoL7bEeSdssyZX-p90g" base_Element="_VIujsKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZuWrAaNWEeS9Obpdy8FCjA" base_StructuralFeature="_ZuWrAKNWEeS9Obpdy8FCjA" support="CONDITIONAL" condition="Present if lossCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if lossCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies to packet systems."/>
+  <OpenModel_Profile:Preliminary xmi:id="_Yl83QL7bEeSdssyZX-p90g" base_Element="_ZuWrAKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bVjSUaNWEeS9Obpdy8FCjA" base_StructuralFeature="_bVjSUKNWEeS9Obpdy8FCjA" support="CONDITIONAL" condition="Present if repeatCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if repeatCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this primarily applies to packet systemswhere a packet may be delivered more than once (in fault recovery for example). &#xD;&#xA;Note that it can also apply to TDM where several frames may  be received twice due to switching in a system with a large differential propagation delay."/>
+  <OpenModel_Profile:Preliminary xmi:id="_bCrYYL7bEeSdssyZX-p90g" base_Element="_bVjSUKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hGjb0L7aEeSdssyZX-p90g" base_StructuralFeature="_hGi0wL7aEeSdssyZX-p90g" support="CONDITIONAL" condition="Present if deliveryOrderCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if deliveryOrderCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies to packet systems.&#xD;&#xA;"/>
+  <OpenModel_Profile:Preliminary xmi:id="_d2I-gL7bEeSdssyZX-p90g" base_Element="_hGi0wL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9tZgcb7aEeSdssyZX-p90g" base_StructuralFeature="_9tZgcL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:Preliminary xmi:id="_fOAJUL7bEeSdssyZX-p90g" base_Element="_9tZgcL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_piS5Eb7aEeSdssyZX-p90g" base_StructuralFeature="_piS5EL7aEeSdssyZX-p90g" support="CONDITIONAL" condition="Present if serverIntegrityProcessCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if serverIntegrityProcessCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that this only applies where the server has some error recovery mechanism alters the characteristics of the link from a normal distribution."/>
+  <OpenModel_Profile:Preliminary xmi:id="_glYL8L7bEeSdssyZX-p90g" base_Element="_piS5EL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_1EYYAZyzEeSaHrTY93cYuA" base_Class="_1EYYAJyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FFQqkaQbEeS9Obpdy8FCjA" base_StructuralFeature="_FFQqkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_pPVEQL-fEeSdssyZX-p90g" base_Element="_FFQqkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_INhcAaQbEeS9Obpdy8FCjA" base_StructuralFeature="_INhcAKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_OwuqUKQbEeS9Obpdy8FCjA" base_Element="_INhcAKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Nhv4Qa3rEeSXJ6XI-2nsRw" base_StructuralFeature="_Nhv4QK3rEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Experimental xmi:id="_SkINAK3rEeSXJ6XI-2nsRw" base_Element="_Nhv4QK3rEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kZMnkaQbEeS9Obpdy8FCjA" base_StructuralFeature="_kZMnkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_pe9AcKQbEeS9Obpdy8FCjA" base_Element="_kZMnkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_MRPF0J2IEeSQBuaNnP_LbA" base_Class="_MROewJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eH6Mc52IEeSQBuaNnP_LbA" base_StructuralFeature="_eH6McJ2IEeSQBuaNnP_LbA" support="CONDITIONAL" condition="Present if risk information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if risk is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ny1Zo52IEeSQBuaNnP_LbA" base_StructuralFeature="_ny1ZoJ2IEeSQBuaNnP_LbA" support="CONDITIONAL" condition="Present if cost information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if cost is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_woOF852IEeSQBuaNnP_LbA" base_StructuralFeature="_woOF8J2IEeSQBuaNnP_LbA" support="CONDITIONAL" condition="Present if transfer timing information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if transfer timing is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_CEGuA52JEeSQBuaNnP_LbA" base_StructuralFeature="_CEGuAJ2JEeSQBuaNnP_LbA" support="CONDITIONAL" condition="Present if transfer capacity information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if transfer capacity is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QLzogJ2JEeSQBuaNnP_LbA" base_StructuralFeature="_QLzBcJ2JEeSQBuaNnP_LbA" support="OPTIONAL" condition="Present if transfer integrity information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if transfer integrity is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_h8cGoJ2LEeSQBuaNnP_LbA" base_StructuralFeature="_h8bfkJ2LEeSQBuaNnP_LbA" support="OPTIONAL" condition="Present if validation information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if validation is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that validation may not be possible for the specific layer protocol or in the particular case."/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_f9upI52JEeSQBuaNnP_LbA" base_StructuralFeature="_f9upIJ2JEeSQBuaNnP_LbA" support="CONDITIONAL" condition="Present if layer transition information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.&#xD;&#xA;Note that if layer transiotio is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.&#xD;&#xA;Note that layer transition occurs in a limited number of cases."/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_dDy8sJ2LEeSQBuaNnP_LbA" base_Class="_dDyVoJ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__L7YgK4GEeSXJ6XI-2nsRw" base_StructuralFeature="__L6xcK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_njjQQL7hEeSdssyZX-p90g" base_Element="__L6xcK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_agoxwFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqm31LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ajppgFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnilLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amds8Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnvlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_SzYBkCeyEeSiY-Znd5RVtA" base_Association="_oGqnwVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amkaoFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnxFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amrIUFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqnylLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_amx2AFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqn0FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_am5KwFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqn2FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aowzAFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqoEFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_apaTQFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_i7cIUVYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aphoAFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_A8YzcVYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_mZ-2QCP4EeSaIcETw2aroA" base_Association="_gqbSgFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oOP_gDK6EeS9t_pD0-sMng" base_StructuralFeature="_gqbSgVYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_7c85wCP4EeSaIcETw2aroA" base_Association="_d_lncFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_apvqcFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_d_lncVYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aqZKsFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_DyIp0VYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ar4_gFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_CHToEVYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ar_tMFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_3ZB88VYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_asGa4Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_Tk5gUVYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_asNIkFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_D4V48VX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mu5soDK6EeS9t_pD0-sMng" base_StructuralFeature="_lvO_QVYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_sXi_YCeyEeSiY-Znd5RVtA" base_Association="_Cakh4FaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oG5aUDK6EeS9t_pD0-sMng" base_StructuralFeature="_Cakh4VaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_asifwFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_Ixb_8VYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nvSLkDK6EeS9t_pD0-sMng" base_StructuralFeature="_2QhSUY8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:Experimental xmi:id="_CDxsMMP8EeSkD7NQ5om7rQ" base_Element="_DEn1cJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DEocgJozEeOyHKqw-cQ_eg" base_StructuralFeature="_DEn1cZozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1EVtYJo5EeOyHKqw-cQ_eg" base_StructuralFeature="_1EVGUZo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tboeBJ4HEeOO3om500DFKg" base_StructuralFeature="_tboeAZ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_v6VYRJ4LEeOO3om500DFKg" base_StructuralFeature="_v6VYQZ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mebAoDK6EeS9t_pD0-sMng" base_StructuralFeature="_buzL4RNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dnWM1BiQEeSh8KVgZCMyDw" base_StructuralFeature="_dnWM0RiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zbrFtBiZEeSh8KVgZCMyDw" base_StructuralFeature="_zbrFsRiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5ta7JBiaEeSh8KVgZCMyDw" base_StructuralFeature="_5ta7IRiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_D-CVsNIvEeS3iYmhnGQeUQ" base_Element="_oGqoCFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_n-mZ8DK6EeS9t_pD0-sMng" base_StructuralFeature="_oGqoCVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aopeQFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_oGqoDFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vrCohBigEeSh8KVgZCMyDw" base_StructuralFeature="_vrCogRigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_1kkOsKTcEeS9Obpdy8FCjA" base_Association="_eIDWYJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eIDWZJ2IEeSQBuaNnP_LbA" base_StructuralFeature="_eIDWYZ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_YNiEoKxuEeS5HuAudtqItw" base_Association="_ny-jkJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ny-jlJ2IEeSQBuaNnP_LbA" base_StructuralFeature="_ny-jkZ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_ySDWcKxuEeS5HuAudtqItw" base_Association="_woXP4J2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_woXP5J2IEeSQBuaNnP_LbA" base_StructuralFeature="_woXP4Z2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_5epfAKx5EeS5HuAudtqItw" base_Association="_CEPQ4J2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_CEPQ5J2JEeSQBuaNnP_LbA" base_StructuralFeature="_CEPQ4Z2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_EpdxoKx6EeS5HuAudtqItw" base_Association="_QL8LYJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QL8LZJ2JEeSQBuaNnP_LbA" base_StructuralFeature="_QL8LYZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_XJP6cLAOEeSXJ6XI-2nsRw" base_Association="_f93zEJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_f93zFJ2JEeSQBuaNnP_LbA" base_StructuralFeature="_f93zEZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_uybyQLAOEeSXJ6XI-2nsRw" base_Association="_h8kpgJ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_h8kphJ2LEeSQBuaNnP_LbA" base_StructuralFeature="_h8kpgZ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:Experimental xmi:id="_kkpd4LA1EeSXJ6XI-2nsRw" base_Element="_yODvULA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_7odKAL7WEeSdssyZX-p90g" base_Element="_gsh30K37EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_BUweII2tEeO38ZmbECnvbg" base_Class="_BUcVEI2tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ajjzcI2uEeO38ZmbECnvbg" base_StructuralFeature="_ajjMYI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NIl6wI28EeO38ZmbECnvbg" base_StructuralFeature="_NIlTsI28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_iVKcoI2wEeO38ZmbECnvbg" base_Class="_iVJ1kI2wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_w3-KsI3wEeO38ZmbECnvbg" base_StructuralFeature="_w39joI3wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IEiZwY22EeO38ZmbECnvbg" base_StructuralFeature="_IEiZwI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_k5n9cI2wEeO38ZmbECnvbg" base_Class="_k5nWYI2wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RMJegY22EeO38ZmbECnvbg" base_StructuralFeature="_RMJegI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_u0H3sI2wEeO38ZmbECnvbg" base_Class="_u0HQoI2wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_olrqYY2uEeO38ZmbECnvbg" base_StructuralFeature="_olrqYI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_bCji8I22EeO38ZmbECnvbg" base_Class="_bCi74I22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_uQqu4Y28EeO38ZmbECnvbg" base_StructuralFeature="_uQqu4I28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_StBl8I23EeO38ZmbECnvbg" base_Class="_StA-4I23EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Xn2yANP9EeSkCochwz02Ig" base_Element="_StA-4I23EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__JHYQI30EeO38ZmbECnvbg" base_StructuralFeature="__JGxMI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__JfywI30EeO38ZmbECnvbg" base_StructuralFeature="__JGxMI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ulDtsY3AEeO38ZmbECnvbg" base_Class="_ulDtsI3AEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_0dybgNP9EeSkCochwz02Ig" base_Element="_ulDtsI3AEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_U1tnkY31EeO38ZmbECnvbg" base_StructuralFeature="_U1tnkI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_-aSwcJP0EeOqfpp-ZJSmaA" base_Class="_-ZWVQJP0EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:Experimental xmi:id="_KIVGgLE6EeSZUdYfPSdgew" base_Element="_-ZWVQJP0EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:Experimental xmi:id="_S5Sl0LE6EeSZUdYfPSdgew" base_Element="_JIYq0JP1EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:Experimental xmi:id="_NGL-wLE6EeSZUdYfPSdgew" base_Element="_5Zv80JP2EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_77PyQY3tEeO38ZmbECnvbg" base_StructuralFeature="_77PyQI3tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZUzGMI3uEeO38ZmbECnvbg" base_StructuralFeature="_ZUyfII3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pXYZAI3uEeO38ZmbECnvbg" base_StructuralFeature="_pXXx8Y3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bhhnAI3vEeO38ZmbECnvbg" base_StructuralFeature="_bhg_8Y3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cbx2gY30EeO38ZmbECnvbg" base_StructuralFeature="_cbx2gI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:Experimental xmi:id="_IbTkALE6EeSZUdYfPSdgew" base_Element="_mZyWYI21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mZyWZI21EeO38ZmbECnvbg" base_StructuralFeature="_mZyWYY21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mZnXQ421EeO38ZmbECnvbg" base_StructuralFeature="_mZnXQI21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NIvrxI28EeO38ZmbECnvbg" base_StructuralFeature="_NIvrwY28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_1ph14NP9EeSkCochwz02Ig" base_Element="_pXXx8I3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pXYZAY3uEeO38ZmbECnvbg" base_StructuralFeature="_pXXx9I3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bhhnAY3vEeO38ZmbECnvbg" base_StructuralFeature="_bhg_9I3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Zbpq4NP9EeSkCochwz02Ig" base_Element="_e2gXEI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_e2gXF431EeO38ZmbECnvbg" base_StructuralFeature="_e2gXEY31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_e2g-II31EeO38ZmbECnvbg" base_StructuralFeature="_e2gXFI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_RG6VIbEtEeSZUdYfPSdgew" base_Class="_RG6VILEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dO6owbEtEeSZUdYfPSdgew" base_StructuralFeature="_dO6owLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7gqwAbEtEeSZUdYfPSdgew" base_StructuralFeature="_7gqwALEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_oUpGYLE1EeSZUdYfPSdgew" base_Element="_7gqwALEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_AjHWMLEuEeSZUdYfPSdgew" base_StructuralFeature="_AjGvILEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_2_LBILE1EeSZUdYfPSdgew" base_Element="_-xPeALEvEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Hu31AKKtEeOfSYroU9Javw" base_Element="_BQT2IKKtEeOfSYroU9Javw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_rgfcwJoyEeOyHKqw-cQ_eg" base_Class="_rgdnkJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mJTsQDK6EeS9t_pD0-sMng" base_Class="_rgdnkJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:Experimental xmi:id="_3DPW8MP7EeSkD7NQ5om7rQ" base_Element="_rgdnkJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_v77tUZoyEeOyHKqw-cQ_eg" base_StructuralFeature="_v77tUJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mL0NsDK6EeS9t_pD0-sMng" base_StructuralFeature="_v77tUJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:Experimental xmi:id="_7usZcMP7EeSkD7NQ5om7rQ" base_Element="_v77tUJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xZiBg54IEeOO3om500DFKg" base_StructuralFeature="_xZiBgJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mLUecDK6EeS9t_pD0-sMng" base_StructuralFeature="_xZiBgJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_k1gHQZo5EeOyHKqw-cQ_eg" base_Class="_k1gHQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mDf_MDK6EeS9t_pD0-sMng" base_Class="_k1gHQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:Experimental xmi:id="_lmvC0MQGEeSkD7NQ5om7rQ" base_Element="_k1gHQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oxb_EZo-EeOyHKqw-cQ_eg" base_StructuralFeature="_oxb_EJo-EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mIM5ADK6EeS9t_pD0-sMng" base_StructuralFeature="_oxb_EJo-EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:Experimental xmi:id="_oISZkMQGEeSkD7NQ5om7rQ" base_Element="_oxb_EJo-EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8-3vc5pDEeOyHKqw-cQ_eg" base_StructuralFeature="_8-3vcJpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mHqtgDK6EeS9t_pD0-sMng" base_StructuralFeature="_8-3vcJpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YzzeY54HEeOO3om500DFKg" base_StructuralFeature="_YzzeYJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mHHT4DK6EeS9t_pD0-sMng" base_StructuralFeature="_YzzeYJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ec0FM54JEeOO3om500DFKg" base_StructuralFeature="_Ec0FMJ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mFN2cDK6EeS9t_pD0-sMng" base_StructuralFeature="_Ec0FMJ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_v8WLwMQGEeSkD7NQ5om7rQ" base_Element="_8_BgcJpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mTaqgDK6EeS9t_pD0-sMng" base_StructuralFeature="_8_BgcZpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_T5-osZ4HEeOO3om500DFKg" base_Class="_T5-osJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mA5-MDK6EeS9t_pD0-sMng" base_Class="_T5-osJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_hzbMcMQKEeSrgb0T3VXRzQ" base_Element="_T5-osJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eSmM454IEeOO3om500DFKg" base_StructuralFeature="_eSmM4J4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eUC-Y54IEeOO3om500DFKg" base_StructuralFeature="_eSmM4J4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mCTFUDK6EeS9t_pD0-sMng" base_StructuralFeature="_eSmM4J4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eSyaIJ4IEeOO3om500DFKg" base_StructuralFeature="_eSxzEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eUC-YZ4IEeOO3om500DFKg" base_StructuralFeature="_eSxzEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mB6DwDK6EeS9t_pD0-sMng" base_StructuralFeature="_eSxzEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eS8LIJ4IEeOO3om500DFKg" base_StructuralFeature="_eS7kEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eUC-Yp4IEeOO3om500DFKg" base_StructuralFeature="_eS7kEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mBfNADK6EeS9t_pD0-sMng" base_StructuralFeature="_eS7kEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eTF8IJ4IEeOO3om500DFKg" base_StructuralFeature="_eTFVEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eUCXUJ4IEeOO3om500DFKg" base_StructuralFeature="_eTFVEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eUCXUZ4IEeOO3om500DFKg" base_StructuralFeature="_eTFVEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eUC-YJ4IEeOO3om500DFKg" base_StructuralFeature="_eTFVEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mBEWQDK6EeS9t_pD0-sMng" base_StructuralFeature="_eTFVEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_U9licMQKEeSrgb0T3VXRzQ" base_Element="_Y0HAYJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Y0HncJ4HEeOO3om500DFKg" base_StructuralFeature="_Y0HAYZ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_X8N2wMQKEeSrgb0T3VXRzQ" base_Element="_xZrLcJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xZrygJ4IEeOO3om500DFKg" base_StructuralFeature="_xZrLcZ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_PV9T8MP8EeSkD7NQ5om7rQ" base_Element="_Ec9PIJ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ec92MJ4JEeOO3om500DFKg" base_StructuralFeature="_Ec9PIZ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Tvr28RBHEeS-tqfHkf_O5w" base_Class="_Tvr28BBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mAIiIDK6EeS9t_pD0-sMng" base_Class="_Tvr28BBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:Experimental xmi:id="_swaecMQKEeSrgb0T3VXRzQ" base_Element="_Tvr28BBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ssnOkBBHEeS-tqfHkf_O5w" base_StructuralFeature="_sseEoBBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mAThQDK6EeS9t_pD0-sMng" base_StructuralFeature="_sseEoBBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:Experimental xmi:id="_va2EYMQKEeSrgb0T3VXRzQ" base_Element="_ss6wkBBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ss6wlBBHEeS-tqfHkf_O5w" base_StructuralFeature="_ss6wkRBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:Preliminary xmi:id="_hKK04MrUEeOt57ZaJqAnzg" base_Element="_byGkAMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_nzCmUcrUEeOt57ZaJqAnzg" base_Class="_nzCmUMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lyCbwDK6EeS9t_pD0-sMng" base_Class="_nzCmUMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DDT5kMrVEeOt57ZaJqAnzg" base_StructuralFeature="_DDTSgMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l92qMDK6EeS9t_pD0-sMng" base_StructuralFeature="_DDTSgMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_D2itU8rVEeOt57ZaJqAnzg" base_StructuralFeature="_D2itUMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l8XccDK6EeS9t_pD0-sMng" base_StructuralFeature="_D2itUMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rBYVIMrVEeOt57ZaJqAnzg" base_StructuralFeature="_rBXuEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l64OsDK6EeS9t_pD0-sMng" base_StructuralFeature="_rBXuEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_d6lKsc96EeOwEItOulyh6w" base_StructuralFeature="_d6lKsM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l38PcDK6EeS9t_pD0-sMng" base_StructuralFeature="_d6lKsM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Q4JwgRBEEeS-tqfHkf_O5w" base_StructuralFeature="_Q4JwgBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l1DTgDK6EeS9t_pD0-sMng" base_StructuralFeature="_Q4JwgBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_vk-RkMrUEeOt57ZaJqAnzg" base_Class="_vk9qgMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lxjTkDK6EeS9t_pD0-sMng" base_Class="_vk9qgMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_x3AloMrUEeOt57ZaJqAnzg" base_Class="_x2_-kMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lwrJ0DK6EeS9t_pD0-sMng" base_Class="_x2_-kMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_4MF4YcrUEeOt57ZaJqAnzg" base_Class="_4MF4YMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lsHZ8DK6EeS9t_pD0-sMng" base_Class="_4MF4YMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eej4U8rWEeOt57ZaJqAnzg" base_StructuralFeature="_eej4UMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lve3ADK6EeS9t_pD0-sMng" base_StructuralFeature="_eej4UMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tGhwc896EeOwEItOulyh6w" base_StructuralFeature="_tGhwcM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_luD6sDK6EeS9t_pD0-sMng" base_StructuralFeature="_tGhwcM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_q_7KoxBEEeS-tqfHkf_O5w" base_StructuralFeature="_q_7KoBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ltkLcDK6EeS9t_pD0-sMng" base_StructuralFeature="_q_7KoBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_huOuwMrVEeOt57ZaJqAnzg" base_Class="_huOHsMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lk1GMDK6EeS9t_pD0-sMng" base_Class="_huOHsMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lyVdY8rVEeOt57ZaJqAnzg" base_StructuralFeature="_lyVdYMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lq5R8DK6EeS9t_pD0-sMng" base_StructuralFeature="_lyVdYMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tRVlkMrVEeOt57ZaJqAnzg" base_StructuralFeature="_tRU-gMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lqZisDK6EeS9t_pD0-sMng" base_StructuralFeature="_tRU-gMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_F4Dco8rWEeOt57ZaJqAnzg" base_StructuralFeature="_F4DcoMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lp3-QDK6EeS9t_pD0-sMng" base_StructuralFeature="_F4DcoMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_o5PVM8rbEeOt57ZaJqAnzg" base_StructuralFeature="_o5PVMMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_loSC0DK6EeS9t_pD0-sMng" base_StructuralFeature="_o5PVMMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ArJEI8rcEeOt57ZaJqAnzg" base_StructuralFeature="_ArJEIMrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lmyOADK6EeS9t_pD0-sMng" base_StructuralFeature="_ArJEIMrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_vxo_IMrVEeOt57ZaJqAnzg" base_Class="_vxoYEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lhxyMDK6EeS9t_pD0-sMng" base_Class="_vxoYEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zevjA8rVEeOt57ZaJqAnzg" base_StructuralFeature="_zevjAMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lkAm0DK6EeS9t_pD0-sMng" base_StructuralFeature="_zevjAMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_15tJk8rVEeOt57ZaJqAnzg" base_StructuralFeature="_15tJkMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ljg3kDK6EeS9t_pD0-sMng" base_StructuralFeature="_15tJkMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6ZBl08rbEeOt57ZaJqAnzg" base_StructuralFeature="_6ZBl0MrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ljBvYDK6EeS9t_pD0-sMng" base_StructuralFeature="_6ZBl0MrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_BC4dcMrWEeOt57ZaJqAnzg" base_Class="_BC32YMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lhEnkDK6EeS9t_pD0-sMng" base_Class="_BC32YMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pSSgoMrWEeOt57ZaJqAnzg" base_StructuralFeature="_pSR5kMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lhPmsDK6EeS9t_pD0-sMng" base_StructuralFeature="_pSR5kMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_EL41wMrWEeOt57ZaJqAnzg" base_Class="_EL4OsMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ldZogDK6EeS9t_pD0-sMng" base_Class="_EL4OsMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_K1ow8MrWEeOt57ZaJqAnzg" base_StructuralFeature="_K1oJ4MrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lgjqMDK6EeS9t_pD0-sMng" base_StructuralFeature="_K1oJ4MrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MqyUsMrWEeOt57ZaJqAnzg" base_StructuralFeature="_MqxtoMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lgD68DK6EeS9t_pD0-sMng" base_StructuralFeature="_MqxtoMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1kdDk8rbEeOt57ZaJqAnzg" base_StructuralFeature="_1kdDkMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lfhvcDK6EeS9t_pD0-sMng" base_StructuralFeature="_1kdDkMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LfY8AfFLEeOb0bs-xqaPmA" base_StructuralFeature="_LfY8APFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:Preliminary xmi:id="__pLH0BvPEeSzeoKP7VQE4w" base_Element="_LfY8APFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ldoSADK6EeS9t_pD0-sMng" base_StructuralFeature="_LfY8APFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_xI3CAcrbEeOt57ZaJqAnzg" base_Class="_xI3CAMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ldLmEDK6EeS9t_pD0-sMng" base_Class="_xI3CAMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_d8DKVM96EeOwEItOulyh6w" base_Class="_d8DKUM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_r0CkkPFKEeOb0bs-xqaPmA" base_StructuralFeature="_rz8d8PFKEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:Experimental xmi:id="_yBwFUBvOEeSzeoKP7VQE4w" base_Element="_rz8d8PFKEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_d8DxYM96EeOwEItOulyh6w" base_StructuralFeature="_d8DKUc96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KWXpAPFMEeOb0bs-xqaPmA" base_Class="_KWXB8PFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:Experimental xmi:id="_kExpkBvNEeSzeoKP7VQE4w" base_Element="_KWXB8PFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lctE8DK6EeS9t_pD0-sMng" base_Class="_KWXB8PFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ZDeWoPFMEeOb0bs-xqaPmA" base_Class="_ZDdvkPFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:Experimental xmi:id="_iJXFwBvNEeSzeoKP7VQE4w" base_Element="_ZDdvkPFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lcd0YDK6EeS9t_pD0-sMng" base_Class="_ZDdvkPFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Q575NBBEEeS-tqfHkf_O5w" base_Class="_Q575MBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1OgVNBvOEeSzeoKP7VQE4w" base_StructuralFeature="_1OgVMBvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1O4vsBvOEeSzeoKP7VQE4w" base_StructuralFeature="_1OgVMBvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:Experimental xmi:id="_1O5WwBvOEeSzeoKP7VQE4w" base_Element="_1OgVMBvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Q575NRBEEeS-tqfHkf_O5w" base_StructuralFeature="_Q575MRBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DDgt5MrVEeOt57ZaJqAnzg" base_StructuralFeature="_DDgt4crVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_D2uThMrVEeOt57ZaJqAnzg" base_StructuralFeature="_D2uTgcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lygchMrVEeOt57ZaJqAnzg" base_StructuralFeature="_lygcgcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rBj7UMrVEeOt57ZaJqAnzg" base_StructuralFeature="_rBjUQcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tRhLwMrVEeOt57ZaJqAnzg" base_StructuralFeature="_tRgkscrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ze8-ZMrVEeOt57ZaJqAnzg" base_StructuralFeature="_ze8-YcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_154vwMrVEeOt57ZaJqAnzg" base_StructuralFeature="_154IscrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_F4PC0MrWEeOt57ZaJqAnzg" base_StructuralFeature="_F4ObwcrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lxLgIDK6EeS9t_pD0-sMng" base_StructuralFeature="_K1zJAcrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lwVyoDK6EeS9t_pD0-sMng" base_StructuralFeature="_Mq-h8crWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eexTtMrWEeOt57ZaJqAnzg" base_StructuralFeature="_eexTscrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_o5a7YMrbEeOt57ZaJqAnzg" base_StructuralFeature="_o5aUUcrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1krGBMrbEeOt57ZaJqAnzg" base_StructuralFeature="_1krGAcrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6ZNMAMrbEeOt57ZaJqAnzg" base_StructuralFeature="_6ZMk8crbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ArUqUMrcEeOt57ZaJqAnzg" base_StructuralFeature="_ArUDQcrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l13y4DK6EeS9t_pD0-sMng" base_StructuralFeature="_tGsvkc96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lzIn8DK6EeS9t_pD0-sMng" base_StructuralFeature="_rAOFkRBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oIRTUDK6EeS9t_pD0-sMng" base_StructuralFeature="_7SNfsQgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_FU2nYRiSEeSh8KVgZCMyDw" base_Class="_FU2nYBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_mBc6ABu_EeSzeoKP7VQE4w" base_Element="_FU2nYBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lS_vUDK6EeS9t_pD0-sMng" base_Class="_FU2nYBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gQzlkBiUEeSh8KVgZCMyDw" base_StructuralFeature="_gQy-gBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lbuNgDK6EeS9t_pD0-sMng" base_StructuralFeature="_gQy-gBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_stER8xiUEeSh8KVgZCMyDw" base_StructuralFeature="_stER8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_laHrADK6EeS9t_pD0-sMng" base_StructuralFeature="_stER8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DYtjcBiVEeSh8KVgZCMyDw" base_StructuralFeature="_DYs8YBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lYmBADK6EeS9t_pD0-sMng" base_StructuralFeature="_DYs8YBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KhSoUxiYEeSh8KVgZCMyDw" base_StructuralFeature="_KhSoUBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lXLEsDK6EeS9t_pD0-sMng" base_StructuralFeature="_KhSoUBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QIRpgxiZEeSh8KVgZCMyDw" base_StructuralFeature="_QIRpgBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lVrP4DK6EeS9t_pD0-sMng" base_StructuralFeature="_QIRpgBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_K6HmwBiSEeSh8KVgZCMyDw" base_Class="_K6G_sBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_nJVIEBu_EeSzeoKP7VQE4w" base_Element="_K6G_sBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lQTnsDK6EeS9t_pD0-sMng" base_Class="_K6G_sBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gzl3oBiWEeSh8KVgZCMyDw" base_StructuralFeature="_gzlQkBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lSCGADK6EeS9t_pD0-sMng" base_StructuralFeature="_gzlQkBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_-M5QwBiSEeSh8KVgZCMyDw" base_Class="_-M4psBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_oXeWMBu_EeSzeoKP7VQE4w" base_Element="_-M4psBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lPyDQDK6EeS9t_pD0-sMng" base_Class="_-M4psBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_JH4XoRiTEeSh8KVgZCMyDw" base_Class="_JH4XoBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_pfnqABu_EeSzeoKP7VQE4w" base_Element="_JH4XoBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lMEA4DK6EeS9t_pD0-sMng" base_Class="_JH4XoBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3I3icxiUEeSh8KVgZCMyDw" base_StructuralFeature="_3I3icBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lNK0IDK6EeS9t_pD0-sMng" base_StructuralFeature="_3I3icBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_OGNS0RiTEeSh8KVgZCMyDw" base_Class="_OGNS0BiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_qnClEBu_EeSzeoKP7VQE4w" base_Element="_OGNS0BiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lJB7ADK6EeS9t_pD0-sMng" base_Class="_OGNS0BiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ub5XoBiVEeSh8KVgZCMyDw" base_StructuralFeature="_Ub4wkBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lLZSgDK6EeS9t_pD0-sMng" base_StructuralFeature="_Ub4wkBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_izZosxiVEeSh8KVgZCMyDw" base_StructuralFeature="_izZosBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lKt9EDK6EeS9t_pD0-sMng" base_StructuralFeature="_izZosBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GuNqMBiWEeSh8KVgZCMyDw" base_StructuralFeature="_GuNDIBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lKD1wDK6EeS9t_pD0-sMng" base_StructuralFeature="_GuNDIBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_cWCOkBiTEeSh8KVgZCMyDw" base_Class="_cWBngBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_rrtHEBu_EeSzeoKP7VQE4w" base_Element="_cWBngBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lFsTIDK6EeS9t_pD0-sMng" base_Class="_cWBngBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tYhNQxiVEeSh8KVgZCMyDw" base_StructuralFeature="_tYhNQBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lHx90DK6EeS9t_pD0-sMng" base_StructuralFeature="_tYhNQBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BiVlwRiXEeSh8KVgZCMyDw" base_StructuralFeature="_BiVlwBiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lHCW8DK6EeS9t_pD0-sMng" base_StructuralFeature="_BiVlwBiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_psjm8xiXEeSh8KVgZCMyDw" base_StructuralFeature="_psjm8BiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lGfkYDK6EeS9t_pD0-sMng" base_StructuralFeature="_psjm8BiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_We3KYRiUEeSh8KVgZCMyDw" base_Class="_We3KYBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_srGukBu_EeSzeoKP7VQE4w" base_Element="_We3KYBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lFFPIDK6EeS9t_pD0-sMng" base_Class="_We3KYBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_bJa1ABiUEeSh8KVgZCMyDw" base_Class="_bJaN8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_tsKi8Bu_EeSzeoKP7VQE4w" base_Element="_bJaN8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lDkMMDK6EeS9t_pD0-sMng" base_Class="_bJaN8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RB-bUBmOEeSzeoKP7VQE4w" base_StructuralFeature="_RB90QBmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lDwZcDK6EeS9t_pD0-sMng" base_StructuralFeature="_RB90QBmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_GnuVwBiYEeSh8KVgZCMyDw" base_Class="_GntusBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_ap-jcBwXEeSzeoKP7VQE4w" base_Element="_GntusBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lC3ooDK6EeS9t_pD0-sMng" base_Class="_GntusBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bc3YoBiYEeSh8KVgZCMyDw" base_StructuralFeature="_bc2xkBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lDCnwDK6EeS9t_pD0-sMng" base_StructuralFeature="_bc2xkBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_MVTuMRiZEeSh8KVgZCMyDw" base_Class="_MVTuMBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_ENNuABvAEeSzeoKP7VQE4w" base_Element="_MVTuMBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lCq0UDK6EeS9t_pD0-sMng" base_Class="_MVTuMBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_BIsPUBiaEeSh8KVgZCMyDw" base_Class="_BIroQBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_2ZBlYBu_EeSzeoKP7VQE4w" base_Element="_BIroQBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_lB7NcDK6EeS9t_pD0-sMng" base_Class="_BIroQBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HPhqsxiaEeSh8KVgZCMyDw" base_StructuralFeature="_HPhqsBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lCHasDK6EeS9t_pD0-sMng" base_StructuralFeature="_HPhqsBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gRHHlBiUEeSh8KVgZCMyDw" base_StructuralFeature="_gRHHkRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_stRGRBiUEeSh8KVgZCMyDw" base_StructuralFeature="_stRGQRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3JNgtBiUEeSh8KVgZCMyDw" base_StructuralFeature="_3JNgsRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DY8M8BiVEeSh8KVgZCMyDw" base_StructuralFeature="_DY7l4RiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UcLEcxiVEeSh8KVgZCMyDw" base_StructuralFeature="_UcLEcBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lODk8DK6EeS9t_pD0-sMng" base_StructuralFeature="_izo5QRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tYxE4BiVEeSh8KVgZCMyDw" base_StructuralFeature="_tYwd0RiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GubsoBiWEeSh8KVgZCMyDw" base_StructuralFeature="_GubFkRiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gz8c9BiWEeSh8KVgZCMyDw" base_StructuralFeature="_gz8c8RiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ps3wBBiXEeSh8KVgZCMyDw" base_StructuralFeature="_ps3wARiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KhfcoBiYEeSh8KVgZCMyDw" base_StructuralFeature="_Khe1kRiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_bdIeZBiYEeSh8KVgZCMyDw" base_StructuralFeature="_bdIeYRiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QImZpBiZEeSh8KVgZCMyDw" base_StructuralFeature="_QImZoRiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_HP3o8BiaEeSh8KVgZCMyDw" base_StructuralFeature="_HP3B4RiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lEwfADK6EeS9t_pD0-sMng" base_StructuralFeature="_RCTLcRmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_-NxnsKNREeS9Obpdy8FCjA" base_Class="_-Npr4KNREeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_CVwJsKNSEeS9Obpdy8FCjA" base_Element="_-Npr4KNREeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_LLBN4LAOEeSXJ6XI-2nsRw" base_Element="_DjpgMKNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_DjpgNKNSEeS9Obpdy8FCjA" base_StructuralFeature="_DjpgMaNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_Unf0IJgMEeSjhfRBVH9_gQ" base_Element="_KjlfMJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_frJHwJgMEeSjhfRBVH9_gQ" base_Class="_frIgsJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pKunoJgMEeSjhfRBVH9_gQ" base_StructuralFeature="_pKuAkJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__XgL05gMEeSjhfRBVH9_gQ" base_StructuralFeature="__XgL0JgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_OunqU5gOEeSjhfRBVH9_gQ" base_StructuralFeature="_OunqUJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_hXvMcZgMEeSjhfRBVH9_gQ" base_Class="_hXvMcJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_blJtU5gNEeSjhfRBVH9_gQ" base_StructuralFeature="_blJtUJgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ta7ic5gVEeSeO5hX75xH1g" base_StructuralFeature="_ta7icJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1nVtw5gWEeSeO5hX75xH1g" base_StructuralFeature="_1nVtwJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pK3KhJgMEeSjhfRBVH9_gQ" base_StructuralFeature="_pK3KgZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_6l-WgZgMEeSjhfRBVH9_gQ" base_Class="_6l-WgJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PM8TI5gQEeSeO5hX75xH1g" base_StructuralFeature="_PM8TIJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XymSo5gWEeSeO5hX75xH1g" base_StructuralFeature="_XymSoJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__XpVxJgMEeSjhfRBVH9_gQ" base_StructuralFeature="__XpVwZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_blS3RJgNEeSjhfRBVH9_gQ" base_StructuralFeature="_blS3QZgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Du1jAZgOEeSjhfRBVH9_gQ" base_Class="_Du1jAJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ouw0RJgOEeSjhfRBVH9_gQ" base_StructuralFeature="_Ouw0QZgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_CqT5AJgQEeSeO5hX75xH1g" base_Class="_CqTR8JgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Example xmi:id="_Y8MiQJsnEeSHn5P512I1Vg" base_Element="_GKgCQJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Example xmi:id="_QLMxQJsoEeSHn5P512I1Vg" base_Element="_HSBcQJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PNGrMJgQEeSeO5hX75xH1g" base_StructuralFeature="_PNGEIZgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_j2VmwZgVEeSeO5hX75xH1g" base_Class="_j2VmwJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Example xmi:id="_OOqBgJsnEeSHn5P512I1Vg" base_Element="_oX1cAJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Example xmi:id="_ITXSUJsoEeSHn5P512I1Vg" base_Element="_JhTXQJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tbEsYJgVEeSeO5hX75xH1g" base_StructuralFeature="_tbEFUZgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Xyx40JgWEeSeO5hX75xH1g" base_StructuralFeature="_XyxRwZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1nfexJgWEeSeO5hX75xH1g" base_StructuralFeature="_1nfewZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_5uuZkCRJEeSaIcETw2aroA" base_Element="_1R3MsCRJEeSaIcETw2aroA"/>
+  <OpenModel_Profile:Experimental xmi:id="_CJZoYCbSEeSaIcETw2aroA" base_Element="_6G0SACbREeSaIcETw2aroA"/>
+  <OpenModel_Profile:Experimental xmi:id="__3fXwE-wEeSGXqgORzeAvQ" base_Element="_lyJ8sE-nEeSGXqgORzeAvQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_-uDDcE-wEeSGXqgORzeAvQ" base_Element="_15jvAE-wEeSGXqgORzeAvQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_GeO2ML7WEeSdssyZX-p90g" base_Element="_DckcAL7WEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_9bj8oRihEeSh8KVgZCMyDw" base_Class="_9bj8oBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mO4IwDK6EeS9t_pD0-sMng" base_Class="_9bj8oBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_2TD1oLAPEeSXJ6XI-2nsRw" base_Element="_9bj8oBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-VM6YxihEeSh8KVgZCMyDw" base_StructuralFeature="_-VM6YBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mPGyQDK6EeS9t_pD0-sMng" base_StructuralFeature="_-VM6YBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_4YClILAPEeSXJ6XI-2nsRw" base_Element="_-VhDcBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_ojeisKT3EeS9Obpdy8FCjA" base_Element="_Rt55IKT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Rt55JKT3EeS9Obpdy8FCjA" base_StructuralFeature="_Rt55IaT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Experimental xmi:id="_2EyngB5AEeSc7uULmomGUw" base_Element="_EI7mABjCEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:Experimental xmi:id="_IrEMYJrqEeOIpsaRO3bXjA" base_Element="_wo4dMFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_b0saoFg5EeOGT-4_Vdnb5w" base_Class="_3AVHcFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_JBquEKK3EeOfSYroU9Javw" base_Element="_3AVHcFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b0zvYFg5EeOGT-4_Vdnb5w" base_StructuralFeature="__olWsFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b06dEFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_Qoxr0FZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b1Bx0Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_jCspcFZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b1JGkFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_c1f1cFZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_b1QbUFg5EeOGT-4_Vdnb5w" base_Class="_5GhX4FZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_KY6N0KK3EeOfSYroU9Javw" base_Element="_5GhX4FZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b1XwEFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_LXPWMFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b1fE0Fg5EeOGT-4_Vdnb5w" base_StructuralFeature="_S4YzcFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b1mZkFg5EeOGT-4_Vdnb5w" base_StructuralFeature="__otSgVZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b1tHQFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_S4h9YVZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_b10cAFg5EeOGT-4_Vdnb5w" base_Class="_VZ3RsFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_Leze4KK3EeOfSYroU9Javw" base_Element="_VZ3RsFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_b17wwFg5EeOGT-4_Vdnb5w" base_Class="_MZH0gFZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_MqQlYKK3EeOfSYroU9Javw" base_Element="_MZH0gFZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b2DFgFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_Qo8q8VZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b2LBUFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_jC1MUVZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b2SWEFg5EeOGT-4_Vdnb5w" base_StructuralFeature="_c1o_YVZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_pjmwIEDNEeWQeOKbNUpP9A" base_Element="_T5GykEDNEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:Experimental xmi:id="_AZi7QFYFEeW5zoktRlwOmg" base_Element="_5dOpYFYEEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_HvU2AFYFEeW5zoktRlwOmg" base_Class="_HvUO8FYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_JAQSYVYFEeW5zoktRlwOmg" base_Class="_JAQSYFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QsLcQFYFEeW5zoktRlwOmg" base_StructuralFeature="_QsK1MFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QsMDUFYFEeW5zoktRlwOmg" base_StructuralFeature="_QsLcQVYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_i38CElYFEeW5zoktRlwOmg" base_StructuralFeature="_i38CEVYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_i38pIVYFEeW5zoktRlwOmg" base_StructuralFeature="_i38pIFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nbTqIFYGEeW5zoktRlwOmg" base_StructuralFeature="_nbTDEVYGEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nbURMVYGEeW5zoktRlwOmg" base_StructuralFeature="_nbURMFYGEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Gkpgs1YHEeW5zoktRlwOmg" base_StructuralFeature="_GkpgslYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GkqHwVYHEeW5zoktRlwOmg" base_StructuralFeature="_GkqHwFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_D4Yc0FYJEeW5zoktRlwOmg" base_Element="_JAQSYFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_E-MOUFYJEeW5zoktRlwOmg" base_Element="_HvUO8FYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_GWon8FYJEeW5zoktRlwOmg" base_Element="_QsIY8FYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_Hn1KEFYJEeW5zoktRlwOmg" base_Element="_i37bAFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_J6eiIFYJEeW5zoktRlwOmg" base_Element="_Gko5oFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_LXiWAFYJEeW5zoktRlwOmg" base_Element="_nbScAFYGEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:Experimental xmi:id="_4tCTIGXJEeWWhJGy6csBUQ" base_Element="_zbRdEBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_yaxOYGXKEeWWhJGy6csBUQ" base_Element="_P-Hp8MD4EeSoNOrYOfaryg"/>
+  <OpenModel_Profile:Experimental xmi:id="_EhlE8GXaEeWrX_JIGzXlSg" base_Element="_5tEV0BiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_tLKM8GYtEeWrX_JIGzXlSg" base_Element="_DEWvsJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:Experimental xmi:id="_vfqmMGYtEeWrX_JIGzXlSg" base_Element="_1EKuQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:Experimental xmi:id="_ym8gMGYtEeWrX_JIGzXlSg" base_Element="_tbetAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Rg3asGYuEeWrX_JIGzXlSg" base_Element="_nzCmUMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_TE9qsGYuEeWrX_JIGzXlSg" base_Element="_vk9qgMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_UWdu0GYuEeWrX_JIGzXlSg" base_Element="_x2_-kMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Experimental xmi:id="_WijL4GYuEeWrX_JIGzXlSg" base_Element="_4MF4YMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Xv1eYGYuEeWrX_JIGzXlSg" base_Element="_huOHsMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Experimental xmi:id="_ZAOIMGYuEeWrX_JIGzXlSg" base_Element="_vxoYEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Experimental xmi:id="_aFK-EGYuEeWrX_JIGzXlSg" base_Element="_BC32YMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_bdMg8GYuEeWrX_JIGzXlSg" base_Element="_EL4OsMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_f3_4UGYuEeWrX_JIGzXlSg" base_Element="_xI3CAMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_kMH_8GYuEeWrX_JIGzXlSg" base_Element="_d8DKUM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:Preliminary xmi:id="_lXJooGYuEeWrX_JIGzXlSg" base_Element="_Q575MBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:Preliminary xmi:id="_UJXxMGYyEeWrX_JIGzXlSg" base_Element="_vq1NIBigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_x9rfwGY4EeWrX_JIGzXlSg" base_Element="_v6GHsJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_jriRMGZ3EeWrX_JIGzXlSg" base_Element="_RtwvMKT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Ty8uQGZ_EeWrX_JIGzXlSg" base_Element="_DUU_sGZ_EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_tAg4AGaBEeWrX_JIGzXlSg" base_Association="_v6VYQJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_wYPBwGaBEeWrX_JIGzXlSg" base_Element="_v6VYQJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_yuVWcGaBEeWrX_JIGzXlSg" base_Element="_tboeAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:Experimental xmi:id="_0iKrkGaBEeWrX_JIGzXlSg" base_Element="_1EVGUJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_2ajJgGaBEeWrX_JIGzXlSg" base_Association="_tboeAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_QkJTIGaDEeWrX_JIGzXlSg" base_Association="_Y0HAYJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Ul9iwGaDEeWrX_JIGzXlSg" base_Association="_xZrLcJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:Obsolete xmi:id="_5jeBQGaMEeWrX_JIGzXlSg" base_Element="_oGqntVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Obsolete xmi:id="_KeKAwGaNEeWrX_JIGzXlSg" base_Element="_XipL8IgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_6JnecGaQEeWrX_JIGzXlSg" base_Element="_oGqnx1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_8m9qoGaQEeWrX_JIGzXlSg" base_Element="_oGqnzVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_-e-8MGaQEeWrX_JIGzXlSg" base_Element="_oGqnhVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_DN47UGaREeWrX_JIGzXlSg" base_Element="_oGqneVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_EhAJAGaREeWrX_JIGzXlSg" base_Element="_oGqnf1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Preliminary xmi:id="_FpsPYGaREeWrX_JIGzXlSg" base_Element="_oGqnfFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Obsolete xmi:id="_YQDCUGaYEeWrX_JIGzXlSg" base_Element="_oGqjV1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Obsolete xmi:id="_SpjEIGapEeWrX_JIGzXlSg" base_Element="_oGqjalLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:Experimental xmi:id="_jBcjMGb3EeWrX_JIGzXlSg" base_Element="_c3Hu8Gb3EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_p2ZGsGeEEeWmgIwAIZlYKQ" base_StructuralFeature="_p2YfoGeEEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_u1EAIGeEEeWmgIwAIZlYKQ" base_Element="_p2YfoGeEEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_BlickGeFEeWmgIwAIZlYKQ" base_Element="_6anG8GeEEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_6KDQgGeGEeWmgIwAIZlYKQ" base_Element="_fQ-KsGeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_9B5nYGeGEeWmgIwAIZlYKQ" base_Element="_z8-fsGeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="__KY94GeGEeWmgIwAIZlYKQ" base_Element="_CYFeYGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_AoFq8GeHEeWmgIwAIZlYKQ" base_Element="_LtQeAGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_CiDdQGeHEeWmgIwAIZlYKQ" base_Element="_YWtR0GeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_Hn1EQGeHEeWmgIwAIZlYKQ" base_Element="_gjpeEGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_JDMPAGeHEeWmgIwAIZlYKQ" base_Element="_ueUCIGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_4X2lwGgYEeWmgIwAIZlYKQ" base_Element="_6eJYgLEsEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_6zwngGgYEeWmgIwAIZlYKQ" base_Element="_RG6VILEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_A2PuYGgZEeWmgIwAIZlYKQ" base_Element="_KSKOYLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_EjEzMGgeEeWmgIwAIZlYKQ" base_Element="_QAuTsLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_F8v74GgeEeWmgIwAIZlYKQ" base_Element="_iIYN4LE0EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Experimental xmi:id="_RwqO0GgeEeWmgIwAIZlYKQ" base_Element="_McyhcGgeEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_ieSCsGgeEeWmgIwAIZlYKQ" base_Element="_AjGvILEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_AsXK4GgfEeWmgIwAIZlYKQ" base_Element="_dO6owLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Lhe6UGgfEeWmgIwAIZlYKQ" base_Element="_lNclkLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_NQtcQGgfEeWmgIwAIZlYKQ" base_Element="_oVoegLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_OpU1AGgfEeWmgIwAIZlYKQ" base_Element="_p90kULEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_QhhswGgfEeWmgIwAIZlYKQ" base_Element="_PIgSQLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_Rs0bMGgfEeWmgIwAIZlYKQ" base_Element="_OLEZoLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_jQshoGgfEeWmgIwAIZlYKQ" base_Element="_gigKULE2EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:Preliminary xmi:id="_k7i54GgfEeWmgIwAIZlYKQ" base_Element="_hNiEULE2EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PzrA4GgiEeWmgIwAIZlYKQ" base_StructuralFeature="_PzqZ0GgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_ThhLoGgiEeWmgIwAIZlYKQ" base_Element="_PzqZ0GgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_sd_IAGkZEeWI2vxwuJqrJA" base_Element="_frIgsJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_umZmAGkZEeWI2vxwuJqrJA" base_Element="_pKuAkJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_v2NBAGkZEeWI2vxwuJqrJA" base_Element="__XgL0JgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_xCYgQGkZEeWI2vxwuJqrJA" base_Element="_OunqUJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_zpj94GkZEeWI2vxwuJqrJA" base_Element="_hXvMcJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_0xIp8GkZEeWI2vxwuJqrJA" base_Element="_blJtUJgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_16SqYGkZEeWI2vxwuJqrJA" base_Element="_ta7icJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_3oeqgGkZEeWI2vxwuJqrJA" base_Element="_1nVtwJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_6UVMwGkZEeWI2vxwuJqrJA" base_Element="_pK3KgJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_7zZLwGkZEeWI2vxwuJqrJA" base_Element="_pK3KgZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_-n1pUGkZEeWI2vxwuJqrJA" base_Element="_6l-WgJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="__sbS0GkZEeWI2vxwuJqrJA" base_Element="_PM8TIJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_A3uoUGkaEeWI2vxwuJqrJA" base_Element="_XymSoJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_CsGwAGkaEeWI2vxwuJqrJA" base_Element="__XpVwJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_DtXYsGkaEeWI2vxwuJqrJA" base_Element="__XpVwZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_FEzswGkaEeWI2vxwuJqrJA" base_Element="_blS3QJgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_Gjw-EGkaEeWI2vxwuJqrJA" base_Element="_blS3QZgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_IFzYkGkaEeWI2vxwuJqrJA" base_Element="_Du1jAJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_JVh7EGkaEeWI2vxwuJqrJA" base_Element="_Ouw0QJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_LK5hQGkaEeWI2vxwuJqrJA" base_Element="_Ouw0QZgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_NGlx4GkaEeWI2vxwuJqrJA" base_Element="_CqTR8JgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_OrCAIGkaEeWI2vxwuJqrJA" base_Element="_PNGEIJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_QQe7AGkaEeWI2vxwuJqrJA" base_Element="_PNGEIZgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_RfAjoGkaEeWI2vxwuJqrJA" base_Element="_j2VmwJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_S1X5oGkaEeWI2vxwuJqrJA" base_Element="_tbEFUJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_T5oL8GkaEeWI2vxwuJqrJA" base_Element="_tbEFUZgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_VL0zoGkaEeWI2vxwuJqrJA" base_Element="_XyxRwJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_WbH4UGkaEeWI2vxwuJqrJA" base_Element="_XyxRwZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_X5laYGkaEeWI2vxwuJqrJA" base_Element="_1nfewJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_Y-plAGkaEeWI2vxwuJqrJA" base_Element="_1nfewZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:Experimental xmi:id="_eEBjYGkaEeWI2vxwuJqrJA" base_Element="_gPeu4BifEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:Experimental xmi:id="_gOnysGkaEeWI2vxwuJqrJA" base_Element="_4aFTwOvTEeOE19T_GJuRHg"/>
+  <OpenModel_Profile:Experimental xmi:id="_jvji0GkaEeWI2vxwuJqrJA" base_Element="_zpR3MOvTEeOE19T_GJuRHg"/>
+  <OpenModel_Profile:Preliminary xmi:id="_n8XhgGkaEeWI2vxwuJqrJA" base_Element="_opnrsOvTEeOE19T_GJuRHg"/>
+  <OpenModel_Profile:Experimental xmi:id="_6ZSesH7lEeW277wuxq7D1g" base_Element="_YSsboGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_90KDEH7lEeW277wuxq7D1g" base_Element="_Ql5SkGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="__lCK0H7lEeW277wuxq7D1g" base_Element="_XbZx0GgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_BHCwIH7mEeW277wuxq7D1g" base_Element="_9FvssGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_Cnt4sH7mEeW277wuxq7D1g" base_Element="_DuF5sGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qw7p4JDlEeW1E_kO1HlPLw" base_StructuralFeature="_2EZj8VYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qw9fEJDlEeW1E_kO1HlPLw" base_StructuralFeature="_yODvUbA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qxDlsJDlEeW1E_kO1HlPLw" base_StructuralFeature="_-VhDcRihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:LikelyToChange xmi:id="_IzjF4JHLEeW1E_kO1HlPLw" base_Element="_oGqnr1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyAB32EeaVEcfXx-aEqQ" base_Element="_oGqilVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyAR32EeaVEcfXx-aEqQ" base_Element="_8Q4ecKxrEeS5HuAudtqItw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyAh32EeaVEcfXx-aEqQ" base_Element="_Hg3wABizEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyAx32EeaVEcfXx-aEqQ" base_Element="_oGqi3FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyBB32EeaVEcfXx-aEqQ" base_Element="_oGqjalLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyBR32EeaVEcfXx-aEqQ" base_Element="_oGqja1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyBh32EeaVEcfXx-aEqQ" base_Element="_oGqjbFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyBx32EeaVEcfXx-aEqQ" base_Element="_oGqjbVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyCB32EeaVEcfXx-aEqQ" base_Element="_oGqjf1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyCR32EeaVEcfXx-aEqQ" base_Element="_oGqjgFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyCh32EeaVEcfXx-aEqQ" base_Element="_oGqjgVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyCx32EeaVEcfXx-aEqQ" base_Element="_EZCboGaYEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyDB32EeaVEcfXx-aEqQ" base_Element="_oGqjglLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyDR32EeaVEcfXx-aEqQ" base_Element="_MvUxIGaYEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyDh32EeaVEcfXx-aEqQ" base_Element="_oGqjV1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyDx32EeaVEcfXx-aEqQ" base_Element="_oGqjWFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyEB32EeaVEcfXx-aEqQ" base_Element="_oGqjWVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyER32EeaVEcfXx-aEqQ" base_Element="_oGqjWlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyEh32EeaVEcfXx-aEqQ" base_Element="_oGqjW1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyEx32EeaVEcfXx-aEqQ" base_Element="_XrjoYL7XEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyFB32EeaVEcfXx-aEqQ" base_Element="_6LJtgKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyFR32EeaVEcfXx-aEqQ" base_Element="_pp9rwGapEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyFh32EeaVEcfXx-aEqQ" base_Element="_FVmMsKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyFx32EeaVEcfXx-aEqQ" base_Element="_xeCFAGapEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyGB32EeaVEcfXx-aEqQ" base_Element="_Gn2ewKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyGR32EeaVEcfXx-aEqQ" base_Element="_GoHkgKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyGh32EeaVEcfXx-aEqQ" base_Element="_HVLe0KNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyGx32EeaVEcfXx-aEqQ" base_Element="_3KqQoGapEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyHB32EeaVEcfXx-aEqQ" base_Element="_JCANAKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyHR32EeaVEcfXx-aEqQ" base_Element="_JCRSwKNXEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyHh32EeaVEcfXx-aEqQ" base_Element="_SI-YgKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyHx32EeaVEcfXx-aEqQ" base_Element="_7rf-kGapEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyIB32EeaVEcfXx-aEqQ" base_Element="_Sm1ZMKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyIR32EeaVEcfXx-aEqQ" base_Element="_SnGe8KQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyIh32EeaVEcfXx-aEqQ" base_Element="_dCtNEKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyIx32EeaVEcfXx-aEqQ" base_Element="_f0zvEGaqEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyJB32EeaVEcfXx-aEqQ" base_Element="_kv5iQKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyJR32EeaVEcfXx-aEqQ" base_Element="_kPd8gGaqEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyJh32EeaVEcfXx-aEqQ" base_Element="_lPav0KQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyJx32EeaVEcfXx-aEqQ" base_Element="_lPr1kKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyKB32EeaVEcfXx-aEqQ" base_Element="_pVOHkKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyKR32EeaVEcfXx-aEqQ" base_Element="_rEzcoGaqEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyKh32EeaVEcfXx-aEqQ" base_Element="_po54kKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyKx32EeaVEcfXx-aEqQ" base_Element="_ppK-UKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyLB32EeaVEcfXx-aEqQ" base_Element="_CxSZ0K4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyLR32EeaVEcfXx-aEqQ" base_Element="_wXPmoGaqEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyLh32EeaVEcfXx-aEqQ" base_Element="_Jsq3kK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyLx32EeaVEcfXx-aEqQ" base_Element="_5lnasGaqEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyMB32EeaVEcfXx-aEqQ" base_Element="_KCIKMK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyMR32EeaVEcfXx-aEqQ" base_Element="_KCdhYK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyMh32EeaVEcfXx-aEqQ" base_Element="_cF4qkK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyMx32EeaVEcfXx-aEqQ" base_Element="_9xuOwGaqEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyNB32EeaVEcfXx-aEqQ" base_Element="_fGIvgK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyNR32EeaVEcfXx-aEqQ" base_Element="_fGdfoK4AEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyNh32EeaVEcfXx-aEqQ" base_Element="_-GPhcL7eEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyNx32EeaVEcfXx-aEqQ" base_Element="_DEkBYGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyOB32EeaVEcfXx-aEqQ" base_Element="_-umh8L7eEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyOR32EeaVEcfXx-aEqQ" base_Element="_-wQHwL7eEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyOh32EeaVEcfXx-aEqQ" base_Element="_zMhw4MDWEeSoNOrYOfaryg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyOx32EeaVEcfXx-aEqQ" base_Element="_MKgSMGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyPB32EeaVEcfXx-aEqQ" base_Element="_0WGoEMDWEeSoNOrYOfaryg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyPR32EeaVEcfXx-aEqQ" base_Element="_0WmXUMDWEeSoNOrYOfaryg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyPh32EeaVEcfXx-aEqQ" base_Element="_HSrdMK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyPx32EeaVEcfXx-aEqQ" base_Element="_QhT6YGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyQB32EeaVEcfXx-aEqQ" base_Element="_OtjTUK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyQR32EeaVEcfXx-aEqQ" base_Element="_VWoqkGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyQh32EeaVEcfXx-aEqQ" base_Element="_PEIAQK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyQx32EeaVEcfXx-aEqQ" base_Element="_PEelkK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyRB32EeaVEcfXx-aEqQ" base_Element="_Sx55kK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyRR32EeaVEcfXx-aEqQ" base_Element="_Y-tkgGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyRh32EeaVEcfXx-aEqQ" base_Element="_Tz9McK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyRx32EeaVEcfXx-aEqQ" base_Element="_T0RVgK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAySB32EeaVEcfXx-aEqQ" base_Element="_bnwf8K4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAySR32EeaVEcfXx-aEqQ" base_Element="_h4nkcGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAySh32EeaVEcfXx-aEqQ" base_Element="_cz-bcK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAySx32EeaVEcfXx-aEqQ" base_Element="_c0SkgK4HEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyTB32EeaVEcfXx-aEqQ" base_Element="_OK-YkLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyTR32EeaVEcfXx-aEqQ" base_Element="_pfX6cGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyTh32EeaVEcfXx-aEqQ" base_Element="_kOFqcLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyTx32EeaVEcfXx-aEqQ" base_Element="_t2u8QGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyUB32EeaVEcfXx-aEqQ" base_Element="_q8Sn0LFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyUR32EeaVEcfXx-aEqQ" base_Element="_q8mJ0LFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyUh32EeaVEcfXx-aEqQ" base_Element="_sUoTwLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyUx32EeaVEcfXx-aEqQ" base_Element="_0ergoGarEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyVB32EeaVEcfXx-aEqQ" base_Element="_u6ossLFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyVR32EeaVEcfXx-aEqQ" base_Element="_u7m9ELFmEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyVh32EeaVEcfXx-aEqQ" base_Element="_P-Hp8MD4EeSoNOrYOfaryg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyVx32EeaVEcfXx-aEqQ" base_Element="_cS4UwGXLEeWWhJGy6csBUQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyWB32EeaVEcfXx-aEqQ" base_Element="_DUU_sGZ_EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyWR32EeaVEcfXx-aEqQ" base_Element="_SLFYkGZ_EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyWh32EeaVEcfXx-aEqQ" base_Element="_2WpC8EC7EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyWx32EeaVEcfXx-aEqQ" base_Element="_Gw-MQGasEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyXB32EeaVEcfXx-aEqQ" base_Element="_6A9_oEC7EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyXR32EeaVEcfXx-aEqQ" base_Element="_KcZ8MGasEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyXh32EeaVEcfXx-aEqQ" base_Element="_7K6DMEC7EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyXx32EeaVEcfXx-aEqQ" base_Element="_ReamYGasEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyYB32EeaVEcfXx-aEqQ" base_Element="_8qSLQEC7EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyYR32EeaVEcfXx-aEqQ" base_Element="_VjvdAGasEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyYh32EeaVEcfXx-aEqQ" base_Element="_-ixW4EC7EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyYx32EeaVEcfXx-aEqQ" base_Element="_ZvYXAGasEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyZB32EeaVEcfXx-aEqQ" base_Element="_dV67AEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyZR32EeaVEcfXx-aEqQ" base_Element="_oigQQGawEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyZh32EeaVEcfXx-aEqQ" base_Element="_fg49wEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyZx32EeaVEcfXx-aEqQ" base_Element="_tv_BwGawEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyaB32EeaVEcfXx-aEqQ" base_Element="_gq9kMEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyaR32EeaVEcfXx-aEqQ" base_Element="_y0VFYGawEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyah32EeaVEcfXx-aEqQ" base_Element="_i4cvcEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyax32EeaVEcfXx-aEqQ" base_Element="_3pKtYGawEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAybB32EeaVEcfXx-aEqQ" base_Element="_RWILYEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAybR32EeaVEcfXx-aEqQ" base_Element="__8enYGawEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAybh32EeaVEcfXx-aEqQ" base_Element="_VOHwoEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAybx32EeaVEcfXx-aEqQ" base_Element="_DgyboGaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAycB32EeaVEcfXx-aEqQ" base_Element="_W4avQEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAycR32EeaVEcfXx-aEqQ" base_Element="_HbsK8GaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAych32EeaVEcfXx-aEqQ" base_Element="_XrdVwEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAycx32EeaVEcfXx-aEqQ" base_Element="_K-pUUGaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAydB32EeaVEcfXx-aEqQ" base_Element="_YcGIgEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAydR32EeaVEcfXx-aEqQ" base_Element="_OV488GaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAydh32EeaVEcfXx-aEqQ" base_Element="_T5GykEDNEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAydx32EeaVEcfXx-aEqQ" base_Element="_UhgxsGaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyeB32EeaVEcfXx-aEqQ" base_Element="_YHthAEDNEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyeR32EeaVEcfXx-aEqQ" base_Element="_aeRIsEDNEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyeh32EeaVEcfXx-aEqQ" base_Element="_g2JzIGaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyex32EeaVEcfXx-aEqQ" base_Element="_cw_ZQEDNEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyfB32EeaVEcfXx-aEqQ" base_Element="_nTpbAGaxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyfR32EeaVEcfXx-aEqQ" base_Element="_c3Hu8Gb3EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyfh32EeaVEcfXx-aEqQ" base_Element="_mmORgGb3EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyfx32EeaVEcfXx-aEqQ" base_Element="_6anG8GeEEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAygB32EeaVEcfXx-aEqQ" base_Element="_LNz-YGeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAygR32EeaVEcfXx-aEqQ" base_Element="_fQ-KsGeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAygh32EeaVEcfXx-aEqQ" base_Element="_wToacGeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAygx32EeaVEcfXx-aEqQ" base_Element="_z8-fsGeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyhB32EeaVEcfXx-aEqQ" base_Element="_3q5i8GeFEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyhR32EeaVEcfXx-aEqQ" base_Element="_CYFeYGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyhh32EeaVEcfXx-aEqQ" base_Element="_Ifb3IGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyhx32EeaVEcfXx-aEqQ" base_Element="_LtQeAGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyiB32EeaVEcfXx-aEqQ" base_Element="_UKGHcGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyiR32EeaVEcfXx-aEqQ" base_Element="_YWtR0GeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyih32EeaVEcfXx-aEqQ" base_Element="_cxqaMGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyix32EeaVEcfXx-aEqQ" base_Element="_gjpeEGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyjB32EeaVEcfXx-aEqQ" base_Element="_nkZkAGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyjR32EeaVEcfXx-aEqQ" base_Element="_ueUCIGeGEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyjh32EeaVEcfXx-aEqQ" base_Element="_OseLsGeHEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyjx32EeaVEcfXx-aEqQ" base_Element="_oGqltlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAykB32EeaVEcfXx-aEqQ" base_Element="_oGql-FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAykR32EeaVEcfXx-aEqQ" base_Element="_nATnUFlqEeSUSuWjwt7kSQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAykh32EeaVEcfXx-aEqQ" base_Element="_GmUo8I2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAykx32EeaVEcfXx-aEqQ" base_Element="_QTidoJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAylB32EeaVEcfXx-aEqQ" base_Element="_oGqmAlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAylR32EeaVEcfXx-aEqQ" base_Element="_MgmPsGY3EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAylh32EeaVEcfXx-aEqQ" base_Element="_oGqmBFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAylx32EeaVEcfXx-aEqQ" base_Element="_oGqmA1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAymB32EeaVEcfXx-aEqQ" base_Element="_oGqmBVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAymR32EeaVEcfXx-aEqQ" base_Element="_pTYPQGXOEeWWhJGy6csBUQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAymh32EeaVEcfXx-aEqQ" base_Element="_oGqmB1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAymx32EeaVEcfXx-aEqQ" base_Element="_oGqmBlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAynB32EeaVEcfXx-aEqQ" base_Element="_oGql_1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAynR32EeaVEcfXx-aEqQ" base_Element="_uqwoYGY2EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAynh32EeaVEcfXx-aEqQ" base_Element="_oGqmAVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAynx32EeaVEcfXx-aEqQ" base_Element="_oGqmAFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyoB32EeaVEcfXx-aEqQ" base_Element="_2ES2QFYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyoR32EeaVEcfXx-aEqQ" base_Element="_XeBh0GXPEeWWhJGy6csBUQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyoh32EeaVEcfXx-aEqQ" base_Element="_2ES2QVYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyox32EeaVEcfXx-aEqQ" base_Element="_2ES2QlYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAypB32EeaVEcfXx-aEqQ" base_Element="_dm_ngBiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAypR32EeaVEcfXx-aEqQ" base_Element="_WI_Q0GY4EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyph32EeaVEcfXx-aEqQ" base_Element="_dm_ngRiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAypx32EeaVEcfXx-aEqQ" base_Element="_dm_nghiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyqB32EeaVEcfXx-aEqQ" base_Element="_oGqmC1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyqR32EeaVEcfXx-aEqQ" base_Element="_oGql6lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyqh32EeaVEcfXx-aEqQ" base_Element="_IneoYI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyqx32EeaVEcfXx-aEqQ" base_Element="_oGqmFVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyrB32EeaVEcfXx-aEqQ" base_Element="_wGzdsGY4EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyrR32EeaVEcfXx-aEqQ" base_Element="_oGqmF1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyrh32EeaVEcfXx-aEqQ" base_Element="_oGqmFlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyrx32EeaVEcfXx-aEqQ" base_Element="_i7UzkFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAysB32EeaVEcfXx-aEqQ" base_Element="_lXFJEGXfEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAysR32EeaVEcfXx-aEqQ" base_Element="_i7UzkVYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAysh32EeaVEcfXx-aEqQ" base_Element="_i7UzklYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAysx32EeaVEcfXx-aEqQ" base_Element="_A8SFwFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAytB32EeaVEcfXx-aEqQ" base_Element="_uRMkYGXfEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAytR32EeaVEcfXx-aEqQ" base_Element="_A8SFwVYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyth32EeaVEcfXx-aEqQ" base_Element="_A8SFwlYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAytx32EeaVEcfXx-aEqQ" base_Element="_gqUk0FYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyuB32EeaVEcfXx-aEqQ" base_Element="_xC7hoGXeEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyuR32EeaVEcfXx-aEqQ" base_Element="_gqUk0VYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyuh32EeaVEcfXx-aEqQ" base_Element="_gqUk0lYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyux32EeaVEcfXx-aEqQ" base_Element="_d_droFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyvB32EeaVEcfXx-aEqQ" base_Element="_zfUkMGXhEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICAyvR32EeaVEcfXx-aEqQ" base_Element="_d_droVYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ78B32EeaVEcfXx-aEqQ" base_Element="_d_drolYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ78R32EeaVEcfXx-aEqQ" base_Element="_v6GHsJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ78h32EeaVEcfXx-aEqQ" base_Element="_jJK_cGaBEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ78x32EeaVEcfXx-aEqQ" base_Element="_v6GHsZ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ79B32EeaVEcfXx-aEqQ" base_Element="_v6GHsp4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ79R32EeaVEcfXx-aEqQ" base_Element="_7R-PIAgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ79h32EeaVEcfXx-aEqQ" base_Element="_9GvqcGYuEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ79x32EeaVEcfXx-aEqQ" base_Element="_7R-PIQgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7-B32EeaVEcfXx-aEqQ" base_Element="_7R-PIggoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7-R32EeaVEcfXx-aEqQ" base_Element="_9_yMUEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7-h32EeaVEcfXx-aEqQ" base_Element="_VWLLwGdUEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7-x32EeaVEcfXx-aEqQ" base_Element="_-XpSsEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7_B32EeaVEcfXx-aEqQ" base_Element="_-X6YcEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7_R32EeaVEcfXx-aEqQ" base_Element="_oGqneFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7_h32EeaVEcfXx-aEqQ" base_Element="_fZoe8FlsEeSUSuWjwt7kSQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ7_x32EeaVEcfXx-aEqQ" base_Element="_yl3LUI2tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8AB32EeaVEcfXx-aEqQ" base_Element="_oGqneVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8AR32EeaVEcfXx-aEqQ" base_Element="_UU5fkGaREeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ah32EeaVEcfXx-aEqQ" base_Element="_oGqne1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ax32EeaVEcfXx-aEqQ" base_Element="_oGqnelLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8BB32EeaVEcfXx-aEqQ" base_Element="_oGqnf1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8BR32EeaVEcfXx-aEqQ" base_Element="_kD16IGaQEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Bh32EeaVEcfXx-aEqQ" base_Element="_oGqngVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Bx32EeaVEcfXx-aEqQ" base_Element="_oGqngFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8CB32EeaVEcfXx-aEqQ" base_Element="_oGqnfFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8CR32EeaVEcfXx-aEqQ" base_Element="_GpVj8GaQEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ch32EeaVEcfXx-aEqQ" base_Element="_oGqnflLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Cx32EeaVEcfXx-aEqQ" base_Element="_oGqnfVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8DB32EeaVEcfXx-aEqQ" base_Element="_oGqnjVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8DR32EeaVEcfXx-aEqQ" base_Element="_qWxW8GZzEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Dh32EeaVEcfXx-aEqQ" base_Element="_JT5CcI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Dx32EeaVEcfXx-aEqQ" base_Element="_RvF1oJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8EB32EeaVEcfXx-aEqQ" base_Element="_oGqnkFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ER32EeaVEcfXx-aEqQ" base_Element="_FNK8MGZ1EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Eh32EeaVEcfXx-aEqQ" base_Element="_oGqnklLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ex32EeaVEcfXx-aEqQ" base_Element="_oGqnkVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8FB32EeaVEcfXx-aEqQ" base_Element="_oGqnk1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8FR32EeaVEcfXx-aEqQ" base_Element="_c2YpMGZ1EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Fh32EeaVEcfXx-aEqQ" base_Element="_oGqnlVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Fx32EeaVEcfXx-aEqQ" base_Element="_oGqnlFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8GB32EeaVEcfXx-aEqQ" base_Element="_oGqnllLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8GR32EeaVEcfXx-aEqQ" base_Element="_vVInAGZ2EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Gh32EeaVEcfXx-aEqQ" base_Element="_oGqnmFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Gx32EeaVEcfXx-aEqQ" base_Element="_oGqnl1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8HB32EeaVEcfXx-aEqQ" base_Element="_DjfvMKNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8HR32EeaVEcfXx-aEqQ" base_Element="_fVjIYGZ3EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Hh32EeaVEcfXx-aEqQ" base_Element="_DjfvMaNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Hx32EeaVEcfXx-aEqQ" base_Element="_DjfvMqNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8IB32EeaVEcfXx-aEqQ" base_Element="_RtwvMKT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8IR32EeaVEcfXx-aEqQ" base_Element="_RTIEkGZ5EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ih32EeaVEcfXx-aEqQ" base_Element="_RtwvMaT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ix32EeaVEcfXx-aEqQ" base_Element="_RtwvMqT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8JB32EeaVEcfXx-aEqQ" base_Element="_yfYoEEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8JR32EeaVEcfXx-aEqQ" base_Element="_ZLLHYGdUEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Jh32EeaVEcfXx-aEqQ" base_Element="_0ZK0MEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Jx32EeaVEcfXx-aEqQ" base_Element="_0Zb58EC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8KB32EeaVEcfXx-aEqQ" base_Element="_oGqnr1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8KR32EeaVEcfXx-aEqQ" base_Element="_oGqnsFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Kh32EeaVEcfXx-aEqQ" base_Element="_1AQxMI2tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Kx32EeaVEcfXx-aEqQ" base_Element="_oGqnslLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8LB32EeaVEcfXx-aEqQ" base_Element="_j4rTUGaNEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8LR32EeaVEcfXx-aEqQ" base_Element="_oGqntFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Lh32EeaVEcfXx-aEqQ" base_Element="_oGqns1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Lx32EeaVEcfXx-aEqQ" base_Element="_oGqntVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8MB32EeaVEcfXx-aEqQ" base_Element="_D-WEsGaNEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8MR32EeaVEcfXx-aEqQ" base_Element="_oGqnt1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Mh32EeaVEcfXx-aEqQ" base_Element="_oGqntlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Mx32EeaVEcfXx-aEqQ" base_Element="_DyAG8FYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8NB32EeaVEcfXx-aEqQ" base_Element="_2O5nQGaOEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8NR32EeaVEcfXx-aEqQ" base_Element="_DyAG8VYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Nh32EeaVEcfXx-aEqQ" base_Element="_DyAG8lYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Nx32EeaVEcfXx-aEqQ" base_Element="_oGqoB1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8OB32EeaVEcfXx-aEqQ" base_Element="_Zm4WkGaREeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8OR32EeaVEcfXx-aEqQ" base_Element="_KLgm8I2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Oh32EeaVEcfXx-aEqQ" base_Element="_b_lUAFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ox32EeaVEcfXx-aEqQ" base_Element="_1C1FsGXeEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8PB32EeaVEcfXx-aEqQ" base_Element="_YKPO0I2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8PR32EeaVEcfXx-aEqQ" base_Element="_IxS2AFYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ph32EeaVEcfXx-aEqQ" base_Element="_bMP-cGZ8EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Px32EeaVEcfXx-aEqQ" base_Element="_IxS2AVYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8QB32EeaVEcfXx-aEqQ" base_Element="_IxS2AlYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8QR32EeaVEcfXx-aEqQ" base_Element="_Ykm6QFeGEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Qh32EeaVEcfXx-aEqQ" base_Element="_y3OwkGZ9EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Qx32EeaVEcfXx-aEqQ" base_Element="_Y9kz4FeGEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8RB32EeaVEcfXx-aEqQ" base_Element="_Y915oFeGEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8RR32EeaVEcfXx-aEqQ" base_Element="_1HbEgEDAEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Rh32EeaVEcfXx-aEqQ" base_Element="_diIzMGY5EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Rx32EeaVEcfXx-aEqQ" base_Element="_Dd7akEDCEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8SB32EeaVEcfXx-aEqQ" base_Element="_DeNHYEDCEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8SR32EeaVEcfXx-aEqQ" base_Element="_gROecFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Sh32EeaVEcfXx-aEqQ" base_Element="_IX_aMFlqEeSUSuWjwt7kSQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Sx32EeaVEcfXx-aEqQ" base_Element="_XUDNsI2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8TB32EeaVEcfXx-aEqQ" base_Element="_OwauQFeEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8TR32EeaVEcfXx-aEqQ" base_Element="_hDARUGXKEeWWhJGy6csBUQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Th32EeaVEcfXx-aEqQ" base_Element="_OwauQVeEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Tx32EeaVEcfXx-aEqQ" base_Element="_OwauQleEEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8UB32EeaVEcfXx-aEqQ" base_Element="_zbRdEBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8UR32EeaVEcfXx-aEqQ" base_Element="_a8fOUGYzEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Uh32EeaVEcfXx-aEqQ" base_Element="_zbRdERiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Ux32EeaVEcfXx-aEqQ" base_Element="_zbRdEhiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8VB32EeaVEcfXx-aEqQ" base_Element="_CUJD4BicEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8VR32EeaVEcfXx-aEqQ" base_Element="_pSv2sGaKEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Vh32EeaVEcfXx-aEqQ" base_Element="_C4-PQBicEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Vx32EeaVEcfXx-aEqQ" base_Element="_C5X34BicEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8WB32EeaVEcfXx-aEqQ" base_Element="_GuuSYEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8WR32EeaVEcfXx-aEqQ" base_Element="_kuahEGdUEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Wh32EeaVEcfXx-aEqQ" base_Element="_HFnvcEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Wx32EeaVEcfXx-aEqQ" base_Element="_HF-UwEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8XB32EeaVEcfXx-aEqQ" base_Element="_p2YfoGeEEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8XR32EeaVEcfXx-aEqQ" base_Element="_3UayEGeEEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Xh32EeaVEcfXx-aEqQ" base_Element="_eEpDMFX4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Xx32EeaVEcfXx-aEqQ" base_Element="_O_KOIHR-EeO4pZvobs-yIg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8YB32EeaVEcfXx-aEqQ" base_Element="_4XUzoI2tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8YR32EeaVEcfXx-aEqQ" base_Element="_D4N9IFX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Yh32EeaVEcfXx-aEqQ" base_Element="_otFNMGYvEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Yx32EeaVEcfXx-aEqQ" base_Element="_D4OkMFX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ZB32EeaVEcfXx-aEqQ" base_Element="_D4OkMVX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ZR32EeaVEcfXx-aEqQ" base_Element="_3Y4zAFYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Zh32EeaVEcfXx-aEqQ" base_Element="_9A4dkGYvEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8Zx32EeaVEcfXx-aEqQ" base_Element="_3Y4zAVYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8aB32EeaVEcfXx-aEqQ" base_Element="_3Y4zAlYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8aR32EeaVEcfXx-aEqQ" base_Element="_lvFOQFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ah32EeaVEcfXx-aEqQ" base_Element="_cEQPAGYwEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ax32EeaVEcfXx-aEqQ" base_Element="_lvFOQVYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8bB32EeaVEcfXx-aEqQ" base_Element="_lvFOQlYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8bR32EeaVEcfXx-aEqQ" base_Element="_CHM6YFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8bh32EeaVEcfXx-aEqQ" base_Element="_qRR48GYxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8bx32EeaVEcfXx-aEqQ" base_Element="_CHM6YVYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8cB32EeaVEcfXx-aEqQ" base_Element="_CHM6YlYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8cR32EeaVEcfXx-aEqQ" base_Element="_TkuhMFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ch32EeaVEcfXx-aEqQ" base_Element="_-sn7wGYxEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8cx32EeaVEcfXx-aEqQ" base_Element="_TkuhMVYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8dB32EeaVEcfXx-aEqQ" base_Element="_TkuhMlYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8dR32EeaVEcfXx-aEqQ" base_Element="_5tEV0BiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8dh32EeaVEcfXx-aEqQ" base_Element="_tAitcGXiEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8dx32EeaVEcfXx-aEqQ" base_Element="_5tEV0RiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8eB32EeaVEcfXx-aEqQ" base_Element="_5tEV0hiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8eR32EeaVEcfXx-aEqQ" base_Element="_RLDi4BieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8eh32EeaVEcfXx-aEqQ" base_Element="_88FkIGXiEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ex32EeaVEcfXx-aEqQ" base_Element="_R6bxYBieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8fB32EeaVEcfXx-aEqQ" base_Element="_R61aABieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8fR32EeaVEcfXx-aEqQ" base_Element="_vq1NIBigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8fh32EeaVEcfXx-aEqQ" base_Element="_qvPK0GYyEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8fx32EeaVEcfXx-aEqQ" base_Element="_vq1NIRigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8gB32EeaVEcfXx-aEqQ" base_Element="_vq1NIhigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8gR32EeaVEcfXx-aEqQ" base_Element="_S811EEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8gh32EeaVEcfXx-aEqQ" base_Element="_g606sGdUEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8gx32EeaVEcfXx-aEqQ" base_Element="_TbSEkEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8hB32EeaVEcfXx-aEqQ" base_Element="_TbijQEDBEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8hR32EeaVEcfXx-aEqQ" base_Element="_9UVusFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8hh32EeaVEcfXx-aEqQ" base_Element="_Rsz_EFlrEeSUSuWjwt7kSQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8hx32EeaVEcfXx-aEqQ" base_Element="_Y17QII2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8iB32EeaVEcfXx-aEqQ" base_Element="_CadNIFaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8iR32EeaVEcfXx-aEqQ" base_Element="_chP0AGXjEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ih32EeaVEcfXx-aEqQ" base_Element="_CadNIVaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ix32EeaVEcfXx-aEqQ" base_Element="_CadNIlaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8jB32EeaVEcfXx-aEqQ" base_Element="_a97NQFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8jR32EeaVEcfXx-aEqQ" base_Element="_TOCGsHcNEeO5z_IJj67BhQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8jh32EeaVEcfXx-aEqQ" base_Element="_ZiVDII2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8jx32EeaVEcfXx-aEqQ" base_Element="_oGqn6FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8kB32EeaVEcfXx-aEqQ" base_Element="_oGqn6VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8kR32EeaVEcfXx-aEqQ" base_Element="_oGqn5lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8kh32EeaVEcfXx-aEqQ" base_Element="_oGqn51LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8kx32EeaVEcfXx-aEqQ" base_Element="_oGqn6lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8lB32EeaVEcfXx-aEqQ" base_Element="_oGqn61LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8lR32EeaVEcfXx-aEqQ" base_Element="_oGqn41LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8lh32EeaVEcfXx-aEqQ" base_Element="_oGqn5FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8lx32EeaVEcfXx-aEqQ" base_Element="_oGqn5VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8mB32EeaVEcfXx-aEqQ" base_Element="_2PdiYI8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8mR32EeaVEcfXx-aEqQ" base_Element="_nSVYYGYtEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8mh32EeaVEcfXx-aEqQ" base_Element="_2PdiYY8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8mx32EeaVEcfXx-aEqQ" base_Element="_2PdiYo8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8nB32EeaVEcfXx-aEqQ" base_Element="_DEWvsJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8nR32EeaVEcfXx-aEqQ" base_Element="_lR8-8GaDEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8nh32EeaVEcfXx-aEqQ" base_Element="_DEWvsZozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8nx32EeaVEcfXx-aEqQ" base_Element="_DEWvspozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8oB32EeaVEcfXx-aEqQ" base_Element="_1EKuQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8oR32EeaVEcfXx-aEqQ" base_Element="_FA9ZQGaCEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8oh32EeaVEcfXx-aEqQ" base_Element="_1EKuQZo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ox32EeaVEcfXx-aEqQ" base_Element="_1EKuQpo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8pB32EeaVEcfXx-aEqQ" base_Element="_tbetAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8pR32EeaVEcfXx-aEqQ" base_Element="_LAwYgGaCEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ph32EeaVEcfXx-aEqQ" base_Element="_tbetAZ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8px32EeaVEcfXx-aEqQ" base_Element="_tbetAp4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8qB32EeaVEcfXx-aEqQ" base_Element="_H7c0oIgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8qR32EeaVEcfXx-aEqQ" base_Element="_g5HvwGZ-EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8qh32EeaVEcfXx-aEqQ" base_Element="_aG2sgI2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8qx32EeaVEcfXx-aEqQ" base_Element="_XipL8IgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8rB32EeaVEcfXx-aEqQ" base_Element="_LnPvwGaNEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8rR32EeaVEcfXx-aEqQ" base_Element="_XipL8YgjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8rh32EeaVEcfXx-aEqQ" base_Element="_XipL8ogjEeOIkJV2fkx5ZA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8rx32EeaVEcfXx-aEqQ" base_Element="_br9TQBNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8sB32EeaVEcfXx-aEqQ" base_Element="_GZg54GZ9EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8sR32EeaVEcfXx-aEqQ" base_Element="_br9TQRNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8sh32EeaVEcfXx-aEqQ" base_Element="_br9TQhNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8sx32EeaVEcfXx-aEqQ" base_Element="_sz8KcBieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8tB32EeaVEcfXx-aEqQ" base_Element="_-pF_oGZ-EeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8tR32EeaVEcfXx-aEqQ" base_Element="_wVT_cBieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8th32EeaVEcfXx-aEqQ" base_Element="_wVzusBieEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8tx32EeaVEcfXx-aEqQ" base_Element="_m79KEJ2KEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8uB32EeaVEcfXx-aEqQ" base_Element="_DlqK0GaAEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8uR32EeaVEcfXx-aEqQ" base_Element="_pW14IJ2KEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8uh32EeaVEcfXx-aEqQ" base_Element="_pXG94J2KEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8ux32EeaVEcfXx-aEqQ" base_Element="_NfrbEEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8vB32EeaVEcfXx-aEqQ" base_Element="_dax7YGdUEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8vR32EeaVEcfXx-aEqQ" base_Element="_SQrE4EC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8vh32EeaVEcfXx-aEqQ" base_Element="_SQ8xsEC8EeWxhL2B6Peg6A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8vx32EeaVEcfXx-aEqQ" base_Element="_KsslQL7XEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8wB32EeaVEcfXx-aEqQ" base_Element="_GCL5wJywEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8wR32EeaVEcfXx-aEqQ" base_Element="_nEnuEGaREeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8wh32EeaVEcfXx-aEqQ" base_Element="_y7uSYKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8wx32EeaVEcfXx-aEqQ" base_Element="_s_Ao4GaREeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8xB32EeaVEcfXx-aEqQ" base_Element="_3G8VoKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8xR32EeaVEcfXx-aEqQ" base_Element="_3HOpgKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8xh32EeaVEcfXx-aEqQ" base_Element="_W79L4JyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8xx32EeaVEcfXx-aEqQ" base_Element="_1aqmkGaREeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8yB32EeaVEcfXx-aEqQ" base_Element="_xudDYKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8yR32EeaVEcfXx-aEqQ" base_Element="_-3SSAGaREeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8yh32EeaVEcfXx-aEqQ" base_Element="_yM0aYKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8yx32EeaVEcfXx-aEqQ" base_Element="_yNFgIKQZEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8zB32EeaVEcfXx-aEqQ" base_Element="_d6GCsJyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8zR32EeaVEcfXx-aEqQ" base_Element="_rY2cAGaUEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8zh32EeaVEcfXx-aEqQ" base_Element="_egyYAK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ8zx32EeaVEcfXx-aEqQ" base_Element="_4Bjo8GaUEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ80B32EeaVEcfXx-aEqQ" base_Element="_fFtC8K4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ80R32EeaVEcfXx-aEqQ" base_Element="_fGAk8K4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ80h32EeaVEcfXx-aEqQ" base_Element="_yN3iELA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ80x32EeaVEcfXx-aEqQ" base_Element="_A9__gGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ81B32EeaVEcfXx-aEqQ" base_Element="_yN3iEbA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ81R32EeaVEcfXx-aEqQ" base_Element="_yN3iErA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ81h32EeaVEcfXx-aEqQ" base_Element="_sVcR8JyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ81x32EeaVEcfXx-aEqQ" base_Element="_JUwPEGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ82B32EeaVEcfXx-aEqQ" base_Element="_HkibYKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ82R32EeaVEcfXx-aEqQ" base_Element="_R3K8EGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ82h32EeaVEcfXx-aEqQ" base_Element="_IHGV4KNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ82x32EeaVEcfXx-aEqQ" base_Element="_IHXboKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICJ83B32EeaVEcfXx-aEqQ" base_Element="_QcR4IKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs8B32EeaVEcfXx-aEqQ" base_Element="_WOHHIGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs8R32EeaVEcfXx-aEqQ" base_Element="_TZf3MKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs8h32EeaVEcfXx-aEqQ" base_Element="_TZyLEKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs8x32EeaVEcfXx-aEqQ" base_Element="_ZID8gKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs9B32EeaVEcfXx-aEqQ" base_Element="_a6hy8GaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs9R32EeaVEcfXx-aEqQ" base_Element="_a2plQKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs9h32EeaVEcfXx-aEqQ" base_Element="_a27SEKNVEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs9x32EeaVEcfXx-aEqQ" base_Element="_4ySjcK3mEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs-B32EeaVEcfXx-aEqQ" base_Element="_fYcvwGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs-R32EeaVEcfXx-aEqQ" base_Element="_8iqdwK3mEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs-h32EeaVEcfXx-aEqQ" base_Element="_8jAcAK3mEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs-x32EeaVEcfXx-aEqQ" base_Element="_wuhLAJyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs_B32EeaVEcfXx-aEqQ" base_Element="_pA0YMGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs_R32EeaVEcfXx-aEqQ" base_Element="_VIujsKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs_h32EeaVEcfXx-aEqQ" base_Element="_tYuMkGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTs_x32EeaVEcfXx-aEqQ" base_Element="_X3MVEKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtAB32EeaVEcfXx-aEqQ" base_Element="_X3da0KNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtAR32EeaVEcfXx-aEqQ" base_Element="_ZuWrAKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtAh32EeaVEcfXx-aEqQ" base_Element="_yJUNwGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtAx32EeaVEcfXx-aEqQ" base_Element="_bH_XcKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtBB32EeaVEcfXx-aEqQ" base_Element="_bIQdMKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtBR32EeaVEcfXx-aEqQ" base_Element="_bVjSUKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtBh32EeaVEcfXx-aEqQ" base_Element="_2ao5AGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtBx32EeaVEcfXx-aEqQ" base_Element="_cdzT0KNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtCB32EeaVEcfXx-aEqQ" base_Element="_ceFnsKNWEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtCR32EeaVEcfXx-aEqQ" base_Element="_hGi0wL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtCh32EeaVEcfXx-aEqQ" base_Element="_6gKj8GaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtCx32EeaVEcfXx-aEqQ" base_Element="_hiuacL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtDB32EeaVEcfXx-aEqQ" base_Element="_hjG08L7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtDR32EeaVEcfXx-aEqQ" base_Element="_9tZgcL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtDh32EeaVEcfXx-aEqQ" base_Element="_-rD3EGaVEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtDx32EeaVEcfXx-aEqQ" base_Element="_-FG10L7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtEB32EeaVEcfXx-aEqQ" base_Element="_-Fa-4L7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtER32EeaVEcfXx-aEqQ" base_Element="_piS5EL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtEh32EeaVEcfXx-aEqQ" base_Element="_DOMrEGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtEx32EeaVEcfXx-aEqQ" base_Element="_qpM2wL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtFB32EeaVEcfXx-aEqQ" base_Element="_qpgYwL7aEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtFR32EeaVEcfXx-aEqQ" base_Element="_1EYYAJyzEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtFh32EeaVEcfXx-aEqQ" base_Element="_H4hFIGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtFx32EeaVEcfXx-aEqQ" base_Element="_FFQqkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtGB32EeaVEcfXx-aEqQ" base_Element="_LuQAkGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtGR32EeaVEcfXx-aEqQ" base_Element="_FvhvkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtGh32EeaVEcfXx-aEqQ" base_Element="_Fvy1UKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtGx32EeaVEcfXx-aEqQ" base_Element="_INhcAKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtHB32EeaVEcfXx-aEqQ" base_Element="_R89lkGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtHR32EeaVEcfXx-aEqQ" base_Element="_KCVokKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtHh32EeaVEcfXx-aEqQ" base_Element="_KCmuUKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtHx32EeaVEcfXx-aEqQ" base_Element="_Nhv4QK3rEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtIB32EeaVEcfXx-aEqQ" base_Element="_VMxJcGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtIR32EeaVEcfXx-aEqQ" base_Element="_OAC90K3rEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtIh32EeaVEcfXx-aEqQ" base_Element="_OAcmcK3rEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtIx32EeaVEcfXx-aEqQ" base_Element="_kZMnkKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtJB32EeaVEcfXx-aEqQ" base_Element="_fiLeEGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtJR32EeaVEcfXx-aEqQ" base_Element="_k-MyEKQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtJh32EeaVEcfXx-aEqQ" base_Element="_k-d30KQbEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtJx32EeaVEcfXx-aEqQ" base_Element="_MROewJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtKB32EeaVEcfXx-aEqQ" base_Element="_lzGCgGaWEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtKR32EeaVEcfXx-aEqQ" base_Element="_eH6McJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtKh32EeaVEcfXx-aEqQ" base_Element="_eH6McZ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtKx32EeaVEcfXx-aEqQ" base_Element="_eH6Mcp2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtLB32EeaVEcfXx-aEqQ" base_Element="_ny1ZoJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtLR32EeaVEcfXx-aEqQ" base_Element="_ny1ZoZ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtLh32EeaVEcfXx-aEqQ" base_Element="_ny1Zop2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtLx32EeaVEcfXx-aEqQ" base_Element="_woOF8J2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtMB32EeaVEcfXx-aEqQ" base_Element="_woOF8Z2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtMR32EeaVEcfXx-aEqQ" base_Element="_woOF8p2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtMh32EeaVEcfXx-aEqQ" base_Element="_CEGuAJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtMx32EeaVEcfXx-aEqQ" base_Element="_CEGuAZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtNB32EeaVEcfXx-aEqQ" base_Element="_CEGuAp2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtNR32EeaVEcfXx-aEqQ" base_Element="_QLzBcJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtNh32EeaVEcfXx-aEqQ" base_Element="_QLzBcZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtNx32EeaVEcfXx-aEqQ" base_Element="_QLzBcp2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtOB32EeaVEcfXx-aEqQ" base_Element="_h8bfkJ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtOR32EeaVEcfXx-aEqQ" base_Element="_h8bfkZ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtOh32EeaVEcfXx-aEqQ" base_Element="_h8bfkp2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtOx32EeaVEcfXx-aEqQ" base_Element="_f9upIJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtPB32EeaVEcfXx-aEqQ" base_Element="_f9upIZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtPR32EeaVEcfXx-aEqQ" base_Element="_f9upIp2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtPh32EeaVEcfXx-aEqQ" base_Element="_dDyVoJ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtPx32EeaVEcfXx-aEqQ" base_Element="_dvBo8GaXEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtQB32EeaVEcfXx-aEqQ" base_Element="__L6xcK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtQR32EeaVEcfXx-aEqQ" base_Element="_ymIasGaXEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtQh32EeaVEcfXx-aEqQ" base_Element="__h5BcK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtQx32EeaVEcfXx-aEqQ" base_Element="__iPmwK4GEeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtRB32EeaVEcfXx-aEqQ" base_Element="_oGqwB1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtRR32EeaVEcfXx-aEqQ" base_Element="_OdhAUJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtRh32EeaVEcfXx-aEqQ" base_Element="_Gck6kCOtEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtRx32EeaVEcfXx-aEqQ" base_Element="_ceQCACOtEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtSB32EeaVEcfXx-aEqQ" base_Element="_ZSaakEDCEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtSR32EeaVEcfXx-aEqQ" base_Element="_iyGBEEDCEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtSh32EeaVEcfXx-aEqQ" base_Element="_WhF3kEDEEeWQeOKbNUpP9A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtSx32EeaVEcfXx-aEqQ" base_Element="_PpZIwL7XEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtTB32EeaVEcfXx-aEqQ" base_Element="_muJzIJzQEeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtTR32EeaVEcfXx-aEqQ" base_Element="_lMthgKNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtTh32EeaVEcfXx-aEqQ" base_Element="_YcO9QKVCEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtTx32EeaVEcfXx-aEqQ" base_Element="_qBHToKePEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtUB32EeaVEcfXx-aEqQ" base_Element="_tyBQYBirEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtUR32EeaVEcfXx-aEqQ" base_Element="_oGqm3FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtUh32EeaVEcfXx-aEqQ" base_Element="_oGqm31LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtUx32EeaVEcfXx-aEqQ" base_Element="_oGqm4VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtVB32EeaVEcfXx-aEqQ" base_Element="_oGqm4FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtVR32EeaVEcfXx-aEqQ" base_Element="_oGqnhVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtVh32EeaVEcfXx-aEqQ" base_Element="_oGqnilLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtVx32EeaVEcfXx-aEqQ" base_Element="_oGqnjFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtWB32EeaVEcfXx-aEqQ" base_Element="_oGqni1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtWR32EeaVEcfXx-aEqQ" base_Element="_oGqnu1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtWh32EeaVEcfXx-aEqQ" base_Element="_oGqnvlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtWx32EeaVEcfXx-aEqQ" base_Element="_oGqnwFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtXB32EeaVEcfXx-aEqQ" base_Element="_oGqnv1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtXR32EeaVEcfXx-aEqQ" base_Element="_oGqnwVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtXh32EeaVEcfXx-aEqQ" base_Element="_oGqnxFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtXx32EeaVEcfXx-aEqQ" base_Element="_oGqnxlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtYB32EeaVEcfXx-aEqQ" base_Element="_oGqnxVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtYR32EeaVEcfXx-aEqQ" base_Element="_oGqnx1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtYh32EeaVEcfXx-aEqQ" base_Element="_oGqnylLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtYx32EeaVEcfXx-aEqQ" base_Element="_oGqnzFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtZB32EeaVEcfXx-aEqQ" base_Element="_oGqny1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtZR32EeaVEcfXx-aEqQ" base_Element="_oGqnzVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtZh32EeaVEcfXx-aEqQ" base_Element="_oGqn0FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtZx32EeaVEcfXx-aEqQ" base_Element="_oGqn0lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtaB32EeaVEcfXx-aEqQ" base_Element="_oGqn0VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtaR32EeaVEcfXx-aEqQ" base_Element="_oGqn01LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtah32EeaVEcfXx-aEqQ" base_Element="_oGqn2FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtax32EeaVEcfXx-aEqQ" base_Element="_oGqn2lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtbB32EeaVEcfXx-aEqQ" base_Element="_oGqn2VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtbR32EeaVEcfXx-aEqQ" base_Element="_oGqoD1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtbh32EeaVEcfXx-aEqQ" base_Element="_oGqoEFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtbx32EeaVEcfXx-aEqQ" base_Element="_oGqoElLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtcB32EeaVEcfXx-aEqQ" base_Element="_oGqoEVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtcR32EeaVEcfXx-aEqQ" base_Element="_i7cIUFYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtch32EeaVEcfXx-aEqQ" base_Element="_i7cIUVYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtcx32EeaVEcfXx-aEqQ" base_Element="_i7cIUlYfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtdB32EeaVEcfXx-aEqQ" base_Element="_i7cIU1YfEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtdR32EeaVEcfXx-aEqQ" base_Element="_A8YzcFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtdh32EeaVEcfXx-aEqQ" base_Element="_A8YzcVYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtdx32EeaVEcfXx-aEqQ" base_Element="_A8YzclYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTteB32EeaVEcfXx-aEqQ" base_Element="_A8Yzc1YgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTteR32EeaVEcfXx-aEqQ" base_Element="_gqbSgFYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTteh32EeaVEcfXx-aEqQ" base_Element="_gqbSgVYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtex32EeaVEcfXx-aEqQ" base_Element="_gqbSglYgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtfB32EeaVEcfXx-aEqQ" base_Element="_gqbSg1YgEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtfR32EeaVEcfXx-aEqQ" base_Element="_d_lncFYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtfh32EeaVEcfXx-aEqQ" base_Element="_d_lncVYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtfx32EeaVEcfXx-aEqQ" base_Element="_d_lnclYhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtgB32EeaVEcfXx-aEqQ" base_Element="_d_lnc1YhEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtgR32EeaVEcfXx-aEqQ" base_Element="_2EZj8FYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtgh32EeaVEcfXx-aEqQ" base_Element="_2EZj8VYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtgx32EeaVEcfXx-aEqQ" base_Element="_2EZj8lYkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTthB32EeaVEcfXx-aEqQ" base_Element="_2EZj81YkEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTthR32EeaVEcfXx-aEqQ" base_Element="_DyIp0FYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTthh32EeaVEcfXx-aEqQ" base_Element="_DyIp0VYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTthx32EeaVEcfXx-aEqQ" base_Element="_DyIp0lYmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtiB32EeaVEcfXx-aEqQ" base_Element="_DyIp01YmEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtiR32EeaVEcfXx-aEqQ" base_Element="_CHToEFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtih32EeaVEcfXx-aEqQ" base_Element="_CHToEVYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtix32EeaVEcfXx-aEqQ" base_Element="_CHToElYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtjB32EeaVEcfXx-aEqQ" base_Element="_CHToE1YYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtjR32EeaVEcfXx-aEqQ" base_Element="_3ZB88FYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtjh32EeaVEcfXx-aEqQ" base_Element="_3ZB88VYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtjx32EeaVEcfXx-aEqQ" base_Element="_3ZB88lYWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtkB32EeaVEcfXx-aEqQ" base_Element="_3ZB881YWEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtkR32EeaVEcfXx-aEqQ" base_Element="_Tk5gUFYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtkh32EeaVEcfXx-aEqQ" base_Element="_Tk5gUVYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtkx32EeaVEcfXx-aEqQ" base_Element="_Tk5gUlYYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtlB32EeaVEcfXx-aEqQ" base_Element="_Tk5gU1YYEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtlR32EeaVEcfXx-aEqQ" base_Element="_D4V48FX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtlh32EeaVEcfXx-aEqQ" base_Element="_D4V48VX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtlx32EeaVEcfXx-aEqQ" base_Element="_D4V48lX5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtmB32EeaVEcfXx-aEqQ" base_Element="_D4V481X5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtmR32EeaVEcfXx-aEqQ" base_Element="_lvO_QFYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtmh32EeaVEcfXx-aEqQ" base_Element="_lvO_QVYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtmx32EeaVEcfXx-aEqQ" base_Element="_lvO_QlYXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtnB32EeaVEcfXx-aEqQ" base_Element="_lvO_Q1YXEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtnR32EeaVEcfXx-aEqQ" base_Element="_Cakh4FaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtnh32EeaVEcfXx-aEqQ" base_Element="_Cakh4VaSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtnx32EeaVEcfXx-aEqQ" base_Element="_Cakh4laSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtoB32EeaVEcfXx-aEqQ" base_Element="_Cakh41aSEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtoR32EeaVEcfXx-aEqQ" base_Element="_Ixb_8FYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtoh32EeaVEcfXx-aEqQ" base_Element="_Ixb_8VYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtox32EeaVEcfXx-aEqQ" base_Element="_Ixb_8lYnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtpB32EeaVEcfXx-aEqQ" base_Element="_Ixb_81YnEeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtpR32EeaVEcfXx-aEqQ" base_Element="_2QhSUI8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtph32EeaVEcfXx-aEqQ" base_Element="_2QhSUY8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtpx32EeaVEcfXx-aEqQ" base_Element="_2QhSUo8lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtqB32EeaVEcfXx-aEqQ" base_Element="_2QhSU48lEeOw_ste-s6RrA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtqR32EeaVEcfXx-aEqQ" base_Element="_DEn1cJozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtqh32EeaVEcfXx-aEqQ" base_Element="_DEn1cZozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtqx32EeaVEcfXx-aEqQ" base_Element="_DEn1cpozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtrB32EeaVEcfXx-aEqQ" base_Element="_DEn1c5ozEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtrR32EeaVEcfXx-aEqQ" base_Element="_1EVGUJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtrh32EeaVEcfXx-aEqQ" base_Element="_1EVGUZo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtrx32EeaVEcfXx-aEqQ" base_Element="_1EVGUpo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtsB32EeaVEcfXx-aEqQ" base_Element="_1EVGU5o5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtsR32EeaVEcfXx-aEqQ" base_Element="_tboeAJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtsh32EeaVEcfXx-aEqQ" base_Element="_tboeAZ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtsx32EeaVEcfXx-aEqQ" base_Element="_tboeAp4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTttB32EeaVEcfXx-aEqQ" base_Element="_tboeA54HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTttR32EeaVEcfXx-aEqQ" base_Element="_v6VYQJ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtth32EeaVEcfXx-aEqQ" base_Element="_v6VYQZ4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTttx32EeaVEcfXx-aEqQ" base_Element="_v6VYQp4LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtuB32EeaVEcfXx-aEqQ" base_Element="_v6VYQ54LEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtuR32EeaVEcfXx-aEqQ" base_Element="_buzL4BNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtuh32EeaVEcfXx-aEqQ" base_Element="_buzL4RNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtux32EeaVEcfXx-aEqQ" base_Element="_buzL4hNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtvB32EeaVEcfXx-aEqQ" base_Element="_buzL4xNjEeS1heseQTA6lw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtvR32EeaVEcfXx-aEqQ" base_Element="_dnWM0BiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtvh32EeaVEcfXx-aEqQ" base_Element="_dnWM0RiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtvx32EeaVEcfXx-aEqQ" base_Element="_dnWM0hiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtwB32EeaVEcfXx-aEqQ" base_Element="_dnWM0xiQEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtwR32EeaVEcfXx-aEqQ" base_Element="_zbrFsBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtwh32EeaVEcfXx-aEqQ" base_Element="_zbrFsRiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtwx32EeaVEcfXx-aEqQ" base_Element="_zbrFshiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtxB32EeaVEcfXx-aEqQ" base_Element="_zbrFsxiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtxR32EeaVEcfXx-aEqQ" base_Element="_5ta7IBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtxh32EeaVEcfXx-aEqQ" base_Element="_5ta7IRiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtxx32EeaVEcfXx-aEqQ" base_Element="_5ta7IhiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtyB32EeaVEcfXx-aEqQ" base_Element="_5ta7IxiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtyR32EeaVEcfXx-aEqQ" base_Element="_zPk24JzREeSaHrTY93cYuA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtyh32EeaVEcfXx-aEqQ" base_Element="_oGqoCFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtyx32EeaVEcfXx-aEqQ" base_Element="_oGqoCVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtzB32EeaVEcfXx-aEqQ" base_Element="_oGqoC1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtzR32EeaVEcfXx-aEqQ" base_Element="_oGqoClLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtzh32EeaVEcfXx-aEqQ" base_Element="_oGqoDFLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTtzx32EeaVEcfXx-aEqQ" base_Element="_oGqoDlLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTt0B32EeaVEcfXx-aEqQ" base_Element="_oGqoDVLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICTt0R32EeaVEcfXx-aEqQ" base_Element="_vrCogBigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd8B32EeaVEcfXx-aEqQ" base_Element="_vrCogRigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd8R32EeaVEcfXx-aEqQ" base_Element="_vrCoghigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd8h32EeaVEcfXx-aEqQ" base_Element="_vrCogxigEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd8x32EeaVEcfXx-aEqQ" base_Element="_SEAxEL7XEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd9B32EeaVEcfXx-aEqQ" base_Element="_eIDWYJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd9R32EeaVEcfXx-aEqQ" base_Element="_eIDWYZ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd9h32EeaVEcfXx-aEqQ" base_Element="_eIDWYp2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd9x32EeaVEcfXx-aEqQ" base_Element="_eIDWY52IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd-B32EeaVEcfXx-aEqQ" base_Element="_ny-jkJ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd-R32EeaVEcfXx-aEqQ" base_Element="_ny-jkZ2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd-h32EeaVEcfXx-aEqQ" base_Element="_ny-jkp2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd-x32EeaVEcfXx-aEqQ" base_Element="_ny-jk52IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd_B32EeaVEcfXx-aEqQ" base_Element="_woXP4J2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd_R32EeaVEcfXx-aEqQ" base_Element="_woXP4Z2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd_h32EeaVEcfXx-aEqQ" base_Element="_woXP4p2IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdd_x32EeaVEcfXx-aEqQ" base_Element="_woXP452IEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeAB32EeaVEcfXx-aEqQ" base_Element="_CEPQ4J2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeAR32EeaVEcfXx-aEqQ" base_Element="_CEPQ4Z2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeAh32EeaVEcfXx-aEqQ" base_Element="_CEPQ4p2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeAx32EeaVEcfXx-aEqQ" base_Element="_CEPQ452JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeBB32EeaVEcfXx-aEqQ" base_Element="_QL8LYJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeBR32EeaVEcfXx-aEqQ" base_Element="_QL8LYZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeBh32EeaVEcfXx-aEqQ" base_Element="_QL8LYp2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeBx32EeaVEcfXx-aEqQ" base_Element="_QL8LY52JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeCB32EeaVEcfXx-aEqQ" base_Element="_f93zEJ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeCR32EeaVEcfXx-aEqQ" base_Element="_f93zEZ2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeCh32EeaVEcfXx-aEqQ" base_Element="_f93zEp2JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeCx32EeaVEcfXx-aEqQ" base_Element="_f93zE52JEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeDB32EeaVEcfXx-aEqQ" base_Element="_h8kpgJ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeDR32EeaVEcfXx-aEqQ" base_Element="_h8kpgZ2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeDh32EeaVEcfXx-aEqQ" base_Element="_h8kpgp2LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeDx32EeaVEcfXx-aEqQ" base_Element="_h8kpg52LEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeEB32EeaVEcfXx-aEqQ" base_Element="_yODvULA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeER32EeaVEcfXx-aEqQ" base_Element="_yODvUbA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeEh32EeaVEcfXx-aEqQ" base_Element="_yODvUrA0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeEx32EeaVEcfXx-aEqQ" base_Element="_yODvU7A0EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeFB32EeaVEcfXx-aEqQ" base_Element="_vG5YsKK3EeOfSYroU9Javw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeFR32EeaVEcfXx-aEqQ" base_Element="_8SDrEHk5EeO5z_IJj67BhQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeFh32EeaVEcfXx-aEqQ" base_Element="_8SV-8Hk5EeO5z_IJj67BhQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeFx32EeaVEcfXx-aEqQ" base_Element="_eiKr8HoDEeO2-YDhAjVilg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeGB32EeaVEcfXx-aEqQ" base_Element="_eilisHoDEeO2-YDhAjVilg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeGR32EeaVEcfXx-aEqQ" base_Element="_jEQe8COoEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeGh32EeaVEcfXx-aEqQ" base_Element="_jUZzwCOoEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeGx32EeaVEcfXx-aEqQ" base_Element="_5wJOwCOtEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeHB32EeaVEcfXx-aEqQ" base_Element="_5wiQUCOtEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeHR32EeaVEcfXx-aEqQ" base_Element="_svdPkCPBEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeHh32EeaVEcfXx-aEqQ" base_Element="_s8m6wCPBEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeHx32EeaVEcfXx-aEqQ" base_Element="_gsh30K37EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeIB32EeaVEcfXx-aEqQ" base_Element="_gs0ywK37EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeIR32EeaVEcfXx-aEqQ" base_Element="_SQqTgBizEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeIh32EeaVEcfXx-aEqQ" base_Element="_oGqi1FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeIx32EeaVEcfXx-aEqQ" base_Element="_oGqi1VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeJB32EeaVEcfXx-aEqQ" base_Element="_oGqi1lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeJR32EeaVEcfXx-aEqQ" base_Element="_oGqi11LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeJh32EeaVEcfXx-aEqQ" base_Element="_oGqi2FLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeJx32EeaVEcfXx-aEqQ" base_Element="_oGqi2VLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeKB32EeaVEcfXx-aEqQ" base_Element="_oGqi2lLNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeKR32EeaVEcfXx-aEqQ" base_Element="_oGqi21LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeKh32EeaVEcfXx-aEqQ" base_Element="_oGqlf1LNEeO75dO39GbF8Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeKx32EeaVEcfXx-aEqQ" base_Element="_eGOsEGgYEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeLB32EeaVEcfXx-aEqQ" base_Element="_AE1rMI2pEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeLR32EeaVEcfXx-aEqQ" base_Element="_oDOn8BizEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeLh32EeaVEcfXx-aEqQ" base_Element="_BUcVEI2tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeLx32EeaVEcfXx-aEqQ" base_Element="_e18ZIGgVEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeMB32EeaVEcfXx-aEqQ" base_Element="_ajjMYI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeMR32EeaVEcfXx-aEqQ" base_Element="_jHCa4GgVEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeMh32EeaVEcfXx-aEqQ" base_Element="_csyJwI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeMx32EeaVEcfXx-aEqQ" base_Element="_ctHg8I2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeNB32EeaVEcfXx-aEqQ" base_Element="_iVJ1kI2wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeNR32EeaVEcfXx-aEqQ" base_Element="_MTeuEGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeNh32EeaVEcfXx-aEqQ" base_Element="_d4GJgI2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeNx32EeaVEcfXx-aEqQ" base_Element="_ekZ14I2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeOB32EeaVEcfXx-aEqQ" base_Element="_hPrzkI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeOR32EeaVEcfXx-aEqQ" base_Element="_hNiEULE2EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeOh32EeaVEcfXx-aEqQ" base_Element="_w39joI3wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeOx32EeaVEcfXx-aEqQ" base_Element="_TzLZ0GgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdePB32EeaVEcfXx-aEqQ" base_Element="_xTUC4I3wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdePR32EeaVEcfXx-aEqQ" base_Element="_xT__YI3wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdePh32EeaVEcfXx-aEqQ" base_Element="_IEiZwI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdePx32EeaVEcfXx-aEqQ" base_Element="_ZiNZMGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeQB32EeaVEcfXx-aEqQ" base_Element="_IpxNwI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeQR32EeaVEcfXx-aEqQ" base_Element="_IqKPUI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeQh32EeaVEcfXx-aEqQ" base_Element="_k5nWYI2wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeQx32EeaVEcfXx-aEqQ" base_Element="_fGPCcGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeRB32EeaVEcfXx-aEqQ" base_Element="_fcvzII2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeRR32EeaVEcfXx-aEqQ" base_Element="_gKRAcI2yEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeRh32EeaVEcfXx-aEqQ" base_Element="_69cLMI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeRx32EeaVEcfXx-aEqQ" base_Element="_gigKULE2EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeSB32EeaVEcfXx-aEqQ" base_Element="_RMJegI22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeSR32EeaVEcfXx-aEqQ" base_Element="_kBhQsGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeSh32EeaVEcfXx-aEqQ" base_Element="_GzHo0I3wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeSx32EeaVEcfXx-aEqQ" base_Element="_GzfcQI3wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeTB32EeaVEcfXx-aEqQ" base_Element="_u0HQoI2wEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeTR32EeaVEcfXx-aEqQ" base_Element="_pz--kGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeTh32EeaVEcfXx-aEqQ" base_Element="_olrqYI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeTx32EeaVEcfXx-aEqQ" base_Element="_wQE4QGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeUB32EeaVEcfXx-aEqQ" base_Element="_pEqFYI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeUR32EeaVEcfXx-aEqQ" base_Element="_pFBRwI2uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeUh32EeaVEcfXx-aEqQ" base_Element="_bCi74I22EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeUx32EeaVEcfXx-aEqQ" base_Element="_1fwpMGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeVB32EeaVEcfXx-aEqQ" base_Element="_uQqu4I28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeVR32EeaVEcfXx-aEqQ" base_Element="_8h5PMGgWEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeVh32EeaVEcfXx-aEqQ" base_Element="_uskAsI28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeVx32EeaVEcfXx-aEqQ" base_Element="_us2UkI28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeWB32EeaVEcfXx-aEqQ" base_Element="_StA-4I23EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeWR32EeaVEcfXx-aEqQ" base_Element="_CdttYGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeWh32EeaVEcfXx-aEqQ" base_Element="__JGxMI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeWx32EeaVEcfXx-aEqQ" base_Element="_FzsxwGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeXB32EeaVEcfXx-aEqQ" base_Element="__JGxMY30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeXR32EeaVEcfXx-aEqQ" base_Element="__JGxMo30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeXh32EeaVEcfXx-aEqQ" base_Element="_ulDtsI3AEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeXx32EeaVEcfXx-aEqQ" base_Element="_J5sWwGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeYB32EeaVEcfXx-aEqQ" base_Element="_U1tnkI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeYR32EeaVEcfXx-aEqQ" base_Element="_PBXbMGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeYh32EeaVEcfXx-aEqQ" base_Element="_VM-4EI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeYx32EeaVEcfXx-aEqQ" base_Element="_VNUPQI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeZB32EeaVEcfXx-aEqQ" base_Element="_-ZWVQJP0EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeZR32EeaVEcfXx-aEqQ" base_Element="_UmfQoGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeZh32EeaVEcfXx-aEqQ" base_Element="_JIYq0JP1EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeZx32EeaVEcfXx-aEqQ" base_Element="_5Zv80JP2EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeaB32EeaVEcfXx-aEqQ" base_Element="_5hoYgBizEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeaR32EeaVEcfXx-aEqQ" base_Element="_y7oy8I3tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeah32EeaVEcfXx-aEqQ" base_Element="_d6mgUGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeax32EeaVEcfXx-aEqQ" base_Element="_77PyQI3tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdebB32EeaVEcfXx-aEqQ" base_Element="_kloN4GgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdebR32EeaVEcfXx-aEqQ" base_Element="_8XjTwI3tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdebh32EeaVEcfXx-aEqQ" base_Element="_8X2OsI3tEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdebx32EeaVEcfXx-aEqQ" base_Element="_ZUyfII3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdecB32EeaVEcfXx-aEqQ" base_Element="_oJBcIGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdecR32EeaVEcfXx-aEqQ" base_Element="_Z3im4I3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdech32EeaVEcfXx-aEqQ" base_Element="_Z31h0I3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdecx32EeaVEcfXx-aEqQ" base_Element="_pXXx8Y3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdedB32EeaVEcfXx-aEqQ" base_Element="_ryyYIGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdedR32EeaVEcfXx-aEqQ" base_Element="_pXXx8o3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdedh32EeaVEcfXx-aEqQ" base_Element="_pXXx843uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdedx32EeaVEcfXx-aEqQ" base_Element="_bhg_8Y3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeeB32EeaVEcfXx-aEqQ" base_Element="_vjBIgGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeeR32EeaVEcfXx-aEqQ" base_Element="_bhg_8o3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeeh32EeaVEcfXx-aEqQ" base_Element="_bhg_843vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeex32EeaVEcfXx-aEqQ" base_Element="_NIlTsI28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdefB32EeaVEcfXx-aEqQ" base_Element="_xxGJoGgXEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdefR32EeaVEcfXx-aEqQ" base_Element="_NIlTsY28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdefh32EeaVEcfXx-aEqQ" base_Element="_NIlTso28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdefx32EeaVEcfXx-aEqQ" base_Element="_SU3Q4I30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdegB32EeaVEcfXx-aEqQ" base_Element="_PZfK0GgYEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdegR32EeaVEcfXx-aEqQ" base_Element="_cbx2gI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdegh32EeaVEcfXx-aEqQ" base_Element="_TIgaQGgYEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdegx32EeaVEcfXx-aEqQ" base_Element="_c3s9gI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdehB32EeaVEcfXx-aEqQ" base_Element="_c4IbUI30EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdehR32EeaVEcfXx-aEqQ" base_Element="_Eh1WkBi0EeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdehh32EeaVEcfXx-aEqQ" base_Element="_mZyWYI21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdehx32EeaVEcfXx-aEqQ" base_Element="_mZyWYY21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeiB32EeaVEcfXx-aEqQ" base_Element="_mZyWYo21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeiR32EeaVEcfXx-aEqQ" base_Element="_mZyWY421EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeih32EeaVEcfXx-aEqQ" base_Element="_mZnXQI21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeix32EeaVEcfXx-aEqQ" base_Element="_mZnXQY21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdejB32EeaVEcfXx-aEqQ" base_Element="_mZnXQo21EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdejR32EeaVEcfXx-aEqQ" base_Element="_NIvrwI28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdejh32EeaVEcfXx-aEqQ" base_Element="_NIvrwY28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdejx32EeaVEcfXx-aEqQ" base_Element="_NIvrwo28EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdekB32EeaVEcfXx-aEqQ" base_Element="_NIvrw428EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdekR32EeaVEcfXx-aEqQ" base_Element="_pXXx8I3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdekh32EeaVEcfXx-aEqQ" base_Element="_pXXx9I3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdekx32EeaVEcfXx-aEqQ" base_Element="_pXXx9Y3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdelB32EeaVEcfXx-aEqQ" base_Element="_pXXx9o3uEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdelR32EeaVEcfXx-aEqQ" base_Element="_bhg_8I3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdelh32EeaVEcfXx-aEqQ" base_Element="_bhg_9I3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdelx32EeaVEcfXx-aEqQ" base_Element="_bhg_9Y3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdemB32EeaVEcfXx-aEqQ" base_Element="_bhg_9o3vEeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdemR32EeaVEcfXx-aEqQ" base_Element="_e2gXEI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdemh32EeaVEcfXx-aEqQ" base_Element="_e2gXEY31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdemx32EeaVEcfXx-aEqQ" base_Element="_e2gXEo31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdenB32EeaVEcfXx-aEqQ" base_Element="_e2gXE431EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdenR32EeaVEcfXx-aEqQ" base_Element="_e2gXFI31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdenh32EeaVEcfXx-aEqQ" base_Element="_e2gXFY31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdenx32EeaVEcfXx-aEqQ" base_Element="_e2gXFo31EeO38ZmbECnvbg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeoB32EeaVEcfXx-aEqQ" base_Element="_K2aTABi0EeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeoR32EeaVEcfXx-aEqQ" base_Element="_VhoiwJJxEeO03KWNhYntEQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeoh32EeaVEcfXx-aEqQ" base_Element="_g6GT4JPyEeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeox32EeaVEcfXx-aEqQ" base_Element="_6Xh-QJP3EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdepB32EeaVEcfXx-aEqQ" base_Element="_y6YawJP4EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdepR32EeaVEcfXx-aEqQ" base_Element="_nBHw8JP8EeOqfpp-ZJSmaA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeph32EeaVEcfXx-aEqQ" base_Element="_6eJYgLEsEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdepx32EeaVEcfXx-aEqQ" base_Element="_rmrNwGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeqB32EeaVEcfXx-aEqQ" base_Element="_RG6VILEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeqR32EeaVEcfXx-aEqQ" base_Element="_ZvtTkGgfEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeqh32EeaVEcfXx-aEqQ" base_Element="_dO6owLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeqx32EeaVEcfXx-aEqQ" base_Element="_vNL24GghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICderB32EeaVEcfXx-aEqQ" base_Element="_dzbrELEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICderR32EeaVEcfXx-aEqQ" base_Element="_dz1TsLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICderh32EeaVEcfXx-aEqQ" base_Element="_7gqwALEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICderx32EeaVEcfXx-aEqQ" base_Element="_CTlx8GggEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdesB32EeaVEcfXx-aEqQ" base_Element="_9PLgQLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdesR32EeaVEcfXx-aEqQ" base_Element="_9PmXALEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdesh32EeaVEcfXx-aEqQ" base_Element="_AjGvILEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdesx32EeaVEcfXx-aEqQ" base_Element="_58sKsGgaEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdetB32EeaVEcfXx-aEqQ" base_Element="_DWakQLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdetR32EeaVEcfXx-aEqQ" base_Element="_DWzl0LEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeth32EeaVEcfXx-aEqQ" base_Element="_PzqZ0GgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdetx32EeaVEcfXx-aEqQ" base_Element="_mbN1gGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeuB32EeaVEcfXx-aEqQ" base_Element="_ynb6wGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeuR32EeaVEcfXx-aEqQ" base_Element="_lNclkLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeuh32EeaVEcfXx-aEqQ" base_Element="_EAMLwGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeux32EeaVEcfXx-aEqQ" base_Element="_oVoegLEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdevB32EeaVEcfXx-aEqQ" base_Element="_71BhIGghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdevR32EeaVEcfXx-aEqQ" base_Element="_p90kULEtEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdevh32EeaVEcfXx-aEqQ" base_Element="_14MWUGghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdevx32EeaVEcfXx-aEqQ" base_Element="_KSKOYLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdewB32EeaVEcfXx-aEqQ" base_Element="_Rfe34GghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdewR32EeaVEcfXx-aEqQ" base_Element="_OLEZoLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdewh32EeaVEcfXx-aEqQ" base_Element="_VYOEAGghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdewx32EeaVEcfXx-aEqQ" base_Element="_PIgSQLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdexB32EeaVEcfXx-aEqQ" base_Element="_fZqTwGghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdexR32EeaVEcfXx-aEqQ" base_Element="_-xPeALEvEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdexh32EeaVEcfXx-aEqQ" base_Element="_5_rJUMPvEeSkD7NQ5om7rQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdexx32EeaVEcfXx-aEqQ" base_Element="_Q_HyQGggEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeyB32EeaVEcfXx-aEqQ" base_Element="_vaxN0LEwEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeyR32EeaVEcfXx-aEqQ" base_Element="_mb7SEGggEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeyh32EeaVEcfXx-aEqQ" base_Element="_NTzvkLEwEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdeyx32EeaVEcfXx-aEqQ" base_Element="_tzVkgGggEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdezB32EeaVEcfXx-aEqQ" base_Element="_uWUxcLE0EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdezR32EeaVEcfXx-aEqQ" base_Element="_7F8qEGggEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdezh32EeaVEcfXx-aEqQ" base_Element="_a69wUGggEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdezx32EeaVEcfXx-aEqQ" base_Element="_HKL4AGghEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde0B32EeaVEcfXx-aEqQ" base_Element="_McyhcGgeEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde0R32EeaVEcfXx-aEqQ" base_Element="_vc_ikGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde0h32EeaVEcfXx-aEqQ" base_Element="_TWEtcGgeEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde0x32EeaVEcfXx-aEqQ" base_Element="_QAuTsLEuEeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde1B32EeaVEcfXx-aEqQ" base_Element="_oW5poGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde1R32EeaVEcfXx-aEqQ" base_Element="_iIYN4LE0EeSZUdYfPSdgew"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde1h32EeaVEcfXx-aEqQ" base_Element="_rWXEYGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde1x32EeaVEcfXx-aEqQ" base_Element="_YSsboGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde2B32EeaVEcfXx-aEqQ" base_Element="_kD5jYGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde2R32EeaVEcfXx-aEqQ" base_Element="_9FvssGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde2h32EeaVEcfXx-aEqQ" base_Element="_C8MisGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde2x32EeaVEcfXx-aEqQ" base_Element="_DuF5sGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde3B32EeaVEcfXx-aEqQ" base_Element="_O4Ee0GgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde3R32EeaVEcfXx-aEqQ" base_Element="_Ql5SkGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde3h32EeaVEcfXx-aEqQ" base_Element="_UmEjcGgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde3x32EeaVEcfXx-aEqQ" base_Element="_XbZx0GgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde4B32EeaVEcfXx-aEqQ" base_Element="_cnmJ4GgjEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde4R32EeaVEcfXx-aEqQ" base_Element="_2AdsEGgiEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde4h32EeaVEcfXx-aEqQ" base_Element="_dzFRIGgZEeWmgIwAIZlYKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde4x32EeaVEcfXx-aEqQ" base_Element="_cCVB4BizEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde5B32EeaVEcfXx-aEqQ" base_Element="_BQT2IKKtEeOfSYroU9Javw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde5R32EeaVEcfXx-aEqQ" base_Element="_r9ZDABBFEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde5h32EeaVEcfXx-aEqQ" base_Element="_rgdnkJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde5x32EeaVEcfXx-aEqQ" base_Element="_tgFPQGj6EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde6B32EeaVEcfXx-aEqQ" base_Element="_v77tUJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde6R32EeaVEcfXx-aEqQ" base_Element="__8CNMGj6EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde6h32EeaVEcfXx-aEqQ" base_Element="_xR2XYJoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde6x32EeaVEcfXx-aEqQ" base_Element="_xSOx4JoyEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde7B32EeaVEcfXx-aEqQ" base_Element="_xZiBgJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde7R32EeaVEcfXx-aEqQ" base_Element="_M1JNoGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde7h32EeaVEcfXx-aEqQ" base_Element="_xZiBgZ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde7x32EeaVEcfXx-aEqQ" base_Element="_xZiBgp4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde8B32EeaVEcfXx-aEqQ" base_Element="_k1gHQJo5EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde8R32EeaVEcfXx-aEqQ" base_Element="_gBIhYGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde8h32EeaVEcfXx-aEqQ" base_Element="_oxb_EJo-EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde8x32EeaVEcfXx-aEqQ" base_Element="_rAnGsGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde9B32EeaVEcfXx-aEqQ" base_Element="_GJxyEJo_EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde9R32EeaVEcfXx-aEqQ" base_Element="_GKFUEJo_EeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde9h32EeaVEcfXx-aEqQ" base_Element="_8-3vcJpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde9x32EeaVEcfXx-aEqQ" base_Element="_uVZRMGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde-B32EeaVEcfXx-aEqQ" base_Element="_8-3vcZpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde-R32EeaVEcfXx-aEqQ" base_Element="_8-3vcppDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde-h32EeaVEcfXx-aEqQ" base_Element="_YzzeYJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde-x32EeaVEcfXx-aEqQ" base_Element="_-E0-gGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde_B32EeaVEcfXx-aEqQ" base_Element="_YzzeYZ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde_R32EeaVEcfXx-aEqQ" base_Element="_YzzeYp4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde_h32EeaVEcfXx-aEqQ" base_Element="_Ec0FMJ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICde_x32EeaVEcfXx-aEqQ" base_Element="_Bg-8UGj8EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICdfAB32EeaVEcfXx-aEqQ" base_Element="_Ec0FMZ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn4B32EeaVEcfXx-aEqQ" base_Element="_Ec0FMp4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn4R32EeaVEcfXx-aEqQ" base_Element="_8_BgcJpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn4h32EeaVEcfXx-aEqQ" base_Element="_8_BgcZpDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn4x32EeaVEcfXx-aEqQ" base_Element="_8_BgcppDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn5B32EeaVEcfXx-aEqQ" base_Element="_8_Bgc5pDEeOyHKqw-cQ_eg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn5R32EeaVEcfXx-aEqQ" base_Element="_T5-osJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn5h32EeaVEcfXx-aEqQ" base_Element="_g578MGj8EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn5x32EeaVEcfXx-aEqQ" base_Element="_eSmM4J4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn6B32EeaVEcfXx-aEqQ" base_Element="_eSmM4Z4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn6R32EeaVEcfXx-aEqQ" base_Element="_Ty_wkGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn6h32EeaVEcfXx-aEqQ" base_Element="_eSmM4p4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn6x32EeaVEcfXx-aEqQ" base_Element="_eSxzEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn7B32EeaVEcfXx-aEqQ" base_Element="_eSxzEZ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn7R32EeaVEcfXx-aEqQ" base_Element="_U9BTsGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn7h32EeaVEcfXx-aEqQ" base_Element="_eS7kEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn7x32EeaVEcfXx-aEqQ" base_Element="_eS7kEZ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn8B32EeaVEcfXx-aEqQ" base_Element="_VyLaEGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn8R32EeaVEcfXx-aEqQ" base_Element="_eTFVEJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn8h32EeaVEcfXx-aEqQ" base_Element="_eTFVEZ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn8x32EeaVEcfXx-aEqQ" base_Element="_WaWNUGj7EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn9B32EeaVEcfXx-aEqQ" base_Element="_Y0HAYJ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn9R32EeaVEcfXx-aEqQ" base_Element="_Y0HAYZ4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn9h32EeaVEcfXx-aEqQ" base_Element="_Y0HAYp4HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn9x32EeaVEcfXx-aEqQ" base_Element="_Y0HAY54HEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn-B32EeaVEcfXx-aEqQ" base_Element="_xZrLcJ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn-R32EeaVEcfXx-aEqQ" base_Element="_xZrLcZ4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn-h32EeaVEcfXx-aEqQ" base_Element="_xZrLcp4IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn-x32EeaVEcfXx-aEqQ" base_Element="_xZrLc54IEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn_B32EeaVEcfXx-aEqQ" base_Element="_Ec9PIJ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn_R32EeaVEcfXx-aEqQ" base_Element="_Ec9PIZ4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn_h32EeaVEcfXx-aEqQ" base_Element="_Ec9PIp4JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmn_x32EeaVEcfXx-aEqQ" base_Element="_Ec9PI54JEeOO3om500DFKg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoAB32EeaVEcfXx-aEqQ" base_Element="_Tvr28BBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoAR32EeaVEcfXx-aEqQ" base_Element="_pCLOoGj8EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoAh32EeaVEcfXx-aEqQ" base_Element="_sseEoBBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoAx32EeaVEcfXx-aEqQ" base_Element="_sgyDgGj8EeWI2vxwuJqrJA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoBB32EeaVEcfXx-aEqQ" base_Element="_sseEoRBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoBR32EeaVEcfXx-aEqQ" base_Element="_sseEohBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoBh32EeaVEcfXx-aEqQ" base_Element="_ss6wkBBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoBx32EeaVEcfXx-aEqQ" base_Element="_ss6wkRBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoCB32EeaVEcfXx-aEqQ" base_Element="_ss6wkhBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoCR32EeaVEcfXx-aEqQ" base_Element="_ss6wkxBHEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoCh32EeaVEcfXx-aEqQ" base_Element="_byGkAMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoCx32EeaVEcfXx-aEqQ" base_Element="_opnrsOvTEeOE19T_GJuRHg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoDB32EeaVEcfXx-aEqQ" base_Element="_dP5FkL7VEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoDR32EeaVEcfXx-aEqQ" base_Element="_nzCmUMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoDh32EeaVEcfXx-aEqQ" base_Element="_zejxgEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoDx32EeaVEcfXx-aEqQ" base_Element="_DDTSgMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoEB32EeaVEcfXx-aEqQ" base_Element="_DDTSgcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoER32EeaVEcfXx-aEqQ" base_Element="_DDTSgsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoEh32EeaVEcfXx-aEqQ" base_Element="_D2itUMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoEx32EeaVEcfXx-aEqQ" base_Element="_D2itUcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoFB32EeaVEcfXx-aEqQ" base_Element="_D2itUsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoFR32EeaVEcfXx-aEqQ" base_Element="_rBXuEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoFh32EeaVEcfXx-aEqQ" base_Element="_rBXuEcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoFx32EeaVEcfXx-aEqQ" base_Element="_rBXuEsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoGB32EeaVEcfXx-aEqQ" base_Element="_d6lKsM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoGR32EeaVEcfXx-aEqQ" base_Element="_d7PSAM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoGh32EeaVEcfXx-aEqQ" base_Element="_d7jbEM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoGx32EeaVEcfXx-aEqQ" base_Element="_Q4JwgBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoHB32EeaVEcfXx-aEqQ" base_Element="_Q5MSUBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoHR32EeaVEcfXx-aEqQ" base_Element="_Q5fNQBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoHh32EeaVEcfXx-aEqQ" base_Element="_vk9qgMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoHx32EeaVEcfXx-aEqQ" base_Element="_0Cdv0Ev-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoIB32EeaVEcfXx-aEqQ" base_Element="_x2_-kMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoIR32EeaVEcfXx-aEqQ" base_Element="_0jGXsEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoIh32EeaVEcfXx-aEqQ" base_Element="_4MF4YMrUEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoIx32EeaVEcfXx-aEqQ" base_Element="_8FsmcEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoJB32EeaVEcfXx-aEqQ" base_Element="_eej4UMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoJR32EeaVEcfXx-aEqQ" base_Element="_eej4UcrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoJh32EeaVEcfXx-aEqQ" base_Element="_eej4UsrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoJx32EeaVEcfXx-aEqQ" base_Element="_tGhwcM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoKB32EeaVEcfXx-aEqQ" base_Element="_tGhwcc96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoKR32EeaVEcfXx-aEqQ" base_Element="_tGhwcs96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoKh32EeaVEcfXx-aEqQ" base_Element="_q_7KoBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoKx32EeaVEcfXx-aEqQ" base_Element="_q_7KoRBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoLB32EeaVEcfXx-aEqQ" base_Element="_q_7KohBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoLR32EeaVEcfXx-aEqQ" base_Element="_huOHsMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoLh32EeaVEcfXx-aEqQ" base_Element="_62-wkEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoLx32EeaVEcfXx-aEqQ" base_Element="_lyVdYMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoMB32EeaVEcfXx-aEqQ" base_Element="_lyVdYcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoMR32EeaVEcfXx-aEqQ" base_Element="_lyVdYsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoMh32EeaVEcfXx-aEqQ" base_Element="_tRU-gMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoMx32EeaVEcfXx-aEqQ" base_Element="_tRU-gcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoNB32EeaVEcfXx-aEqQ" base_Element="_tRU-gsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoNR32EeaVEcfXx-aEqQ" base_Element="_F4DcoMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoNh32EeaVEcfXx-aEqQ" base_Element="_F4DcocrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoNx32EeaVEcfXx-aEqQ" base_Element="_F4DcosrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoOB32EeaVEcfXx-aEqQ" base_Element="_o5PVMMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoOR32EeaVEcfXx-aEqQ" base_Element="_o5PVMcrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoOh32EeaVEcfXx-aEqQ" base_Element="_o5PVMsrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoOx32EeaVEcfXx-aEqQ" base_Element="_ArJEIMrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoPB32EeaVEcfXx-aEqQ" base_Element="_ArJEIcrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoPR32EeaVEcfXx-aEqQ" base_Element="_ArJEIsrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoPh32EeaVEcfXx-aEqQ" base_Element="_vxoYEMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoPx32EeaVEcfXx-aEqQ" base_Element="_54hkQEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoQB32EeaVEcfXx-aEqQ" base_Element="_zevjAMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoQR32EeaVEcfXx-aEqQ" base_Element="_zevjAcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoQh32EeaVEcfXx-aEqQ" base_Element="_zevjAsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoQx32EeaVEcfXx-aEqQ" base_Element="_15tJkMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoRB32EeaVEcfXx-aEqQ" base_Element="_15tJkcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoRR32EeaVEcfXx-aEqQ" base_Element="_15tJksrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoRh32EeaVEcfXx-aEqQ" base_Element="_6ZBl0MrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoRx32EeaVEcfXx-aEqQ" base_Element="_6ZBl0crbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoSB32EeaVEcfXx-aEqQ" base_Element="_6ZBl0srbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoSR32EeaVEcfXx-aEqQ" base_Element="_BC32YMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoSh32EeaVEcfXx-aEqQ" base_Element="_5NiGgEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoSx32EeaVEcfXx-aEqQ" base_Element="_pSR5kMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoTB32EeaVEcfXx-aEqQ" base_Element="_pSR5kcrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoTR32EeaVEcfXx-aEqQ" base_Element="_pSR5ksrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoTh32EeaVEcfXx-aEqQ" base_Element="_EL4OsMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoTx32EeaVEcfXx-aEqQ" base_Element="_3zYcsEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoUB32EeaVEcfXx-aEqQ" base_Element="_K1oJ4MrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoUR32EeaVEcfXx-aEqQ" base_Element="_K1oJ4crWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoUh32EeaVEcfXx-aEqQ" base_Element="_K1oJ4srWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoUx32EeaVEcfXx-aEqQ" base_Element="_MqxtoMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoVB32EeaVEcfXx-aEqQ" base_Element="_MqxtocrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoVR32EeaVEcfXx-aEqQ" base_Element="_MqxtosrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoVh32EeaVEcfXx-aEqQ" base_Element="_1kdDkMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoVx32EeaVEcfXx-aEqQ" base_Element="_1kdDkcrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoWB32EeaVEcfXx-aEqQ" base_Element="_1kdDksrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoWR32EeaVEcfXx-aEqQ" base_Element="_LfY8APFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoWh32EeaVEcfXx-aEqQ" base_Element="_L_ZRwPFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoWx32EeaVEcfXx-aEqQ" base_Element="_L_uB4PFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoXB32EeaVEcfXx-aEqQ" base_Element="_MAdowPFLEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoXR32EeaVEcfXx-aEqQ" base_Element="_xI3CAMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoXh32EeaVEcfXx-aEqQ" base_Element="_1M1RMEv-EeWXgvUwfkuadg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoXx32EeaVEcfXx-aEqQ" base_Element="_d8DKUM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoYB32EeaVEcfXx-aEqQ" base_Element="_rz8d8PFKEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoYR32EeaVEcfXx-aEqQ" base_Element="_wIHo4PFKEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoYh32EeaVEcfXx-aEqQ" base_Element="_wIsQoPFKEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoYx32EeaVEcfXx-aEqQ" base_Element="_wJpS4PFKEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoZB32EeaVEcfXx-aEqQ" base_Element="_d8DKUc96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoZR32EeaVEcfXx-aEqQ" base_Element="_d8DKUs96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoZh32EeaVEcfXx-aEqQ" base_Element="_d8DKU896EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoZx32EeaVEcfXx-aEqQ" base_Element="_KWXB8PFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoaB32EeaVEcfXx-aEqQ" base_Element="_ZDdvkPFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoaR32EeaVEcfXx-aEqQ" base_Element="_Q575MBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoah32EeaVEcfXx-aEqQ" base_Element="_1OgVMBvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoax32EeaVEcfXx-aEqQ" base_Element="_1OgVMRvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmobB32EeaVEcfXx-aEqQ" base_Element="_1OgVMhvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmobR32EeaVEcfXx-aEqQ" base_Element="_1OgVMxvOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmobh32EeaVEcfXx-aEqQ" base_Element="_Q575MRBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmobx32EeaVEcfXx-aEqQ" base_Element="_Q575MhBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmocB32EeaVEcfXx-aEqQ" base_Element="_Q575MxBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmocR32EeaVEcfXx-aEqQ" base_Element="_iXRPEL7VEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoch32EeaVEcfXx-aEqQ" base_Element="_DDgt4MrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmocx32EeaVEcfXx-aEqQ" base_Element="_DDgt4crVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmodB32EeaVEcfXx-aEqQ" base_Element="_DDgt4srVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmodR32EeaVEcfXx-aEqQ" base_Element="_DDgt48rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmodh32EeaVEcfXx-aEqQ" base_Element="_D2uTgMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmodx32EeaVEcfXx-aEqQ" base_Element="_D2uTgcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoeB32EeaVEcfXx-aEqQ" base_Element="_D2uTgsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoeR32EeaVEcfXx-aEqQ" base_Element="_D2uTg8rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoeh32EeaVEcfXx-aEqQ" base_Element="_lygcgMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoex32EeaVEcfXx-aEqQ" base_Element="_lygcgcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmofB32EeaVEcfXx-aEqQ" base_Element="_lygcgsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmofR32EeaVEcfXx-aEqQ" base_Element="_lygcg8rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmofh32EeaVEcfXx-aEqQ" base_Element="_rBjUQMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmofx32EeaVEcfXx-aEqQ" base_Element="_rBjUQcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmogB32EeaVEcfXx-aEqQ" base_Element="_rBjUQsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmogR32EeaVEcfXx-aEqQ" base_Element="_rBjUQ8rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmogh32EeaVEcfXx-aEqQ" base_Element="_tRgksMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmogx32EeaVEcfXx-aEqQ" base_Element="_tRgkscrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmohB32EeaVEcfXx-aEqQ" base_Element="_tRgkssrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmohR32EeaVEcfXx-aEqQ" base_Element="_tRgks8rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmohh32EeaVEcfXx-aEqQ" base_Element="_ze8-YMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmohx32EeaVEcfXx-aEqQ" base_Element="_ze8-YcrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoiB32EeaVEcfXx-aEqQ" base_Element="_ze8-YsrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoiR32EeaVEcfXx-aEqQ" base_Element="_ze8-Y8rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoih32EeaVEcfXx-aEqQ" base_Element="_154IsMrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoix32EeaVEcfXx-aEqQ" base_Element="_154IscrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmojB32EeaVEcfXx-aEqQ" base_Element="_154IssrVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmojR32EeaVEcfXx-aEqQ" base_Element="_154Is8rVEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmojh32EeaVEcfXx-aEqQ" base_Element="_F4ObwMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmojx32EeaVEcfXx-aEqQ" base_Element="_F4ObwcrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmokB32EeaVEcfXx-aEqQ" base_Element="_F4ObwsrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmokR32EeaVEcfXx-aEqQ" base_Element="_F4Obw8rWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmokh32EeaVEcfXx-aEqQ" base_Element="_K1zJAMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmokx32EeaVEcfXx-aEqQ" base_Element="_K1zJAcrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmolB32EeaVEcfXx-aEqQ" base_Element="_K1zJAsrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmolR32EeaVEcfXx-aEqQ" base_Element="_K1zJA8rWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmolh32EeaVEcfXx-aEqQ" base_Element="_Mq-h8MrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmolx32EeaVEcfXx-aEqQ" base_Element="_Mq-h8crWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmomB32EeaVEcfXx-aEqQ" base_Element="_Mq-h8srWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmomR32EeaVEcfXx-aEqQ" base_Element="_Mq-h88rWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmomh32EeaVEcfXx-aEqQ" base_Element="_eexTsMrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmomx32EeaVEcfXx-aEqQ" base_Element="_eexTscrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmonB32EeaVEcfXx-aEqQ" base_Element="_eexTssrWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmonR32EeaVEcfXx-aEqQ" base_Element="_eexTs8rWEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmonh32EeaVEcfXx-aEqQ" base_Element="_o5aUUMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmonx32EeaVEcfXx-aEqQ" base_Element="_o5aUUcrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmooB32EeaVEcfXx-aEqQ" base_Element="_o5aUUsrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmooR32EeaVEcfXx-aEqQ" base_Element="_o5aUU8rbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmooh32EeaVEcfXx-aEqQ" base_Element="_1krGAMrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoox32EeaVEcfXx-aEqQ" base_Element="_1krGAcrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmopB32EeaVEcfXx-aEqQ" base_Element="_1krGAsrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmopR32EeaVEcfXx-aEqQ" base_Element="_1krGA8rbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoph32EeaVEcfXx-aEqQ" base_Element="_6ZMk8MrbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmopx32EeaVEcfXx-aEqQ" base_Element="_6ZMk8crbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoqB32EeaVEcfXx-aEqQ" base_Element="_6ZMk8srbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoqR32EeaVEcfXx-aEqQ" base_Element="_6ZMk88rbEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoqh32EeaVEcfXx-aEqQ" base_Element="_ArUDQMrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoqx32EeaVEcfXx-aEqQ" base_Element="_ArUDQcrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmorB32EeaVEcfXx-aEqQ" base_Element="_ArUDQsrcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmorR32EeaVEcfXx-aEqQ" base_Element="_ArUDQ8rcEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmorh32EeaVEcfXx-aEqQ" base_Element="_tGsvkM96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmorx32EeaVEcfXx-aEqQ" base_Element="_tGsvkc96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmosB32EeaVEcfXx-aEqQ" base_Element="_tGsvks96EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmosR32EeaVEcfXx-aEqQ" base_Element="_tGsvk896EeOwEItOulyh6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmosh32EeaVEcfXx-aEqQ" base_Element="_rAOFkBBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmosx32EeaVEcfXx-aEqQ" base_Element="_rAOFkRBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmotB32EeaVEcfXx-aEqQ" base_Element="_rAOFkhBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmotR32EeaVEcfXx-aEqQ" base_Element="_rAOFkxBEEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoth32EeaVEcfXx-aEqQ" base_Element="_7SNfsAgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmotx32EeaVEcfXx-aEqQ" base_Element="_7SNfsQgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmouB32EeaVEcfXx-aEqQ" base_Element="_7SNfsggoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmouR32EeaVEcfXx-aEqQ" base_Element="_7SNfswgoEeSbuczmw5yq0A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmouh32EeaVEcfXx-aEqQ" base_Element="_ks0xML7VEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoux32EeaVEcfXx-aEqQ" base_Element="_ILMHcMrXEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmovB32EeaVEcfXx-aEqQ" base_Element="_e7qOkMrXEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmovR32EeaVEcfXx-aEqQ" base_Element="_7UvukMrYEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmovh32EeaVEcfXx-aEqQ" base_Element="_aE2McMreEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmovx32EeaVEcfXx-aEqQ" base_Element="_oVtqAMreEeOt57ZaJqAnzg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmowB32EeaVEcfXx-aEqQ" base_Element="_wTm_cMxkEeONyOeN2Mx8mQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmowR32EeaVEcfXx-aEqQ" base_Element="_qi9IEMxnEeONyOeN2Mx8mQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmowh32EeaVEcfXx-aEqQ" base_Element="_yX_H0PFMEeOb0bs-xqaPmA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmowx32EeaVEcfXx-aEqQ" base_Element="_f7_1EBBCEeS-tqfHkf_O5w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoxB32EeaVEcfXx-aEqQ" base_Element="_zpR3MOvTEeOE19T_GJuRHg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoxR32EeaVEcfXx-aEqQ" base_Element="_wokSEGsxEeSf07IfAG7CZg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoxh32EeaVEcfXx-aEqQ" base_Element="_FU2nYBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoxx32EeaVEcfXx-aEqQ" base_Element="_gQy-gBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoyB32EeaVEcfXx-aEqQ" base_Element="_gQy-gRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoyR32EeaVEcfXx-aEqQ" base_Element="_gQy-ghiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoyh32EeaVEcfXx-aEqQ" base_Element="_stER8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmoyx32EeaVEcfXx-aEqQ" base_Element="_stER8RiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmozB32EeaVEcfXx-aEqQ" base_Element="_stER8hiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmozR32EeaVEcfXx-aEqQ" base_Element="_DYs8YBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmozh32EeaVEcfXx-aEqQ" base_Element="_DYs8YRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmozx32EeaVEcfXx-aEqQ" base_Element="_DYs8YhiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo0B32EeaVEcfXx-aEqQ" base_Element="_KhSoUBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo0R32EeaVEcfXx-aEqQ" base_Element="_KhSoURiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo0h32EeaVEcfXx-aEqQ" base_Element="_KhSoUhiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo0x32EeaVEcfXx-aEqQ" base_Element="_QIRpgBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo1B32EeaVEcfXx-aEqQ" base_Element="_QIRpgRiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo1R32EeaVEcfXx-aEqQ" base_Element="_QIRpghiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo1h32EeaVEcfXx-aEqQ" base_Element="_K6G_sBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo1x32EeaVEcfXx-aEqQ" base_Element="_gzlQkBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo2B32EeaVEcfXx-aEqQ" base_Element="_gzlQkRiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo2R32EeaVEcfXx-aEqQ" base_Element="_gzlQkhiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo2h32EeaVEcfXx-aEqQ" base_Element="_-M4psBiSEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo2x32EeaVEcfXx-aEqQ" base_Element="_JH4XoBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo3B32EeaVEcfXx-aEqQ" base_Element="_3I3icBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo3R32EeaVEcfXx-aEqQ" base_Element="_3I3icRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo3h32EeaVEcfXx-aEqQ" base_Element="_3I3ichiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo3x32EeaVEcfXx-aEqQ" base_Element="_OGNS0BiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo4B32EeaVEcfXx-aEqQ" base_Element="_Ub4wkBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo4R32EeaVEcfXx-aEqQ" base_Element="_Ub4wkRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo4h32EeaVEcfXx-aEqQ" base_Element="_Ub4wkhiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo4x32EeaVEcfXx-aEqQ" base_Element="_izZosBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo5B32EeaVEcfXx-aEqQ" base_Element="_izZosRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo5R32EeaVEcfXx-aEqQ" base_Element="_izZoshiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo5h32EeaVEcfXx-aEqQ" base_Element="_GuNDIBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo5x32EeaVEcfXx-aEqQ" base_Element="_GuNDIRiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo6B32EeaVEcfXx-aEqQ" base_Element="_GuNDIhiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo6R32EeaVEcfXx-aEqQ" base_Element="_cWBngBiTEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICmo6h32EeaVEcfXx-aEqQ" base_Element="_tYhNQBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY4B32EeaVEcfXx-aEqQ" base_Element="_tYhNQRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY4R32EeaVEcfXx-aEqQ" base_Element="_tYhNQhiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY4h32EeaVEcfXx-aEqQ" base_Element="_BiVlwBiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY4x32EeaVEcfXx-aEqQ" base_Element="_FkelgBiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY5B32EeaVEcfXx-aEqQ" base_Element="_Fk41MBiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY5R32EeaVEcfXx-aEqQ" base_Element="_FySYABiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY5h32EeaVEcfXx-aEqQ" base_Element="_psjm8BiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY5x32EeaVEcfXx-aEqQ" base_Element="_psjm8RiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY6B32EeaVEcfXx-aEqQ" base_Element="_psjm8hiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY6R32EeaVEcfXx-aEqQ" base_Element="_We3KYBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY6h32EeaVEcfXx-aEqQ" base_Element="_bJaN8BiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY6x32EeaVEcfXx-aEqQ" base_Element="_RB90QBmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY7B32EeaVEcfXx-aEqQ" base_Element="_RB90QRmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY7R32EeaVEcfXx-aEqQ" base_Element="_RB90QhmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY7h32EeaVEcfXx-aEqQ" base_Element="_GntusBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY7x32EeaVEcfXx-aEqQ" base_Element="_bc2xkBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY8B32EeaVEcfXx-aEqQ" base_Element="_bc2xkRiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY8R32EeaVEcfXx-aEqQ" base_Element="_bc2xkhiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY8h32EeaVEcfXx-aEqQ" base_Element="_MVTuMBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY8x32EeaVEcfXx-aEqQ" base_Element="_BIroQBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY9B32EeaVEcfXx-aEqQ" base_Element="_HPhqsBiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY9R32EeaVEcfXx-aEqQ" base_Element="_HPhqsRiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY9h32EeaVEcfXx-aEqQ" base_Element="_HPhqshiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY9x32EeaVEcfXx-aEqQ" base_Element="_x9rq4GsxEeSf07IfAG7CZg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY-B32EeaVEcfXx-aEqQ" base_Element="_gRHHkBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY-R32EeaVEcfXx-aEqQ" base_Element="_gRHHkRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY-h32EeaVEcfXx-aEqQ" base_Element="_gRHHkhiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY-x32EeaVEcfXx-aEqQ" base_Element="_gRHHkxiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY_B32EeaVEcfXx-aEqQ" base_Element="_stRGQBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY_R32EeaVEcfXx-aEqQ" base_Element="_stRGQRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY_h32EeaVEcfXx-aEqQ" base_Element="_stRGQhiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwY_x32EeaVEcfXx-aEqQ" base_Element="_stRGQxiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZAB32EeaVEcfXx-aEqQ" base_Element="_3JNgsBiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZAR32EeaVEcfXx-aEqQ" base_Element="_3JNgsRiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZAh32EeaVEcfXx-aEqQ" base_Element="_3JNgshiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZAx32EeaVEcfXx-aEqQ" base_Element="_3JNgsxiUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZBB32EeaVEcfXx-aEqQ" base_Element="_DY7l4BiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZBR32EeaVEcfXx-aEqQ" base_Element="_DY7l4RiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZBh32EeaVEcfXx-aEqQ" base_Element="_DY7l4hiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZBx32EeaVEcfXx-aEqQ" base_Element="_DY7l4xiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZCB32EeaVEcfXx-aEqQ" base_Element="_UcKdYBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZCR32EeaVEcfXx-aEqQ" base_Element="_UcLEcBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZCh32EeaVEcfXx-aEqQ" base_Element="_UcLEcRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZCx32EeaVEcfXx-aEqQ" base_Element="_UcLEchiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZDB32EeaVEcfXx-aEqQ" base_Element="_izo5QBiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZDR32EeaVEcfXx-aEqQ" base_Element="_izo5QRiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZDh32EeaVEcfXx-aEqQ" base_Element="_izo5QhiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZDx32EeaVEcfXx-aEqQ" base_Element="_izo5QxiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZEB32EeaVEcfXx-aEqQ" base_Element="_tYwd0BiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZER32EeaVEcfXx-aEqQ" base_Element="_tYwd0RiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZEh32EeaVEcfXx-aEqQ" base_Element="_tYwd0hiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZEx32EeaVEcfXx-aEqQ" base_Element="_tYwd0xiVEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZFB32EeaVEcfXx-aEqQ" base_Element="_GubFkBiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZFR32EeaVEcfXx-aEqQ" base_Element="_GubFkRiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZFh32EeaVEcfXx-aEqQ" base_Element="_GubFkhiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZFx32EeaVEcfXx-aEqQ" base_Element="_GubFkxiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZGB32EeaVEcfXx-aEqQ" base_Element="_gz8c8BiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZGR32EeaVEcfXx-aEqQ" base_Element="_gz8c8RiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZGh32EeaVEcfXx-aEqQ" base_Element="_gz8c8hiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZGx32EeaVEcfXx-aEqQ" base_Element="_gz8c8xiWEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZHB32EeaVEcfXx-aEqQ" base_Element="_ps3wABiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZHR32EeaVEcfXx-aEqQ" base_Element="_ps3wARiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZHh32EeaVEcfXx-aEqQ" base_Element="_ps3wAhiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZHx32EeaVEcfXx-aEqQ" base_Element="_ps3wAxiXEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZIB32EeaVEcfXx-aEqQ" base_Element="_Khe1kBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZIR32EeaVEcfXx-aEqQ" base_Element="_Khe1kRiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZIh32EeaVEcfXx-aEqQ" base_Element="_Khe1khiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZIx32EeaVEcfXx-aEqQ" base_Element="_Khe1kxiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZJB32EeaVEcfXx-aEqQ" base_Element="_bdIeYBiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZJR32EeaVEcfXx-aEqQ" base_Element="_bdIeYRiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZJh32EeaVEcfXx-aEqQ" base_Element="_bdIeYhiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZJx32EeaVEcfXx-aEqQ" base_Element="_bdIeYxiYEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZKB32EeaVEcfXx-aEqQ" base_Element="_QImZoBiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZKR32EeaVEcfXx-aEqQ" base_Element="_QImZoRiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZKh32EeaVEcfXx-aEqQ" base_Element="_QImZohiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZKx32EeaVEcfXx-aEqQ" base_Element="_QImZoxiZEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZLB32EeaVEcfXx-aEqQ" base_Element="_HP3B4BiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZLR32EeaVEcfXx-aEqQ" base_Element="_HP3B4RiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZLh32EeaVEcfXx-aEqQ" base_Element="_HP3B4hiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZLx32EeaVEcfXx-aEqQ" base_Element="_HP3B4xiaEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZMB32EeaVEcfXx-aEqQ" base_Element="_RCTLcBmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZMR32EeaVEcfXx-aEqQ" base_Element="_RCTLcRmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZMh32EeaVEcfXx-aEqQ" base_Element="_RCTLchmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZMx32EeaVEcfXx-aEqQ" base_Element="_RCTLcxmOEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZNB32EeaVEcfXx-aEqQ" base_Element="_y8I3MGsxEeSf07IfAG7CZg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZNR32EeaVEcfXx-aEqQ" base_Element="_4aFTwOvTEeOE19T_GJuRHg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZNh32EeaVEcfXx-aEqQ" base_Element="_gPeu4BifEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZNx32EeaVEcfXx-aEqQ" base_Element="_-Npr4KNREeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZOB32EeaVEcfXx-aEqQ" base_Element="_q3ZmoLA7EeSXJ6XI-2nsRw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZOR32EeaVEcfXx-aEqQ" base_Element="_DjpgMKNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZOh32EeaVEcfXx-aEqQ" base_Element="_DjpgMaNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZOx32EeaVEcfXx-aEqQ" base_Element="_DjpgMqNSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZPB32EeaVEcfXx-aEqQ" base_Element="_DjpgM6NSEeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZPR32EeaVEcfXx-aEqQ" base_Element="_KjlfMJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZPh32EeaVEcfXx-aEqQ" base_Element="_yIySUJgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZPx32EeaVEcfXx-aEqQ" base_Element="_frIgsJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZQB32EeaVEcfXx-aEqQ" base_Element="_pKuAkJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZQR32EeaVEcfXx-aEqQ" base_Element="_pKuAkZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZQh32EeaVEcfXx-aEqQ" base_Element="_pKuAkpgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZQx32EeaVEcfXx-aEqQ" base_Element="__XgL0JgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZRB32EeaVEcfXx-aEqQ" base_Element="__XgL0ZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZRR32EeaVEcfXx-aEqQ" base_Element="__XgL0pgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZRh32EeaVEcfXx-aEqQ" base_Element="_OunqUJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZRx32EeaVEcfXx-aEqQ" base_Element="_OunqUZgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZSB32EeaVEcfXx-aEqQ" base_Element="_OunqUpgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZSR32EeaVEcfXx-aEqQ" base_Element="_hXvMcJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZSh32EeaVEcfXx-aEqQ" base_Element="_blJtUJgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZSx32EeaVEcfXx-aEqQ" base_Element="_blJtUZgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZTB32EeaVEcfXx-aEqQ" base_Element="_blJtUpgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZTR32EeaVEcfXx-aEqQ" base_Element="_ta7icJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZTh32EeaVEcfXx-aEqQ" base_Element="_ta7icZgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZTx32EeaVEcfXx-aEqQ" base_Element="_ta7icpgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZUB32EeaVEcfXx-aEqQ" base_Element="_1nVtwJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZUR32EeaVEcfXx-aEqQ" base_Element="_1nVtwZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZUh32EeaVEcfXx-aEqQ" base_Element="_1nVtwpgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZUx32EeaVEcfXx-aEqQ" base_Element="_pK3KgJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZVB32EeaVEcfXx-aEqQ" base_Element="_pK3KgZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZVR32EeaVEcfXx-aEqQ" base_Element="_pK3KgpgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZVh32EeaVEcfXx-aEqQ" base_Element="_pK3Kg5gMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZVx32EeaVEcfXx-aEqQ" base_Element="_6l-WgJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZWB32EeaVEcfXx-aEqQ" base_Element="_PM8TIJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZWR32EeaVEcfXx-aEqQ" base_Element="_PM8TIZgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZWh32EeaVEcfXx-aEqQ" base_Element="_PM8TIpgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZWx32EeaVEcfXx-aEqQ" base_Element="_XymSoJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZXB32EeaVEcfXx-aEqQ" base_Element="_XymSoZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZXR32EeaVEcfXx-aEqQ" base_Element="_XymSopgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZXh32EeaVEcfXx-aEqQ" base_Element="__XpVwJgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZXx32EeaVEcfXx-aEqQ" base_Element="__XpVwZgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZYB32EeaVEcfXx-aEqQ" base_Element="__XpVwpgMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZYR32EeaVEcfXx-aEqQ" base_Element="__XpVw5gMEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZYh32EeaVEcfXx-aEqQ" base_Element="_blS3QJgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZYx32EeaVEcfXx-aEqQ" base_Element="_blS3QZgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZZB32EeaVEcfXx-aEqQ" base_Element="_blS3QpgNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZZR32EeaVEcfXx-aEqQ" base_Element="_blS3Q5gNEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZZh32EeaVEcfXx-aEqQ" base_Element="_Du1jAJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZZx32EeaVEcfXx-aEqQ" base_Element="_Ouw0QJgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZaB32EeaVEcfXx-aEqQ" base_Element="_Ouw0QZgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZaR32EeaVEcfXx-aEqQ" base_Element="_Ouw0QpgOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZah32EeaVEcfXx-aEqQ" base_Element="_Ouw0Q5gOEeSjhfRBVH9_gQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZax32EeaVEcfXx-aEqQ" base_Element="_CqTR8JgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZbB32EeaVEcfXx-aEqQ" base_Element="_GKgCQJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZbR32EeaVEcfXx-aEqQ" base_Element="_PNGEIJgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZbh32EeaVEcfXx-aEqQ" base_Element="_HSBcQJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZbx32EeaVEcfXx-aEqQ" base_Element="_PNGEIZgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZcB32EeaVEcfXx-aEqQ" base_Element="_PNGEIpgQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZcR32EeaVEcfXx-aEqQ" base_Element="_PNGEI5gQEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZch32EeaVEcfXx-aEqQ" base_Element="_j2VmwJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZcx32EeaVEcfXx-aEqQ" base_Element="_oX1cAJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZdB32EeaVEcfXx-aEqQ" base_Element="_tbEFUJgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZdR32EeaVEcfXx-aEqQ" base_Element="_JhTXQJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZdh32EeaVEcfXx-aEqQ" base_Element="_tbEFUZgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZdx32EeaVEcfXx-aEqQ" base_Element="_tbEFUpgVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZeB32EeaVEcfXx-aEqQ" base_Element="_tbEFU5gVEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZeR32EeaVEcfXx-aEqQ" base_Element="_XyxRwJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZeh32EeaVEcfXx-aEqQ" base_Element="_XyxRwZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZex32EeaVEcfXx-aEqQ" base_Element="_XyxRwpgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZfB32EeaVEcfXx-aEqQ" base_Element="_XyxRw5gWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZfR32EeaVEcfXx-aEqQ" base_Element="_1nfewJgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZfh32EeaVEcfXx-aEqQ" base_Element="_1nfewZgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZfx32EeaVEcfXx-aEqQ" base_Element="_1nfewpgWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZgB32EeaVEcfXx-aEqQ" base_Element="_1nfew5gWEeSeO5hX75xH1g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZgR32EeaVEcfXx-aEqQ" base_Element="_XdSnYCOeEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZgh32EeaVEcfXx-aEqQ" base_Element="_88knQCIoEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZgx32EeaVEcfXx-aEqQ" base_Element="_1fi3cBfUEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZhB32EeaVEcfXx-aEqQ" base_Element="_xQdisOv0EeOE19T_GJuRHg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZhR32EeaVEcfXx-aEqQ" base_Element="_HDYBUCRcEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZhh32EeaVEcfXx-aEqQ" base_Element="_1R3MsCRJEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZhx32EeaVEcfXx-aEqQ" base_Element="_6G0SACbREeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZiB32EeaVEcfXx-aEqQ" base_Element="_jUcAACRYEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZiR32EeaVEcfXx-aEqQ" base_Element="_OX7UYCRZEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZih32EeaVEcfXx-aEqQ" base_Element="_5W8_gCRZEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZix32EeaVEcfXx-aEqQ" base_Element="_5FqlwCRaEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZjB32EeaVEcfXx-aEqQ" base_Element="_Kf4Z4CRbEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZjR32EeaVEcfXx-aEqQ" base_Element="_wZJrYCPHEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZjh32EeaVEcfXx-aEqQ" base_Element="_wpChgCPHEeSoB4Ln_aUF6w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZjx32EeaVEcfXx-aEqQ" base_Element="_hIFr8CRSEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZkB32EeaVEcfXx-aEqQ" base_Element="_hIhw0CRSEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZkR32EeaVEcfXx-aEqQ" base_Element="_kvovgCRUEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZkh32EeaVEcfXx-aEqQ" base_Element="_kwE0YCRUEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZkx32EeaVEcfXx-aEqQ" base_Element="_QdM7oCRVEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZlB32EeaVEcfXx-aEqQ" base_Element="_eqfO0CRXEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZlR32EeaVEcfXx-aEqQ" base_Element="_QdpnkCRVEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZlh32EeaVEcfXx-aEqQ" base_Element="_ZsqU0CRVEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZlx32EeaVEcfXx-aEqQ" base_Element="_ZtFyoCRVEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZmB32EeaVEcfXx-aEqQ" base_Element="_1dBdYCRVEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZmR32EeaVEcfXx-aEqQ" base_Element="_1deJUCRVEeSaIcETw2aroA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZmh32EeaVEcfXx-aEqQ" base_Element="_QBaoYCeTEeSiY-Znd5RVtA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZmx32EeaVEcfXx-aEqQ" base_Element="_f_9d0CeVEeSiY-Znd5RVtA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZnB32EeaVEcfXx-aEqQ" base_Element="_QCGk4CeTEeSiY-Znd5RVtA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZnR32EeaVEcfXx-aEqQ" base_Element="_r7fGkCeTEeSiY-Znd5RVtA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZnh32EeaVEcfXx-aEqQ" base_Element="_dZoxQCeUEeSiY-Znd5RVtA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZnx32EeaVEcfXx-aEqQ" base_Element="_r7_c4CeTEeSiY-Znd5RVtA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZoB32EeaVEcfXx-aEqQ" base_Element="_79te4J2FEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZoR32EeaVEcfXx-aEqQ" base_Element="_79_ywJ2FEeSQBuaNnP_LbA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZoh32EeaVEcfXx-aEqQ" base_Element="_lyJ8sE-nEeSGXqgORzeAvQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZox32EeaVEcfXx-aEqQ" base_Element="_15jvAE-wEeSGXqgORzeAvQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZpB32EeaVEcfXx-aEqQ" base_Element="_DckcAL7WEeSdssyZX-p90g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZpR32EeaVEcfXx-aEqQ" base_Element="_9bj8oBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZph32EeaVEcfXx-aEqQ" base_Element="_9XvPAGaKEeWrX_JIGzXlSg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZpx32EeaVEcfXx-aEqQ" base_Element="_-VM6YBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZqB32EeaVEcfXx-aEqQ" base_Element="_-VM6YRihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZqR32EeaVEcfXx-aEqQ" base_Element="_-VM6YhihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZqh32EeaVEcfXx-aEqQ" base_Element="_-VhDcBihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZqx32EeaVEcfXx-aEqQ" base_Element="_-VhDcRihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZrB32EeaVEcfXx-aEqQ" base_Element="_-VhDchihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZrR32EeaVEcfXx-aEqQ" base_Element="_-VhDcxihEeSh8KVgZCMyDw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZrh32EeaVEcfXx-aEqQ" base_Element="_Rt55IKT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZrx32EeaVEcfXx-aEqQ" base_Element="_Rt55IaT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZsB32EeaVEcfXx-aEqQ" base_Element="_Rt55IqT3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZsR32EeaVEcfXx-aEqQ" base_Element="_Rt55I6T3EeS9Obpdy8FCjA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZsh32EeaVEcfXx-aEqQ" base_Element="_EI7mABjCEeSzeoKP7VQE4w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZsx32EeaVEcfXx-aEqQ" base_Element="_wo4dMFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZtB32EeaVEcfXx-aEqQ" base_Element="_3AVHcFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZtR32EeaVEcfXx-aEqQ" base_Element="__olWsFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZth32EeaVEcfXx-aEqQ" base_Element="__olWsVZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZtx32EeaVEcfXx-aEqQ" base_Element="__olWslZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZuB32EeaVEcfXx-aEqQ" base_Element="_Qoxr0FZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZuR32EeaVEcfXx-aEqQ" base_Element="_Qoxr0VZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZuh32EeaVEcfXx-aEqQ" base_Element="_Qoxr0lZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZux32EeaVEcfXx-aEqQ" base_Element="_jCspcFZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZvB32EeaVEcfXx-aEqQ" base_Element="_jCspcVZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZvR32EeaVEcfXx-aEqQ" base_Element="_jCspclZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZvh32EeaVEcfXx-aEqQ" base_Element="_c1f1cFZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZvx32EeaVEcfXx-aEqQ" base_Element="_c1f1cVZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZwB32EeaVEcfXx-aEqQ" base_Element="_c1f1clZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZwR32EeaVEcfXx-aEqQ" base_Element="_5GhX4FZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZwh32EeaVEcfXx-aEqQ" base_Element="_LXPWMFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZwx32EeaVEcfXx-aEqQ" base_Element="_Mx0d0FZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZxB32EeaVEcfXx-aEqQ" base_Element="_MyGKoFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZxR32EeaVEcfXx-aEqQ" base_Element="_Myt1sFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZxh32EeaVEcfXx-aEqQ" base_Element="_S4YzcFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZxx32EeaVEcfXx-aEqQ" base_Element="_S4YzcVZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZyB32EeaVEcfXx-aEqQ" base_Element="_S4YzclZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZyR32EeaVEcfXx-aEqQ" base_Element="__otSgFZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZyh32EeaVEcfXx-aEqQ" base_Element="__otSgVZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZyx32EeaVEcfXx-aEqQ" base_Element="__otSglZ2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZzB32EeaVEcfXx-aEqQ" base_Element="__otSg1Z2EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZzR32EeaVEcfXx-aEqQ" base_Element="_S4h9YFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZzh32EeaVEcfXx-aEqQ" base_Element="_S4h9YVZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZzx32EeaVEcfXx-aEqQ" base_Element="_S4h9YlZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ0B32EeaVEcfXx-aEqQ" base_Element="_S4h9Y1Z3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ0R32EeaVEcfXx-aEqQ" base_Element="_VZ3RsFZ3EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ0h32EeaVEcfXx-aEqQ" base_Element="_MZH0gFZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ0x32EeaVEcfXx-aEqQ" base_Element="_Qo8q8FZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ1B32EeaVEcfXx-aEqQ" base_Element="_Qo8q8VZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ1R32EeaVEcfXx-aEqQ" base_Element="_Qo8q8lZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ1h32EeaVEcfXx-aEqQ" base_Element="_Qo8q81Z4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ1x32EeaVEcfXx-aEqQ" base_Element="_jC1MUFZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ2B32EeaVEcfXx-aEqQ" base_Element="_0rt5IFZ5EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ2R32EeaVEcfXx-aEqQ" base_Element="_GiaN4FZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ2h32EeaVEcfXx-aEqQ" base_Element="_jC1MUVZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ2x32EeaVEcfXx-aEqQ" base_Element="_jC1MUlZ4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ3B32EeaVEcfXx-aEqQ" base_Element="_jC1MU1Z4EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ3R32EeaVEcfXx-aEqQ" base_Element="_c1o_YFZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ3h32EeaVEcfXx-aEqQ" base_Element="_c1o_YVZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ3x32EeaVEcfXx-aEqQ" base_Element="_c1o_YlZ6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ4B32EeaVEcfXx-aEqQ" base_Element="_c1o_Y1Z6EeOVGaP4lO41SQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ4R32EeaVEcfXx-aEqQ" base_Element="_5dOpYFYEEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ4h32EeaVEcfXx-aEqQ" base_Element="_VPMpkFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ4x32EeaVEcfXx-aEqQ" base_Element="_2WrLUFYIEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ5B32EeaVEcfXx-aEqQ" base_Element="_5FqrsFYJEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ5R32EeaVEcfXx-aEqQ" base_Element="_HvUO8FYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ5h32EeaVEcfXx-aEqQ" base_Element="_nbURMFYGEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ5x32EeaVEcfXx-aEqQ" base_Element="_1XlQYFYJEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ6B32EeaVEcfXx-aEqQ" base_Element="_1Xph0FYJEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ6R32EeaVEcfXx-aEqQ" base_Element="_GkqHwFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ6h32EeaVEcfXx-aEqQ" base_Element="_n5ZCYFYIEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ6x32EeaVEcfXx-aEqQ" base_Element="_n5cFsFYIEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ7B32EeaVEcfXx-aEqQ" base_Element="_JAQSYFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ7R32EeaVEcfXx-aEqQ" base_Element="_QsLcQVYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ7h32EeaVEcfXx-aEqQ" base_Element="_gmdHoFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ7x32EeaVEcfXx-aEqQ" base_Element="_gminMFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ8B32EeaVEcfXx-aEqQ" base_Element="_i38pIFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ8R32EeaVEcfXx-aEqQ" base_Element="__eUhwFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ8h32EeaVEcfXx-aEqQ" base_Element="__eYMIFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ8x32EeaVEcfXx-aEqQ" base_Element="_QsIY8FYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ9B32EeaVEcfXx-aEqQ" base_Element="_QsK1MFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ9R32EeaVEcfXx-aEqQ" base_Element="_cqIKEFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ9h32EeaVEcfXx-aEqQ" base_Element="_cqKmUFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ9x32EeaVEcfXx-aEqQ" base_Element="_i37bAFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ-B32EeaVEcfXx-aEqQ" base_Element="_i38CEVYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ-R32EeaVEcfXx-aEqQ" base_Element="_yGsrQFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ICwZ-h32EeaVEcfXx-aEqQ" base_Element="_yGugcFYFEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i0B32EeaVEcfXx-aEqQ" base_Element="_nbScAFYGEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i0R32EeaVEcfXx-aEqQ" base_Element="_nbTDEVYGEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i0h32EeaVEcfXx-aEqQ" base_Element="_rVTvoFYIEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i0x32EeaVEcfXx-aEqQ" base_Element="_rVWL4FYIEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i1B32EeaVEcfXx-aEqQ" base_Element="_Gko5oFYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i1R32EeaVEcfXx-aEqQ" base_Element="_GkpgslYHEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i1h32EeaVEcfXx-aEqQ" base_Element="_o8zKsFYJEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i1x32EeaVEcfXx-aEqQ" base_Element="_o83cIFYJEeW5zoktRlwOmg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i2B32EeaVEcfXx-aEqQ" base_Element="_kr10UEDrEeWHCPNn7aoIVw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IC5i2R32EeaVEcfXx-aEqQ" base_Element="_g738cPHhEeWwSoymEK8fCg"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/Tapi.uml
+++ b/xmi2yang tool-v2.0/project/Tapi.uml
@@ -1,0 +1,992 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_cOw5UDA4Eea4fKwSGMr6CA" name="Tapi">
+    <packagedElement xmi:type="uml:Package" xmi:id="_cDG3IC5wEea0_JngOlSKcA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="__gLXQBrpEeaeisu1tQM3_Q" name="LocalClassHasExtensionsSpec" memberEnd="__gLXQxrpEeaeisu1tQM3_Q __gLXRRrpEeaeisu1tQM3_Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__gLXQRrpEeaeisu1tQM3_Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__gLXQhrpEeaeisu1tQM3_Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="__gLXRRrpEeaeisu1tQM3_Q" name="_localClass" type="_UhrZoN8qEeWT9tG0gGLRFw" association="__gLXQBrpEeaeisu1tQM3_Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_cKFNkDNtEea0Br-ajMxp_A" name="GlobalClassHasExtensionsSpec" memberEnd="_cKOXgDNtEea0Br-ajMxp_A _cKOXgzNtEea0Br-ajMxp_A">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cKFNkjNtEea0Br-ajMxp_A" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cKFNkzNtEea0Br-ajMxp_A" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_cKOXgzNtEea0Br-ajMxp_A" name="_globalClass" type="_xEvjkN8AEeW-BtRsuJPbqg" association="_cKFNkDNtEea0Br-ajMxp_A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_49C8MLoXEeWgnN4av0rtYw" name="Context" client="_sfccMOK0EeSq5fATALSQkQ">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGqneFLNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_LIRpIPEkEeWIT-EHROE-tg" name="ContextIsDefinedByServiceEndPoints" memberEnd="_LIbaIvEkEeWIT-EHROE-tg _LIbaJPEkEeWIT-EHROE-tg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LIbaIPEkEeWIT-EHROE-tg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_LIbaIfEkEeWIT-EHROE-tg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_LIbaJPEkEeWIT-EHROE-tg" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_LIRpIPEkEeWIT-EHROE-tg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WiozoPEkEeWIT-EHROE-tg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WiozofEkEeWIT-EHROE-tg" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_LB6fQPEgEeWIT-EHROE-tg" name="ContextScopesAllConnServices" memberEnd="_LCDpMPEgEeWIT-EHROE-tg _LCDpMvEgEeWIT-EHROE-tg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LB6fQfEgEeWIT-EHROE-tg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_LB6fQvEgEeWIT-EHROE-tg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_LCDpMvEgEeWIT-EHROE-tg" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_LB6fQPEgEeWIT-EHROE-tg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xmTqwPEjEeWIT-EHROE-tg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xmTqwfEjEeWIT-EHROE-tg" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2ZlAoC0oEeah7qIgVNfKeA" name="ContextScopesAllNotifications" memberEnd="_2ZlApC0oEeah7qIgVNfKeA _2ZlApy0oEeah7qIgVNfKeA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2ZlAoi0oEeah7qIgVNfKeA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2ZlAoy0oEeah7qIgVNfKeA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_2ZlApy0oEeah7qIgVNfKeA" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_2ZlAoC0oEeah7qIgVNfKeA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_MWFHQCz0EeaYO8M_h7XJ5A" name="ContextScopesAllNotifSubscriptions" memberEnd="_MWFHRCz0EeaYO8M_h7XJ5A _MWO4QCz0EeaYO8M_h7XJ5A">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MWFHQiz0EeaYO8M_h7XJ5A" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MWFHQyz0EeaYO8M_h7XJ5A" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MWO4QCz0EeaYO8M_h7XJ5A" name="context" type="_sfccMOK0EeSq5fATALSQkQ" association="_MWFHQCz0EeaYO8M_h7XJ5A">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sEeLoCz0EeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sEeLoiz0EeaYO8M_h7XJ5A" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_gPX2UPEyEeWIT-EHROE-tg" name="ContextScopesAllPathServices" memberEnd="_gPX2U_EyEeWIT-EHROE-tg _gPX2VfEyEeWIT-EHROE-tg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gPX2UfEyEeWIT-EHROE-tg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gPX2UvEyEeWIT-EHROE-tg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_gPX2VfEyEeWIT-EHROE-tg" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_gPX2UPEyEeWIT-EHROE-tg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mQnAAPEyEeWIT-EHROE-tg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mQnAAfEyEeWIT-EHROE-tg" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_GeUhUPTbEeWQB8HQFBfkJQ" name="ContextScopesAllVNwServices" memberEnd="_GeUhU_TbEeWQB8HQFBfkJQ _GeUhVfTbEeWQB8HQFBfkJQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_GeUhUfTbEeWQB8HQFBfkJQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_GeUhUvTbEeWQB8HQFBfkJQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_GeUhVfTbEeWQB8HQFBfkJQ" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_GeUhUPTbEeWQB8HQFBfkJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OFGFcPTbEeWQB8HQFBfkJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OFGFcfTbEeWQB8HQFBfkJQ" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_7HFlYEHHEeWqPKyD1j6LMg" name="ContextScopesTopologies" memberEnd="_7HFlY0HHEeWqPKyD1j6LMg _7HGMcEHHEeWqPKyD1j6LMg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7HFlYUHHEeWqPKyD1j6LMg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7HFlYkHHEeWqPKyD1j6LMg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_7HGMcEHHEeWqPKyD1j6LMg" name="_ncd" type="_sfccMOK0EeSq5fATALSQkQ" association="_7HFlYEHHEeWqPKyD1j6LMg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2OgckKfzEeW6jfwWQNiYcg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2SbTQKfzEeW6jfwWQNiYcg" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_MjPmQD4bEea-1_BGg-qcjQ" name="ContextScopesComputedPaths" memberEnd="_MjPmRD4bEea-1_BGg-qcjQ _MjPmRz4bEea-1_BGg-qcjQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MjPmQj4bEea-1_BGg-qcjQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MjPmQz4bEea-1_BGg-qcjQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MjPmRz4bEea-1_BGg-qcjQ" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_MjPmQD4bEea-1_BGg-qcjQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_L6VMID4bEea-1_BGg-qcjQ" name="ContextScopesConnections" memberEnd="_L6VMJD4bEea-1_BGg-qcjQ _L6VMJz4bEea-1_BGg-qcjQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_L6VMIj4bEea-1_BGg-qcjQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_L6VMIz4bEea-1_BGg-qcjQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_L6VMJz4bEea-1_BGg-qcjQ" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_L6VMID4bEea-1_BGg-qcjQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_b5a4wETvEead1bezhJG4aw" name="ContextScopesNwTopoService" memberEnd="_b5a4xETvEead1bezhJG4aw _b5a4x0TvEead1bezhJG4aw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_b5a4wkTvEead1bezhJG4aw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_b5a4w0TvEead1bezhJG4aw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_b5a4x0TvEead1bezhJG4aw" name="_context" type="_sfccMOK0EeSq5fATALSQkQ" association="_b5a4wETvEead1bezhJG4aw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_S3giAO_tEeWLlrwIF3w0vA" name="ServiceEPHasStatePac" memberEnd="_S3giA-_tEeWLlrwIF3w0vA _S3giBe_tEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_S3giAe_tEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_S3giAu_tEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_S3giBe_tEeWLlrwIF3w0vA" name="_serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" association="_S3giAO_tEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_aFAUMNnYEeWIOYiRCk5bbQ" name="ServiceEPIncludesLP" memberEnd="_aFAUM9nYEeWIOYiRCk5bbQ _aFAUNdnYEeWIOYiRCk5bbQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aFAUMdnYEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aFAUMtnYEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_aFAUNdnYEeWIOYiRCk5bbQ" name="_serviceEndPoint" type="_It0sYEG-EeWMO5szP8dKiA" association="_aFAUMNnYEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_32-2kLoYEeWgnN4av0rtYw" name="ServiceEndPoint">
+        <client xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_eEpDMFX4EeOVGaP4lO41SQ"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_XqBXAC5wEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_ZA31MC5wEea0_JngOlSKcA" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_j2GU0N78EeW-BtRsuJPbqg" name="AdminStatePac" isLeaf="true" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="__hsSIN78EeW-BtRsuJPbqg" annotatedElement="_j2GU0N78EeW-BtRsuJPbqg">
+          <body>Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4ZaA0N78EeW-BtRsuJPbqg" name="administrativeState" type="_zSpnYNnjEeWIOYiRCk5bbQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BY3PIN79EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ER7uAN79EeW-BtRsuJPbqg" name="lifecycleState" visibility="public" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_xEvjkN8AEeW-BtRsuJPbqg" name="GlobalClass" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjkd8AEeW-BtRsuJPbqg" annotatedElement="_xEvjkN8AEeW-BtRsuJPbqg">
+          <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjm98AEeW-BtRsuJPbqg" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjnN8AEeW-BtRsuJPbqg" annotatedElement="_xEvjm98AEeW-BtRsuJPbqg">
+            <body>UUID: An identifier that is universally unique&#xD;
+&#xD;
+(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjnd8AEeW-BtRsuJPbqg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjnt8AEeW-BtRsuJPbqg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjn98AEeW-BtRsuJPbqg" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjoN8AEeW-BtRsuJPbqg">
+            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjod8AEeW-BtRsuJPbqg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjot8AEeW-BtRsuJPbqg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjo98AEeW-BtRsuJPbqg" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjpN8AEeW-BtRsuJPbqg">
+            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjpd8AEeW-BtRsuJPbqg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjpt8AEeW-BtRsuJPbqg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cKOXgDNtEea0Br-ajMxp_A" name="_extensions" type="_VZkuoC6BEea0_JngOlSKcA" isReadOnly="true" aggregation="composite" association="_cKFNkDNtEea0Br-ajMxp_A">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yapTUDNyEea0Br-ajMxp_A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yapTUjNyEea0Br-ajMxp_A" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_r01pEL6nEeWRz-VHgA3LJQ" name="LayerProtocol" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_r01pEb6nEeWRz-VHgA3LJQ" annotatedElement="_r01pEL6nEeWRz-VHgA3LJQ">
+          <body>Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. &#xD;
+It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. &#xD;
+Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. </body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_D65isN8sEeWT9tG0gGLRFw" general="_UhrZoN8qEeWT9tG0gGLRFw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_r01pE76nEeWRz-VHgA3LJQ" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_r01pFL6nEeWRz-VHgA3LJQ" annotatedElement="_r01pE76nEeWRz-VHgA3LJQ">
+            <body>Indicate the specific layer-protocol described by the LayerProtocol entity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_r01pFb6nEeWRz-VHgA3LJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_r01pFr6nEeWRz-VHgA3LJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_r01pH76nEeWRz-VHgA3LJQ" name="terminationDirection" visibility="public" type="_Ydx2sNnjEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_r01pIL6nEeWRz-VHgA3LJQ" annotatedElement="_r01pH76nEeWRz-VHgA3LJQ">
+            <body>The overall directionality of the LP. &#xD;
+- A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.&#xD;
+- A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows&#xD;
+- A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_r01pIb6nEeWRz-VHgA3LJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_r01pIr6nEeWRz-VHgA3LJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_r01pI76nEeWRz-VHgA3LJQ" name="terminationState" type="_adPI0NnqEeWIOYiRCk5bbQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_r01pJL6nEeWRz-VHgA3LJQ" annotatedElement="_r01pI76nEeWRz-VHgA3LJQ">
+            <body>Indicates whether the layer is terminated and if so how.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_oJg1UN79EeW-BtRsuJPbqg" name="LifecycleStatePac" isLeaf="true" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_oJg1Ud79EeW-BtRsuJPbqg" annotatedElement="_oJg1UN79EeW-BtRsuJPbqg">
+          <body>Provides state attributes for an entity that has lifeccycle aspects only.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oJg1U979EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_UhrZoN8qEeWT9tG0gGLRFw" name="LocalClass" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_UhrZod8qEeWT9tG0gGLRFw" annotatedElement="_UhrZoN8qEeWT9tG0gGLRFw">
+          <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dlarAN8qEeWT9tG0gGLRFw" name="localId">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__gLXQxrpEeaeisu1tQM3_Q" name="_extensions" type="_VZkuoC6BEea0_JngOlSKcA" isReadOnly="true" aggregation="composite" association="__gLXQBrpEeaeisu1tQM3_Q">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2iUTUDNyEea0Br-ajMxp_A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2iUTUjNyEea0Br-ajMxp_A" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_TlA2gN79EeW-BtRsuJPbqg" name="OperationalStatePac" isLeaf="true" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_TlA2gd79EeW-BtRsuJPbqg" annotatedElement="_TlA2gN79EeW-BtRsuJPbqg">
+          <body>Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2g979EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2hN79EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_rBq8YO-fEeWLlrwIF3w0vA" name="TimeRange">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qDhdIL2OEeWdore3Cxez9g" name="endTime" type="_6iCS8O-fEeWLlrwIF3w0vA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8s_SoL2OEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8s_Sob2OEeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nkyJ0L2OEeWdore3Cxez9g" name="startTime" type="_6iCS8O-fEeWLlrwIF3w0vA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_651S8L2OEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_65_D8L2OEeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_VZkuoC6BEea0_JngOlSKcA" name="ExtensionsSpec" isAbstract="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VZkuoS6BEea0_JngOlSKcA" name="extensionsSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VZkuoi6BEea0_JngOlSKcA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VZkuoy6BEea0_JngOlSKcA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_EGSwgDOFEeansfg7-s4Unw" name="extensionsSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NdODoDOFEeansfg7-s4Unw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NdODojOFEeansfg7-s4Unw" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_sfccMOK0EeSq5fATALSQkQ" name="Context" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sfccMeK0EeSq5fATALSQkQ">
+          <body>The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_NqC_oO_iEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_b5a4xETvEead1bezhJG4aw" name="_nwTopologyService" type="_zC-54D3fEea-1_BGg-qcjQ" isReadOnly="true" aggregation="composite" association="_b5a4wETvEead1bezhJG4aw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LCDpMPEgEeWIT-EHROE-tg" name="_connectivityService" type="_zC-54D3fEea-1_BGg-qcjQ" aggregation="composite" association="_LB6fQPEgEeWIT-EHROE-tg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wuyz8PEjEeWIT-EHROE-tg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wuyz8fEjEeWIT-EHROE-tg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GeUhU_TbEeWQB8HQFBfkJQ" name="_vnwService" type="_zC-54D3fEea-1_BGg-qcjQ" aggregation="composite" association="_GeUhUPTbEeWQB8HQFBfkJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Md-9sPTbEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Md-9sfTbEeWQB8HQFBfkJQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gPX2U_EyEeWIT-EHROE-tg" name="_pathCompService" type="_zC-54D3fEea-1_BGg-qcjQ" aggregation="composite" association="_gPX2UPEyEeWIT-EHROE-tg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_lzJn8PEyEeWIT-EHROE-tg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_lzJn8fEyEeWIT-EHROE-tg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MWFHRCz0EeaYO8M_h7XJ5A" name="_notifSubscription" type="_zC-54D3fEea-1_BGg-qcjQ" aggregation="composite" association="_MWFHQCz0EeaYO8M_h7XJ5A">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mZtBMCz0EeaYO8M_h7XJ5A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mZtBMiz0EeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LIbaIvEkEeWIT-EHROE-tg" name="_serviceEndPoint" type="_tjWBYD3fEea-1_BGg-qcjQ" isReadOnly="true" aggregation="composite" association="_LIRpIPEkEeWIT-EHROE-tg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_URpocPEkEeWIT-EHROE-tg" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_URpocfEkEeWIT-EHROE-tg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7HFlY0HHEeWqPKyD1j6LMg" name="_topology" type="_tjWBYD3fEea-1_BGg-qcjQ" isReadOnly="true" aggregation="composite" association="_7HFlYEHHEeWqPKyD1j6LMg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FeLVAEHIEeWqPKyD1j6LMg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FeNKMEHIEeWqPKyD1j6LMg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_L6VMJD4bEea-1_BGg-qcjQ" name="_connection" type="_tjWBYD3fEea-1_BGg-qcjQ" isReadOnly="true" aggregation="composite" association="_L6VMID4bEea-1_BGg-qcjQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_urF1UD4bEea-1_BGg-qcjQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_urF1Uj4bEea-1_BGg-qcjQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MjPmRD4bEea-1_BGg-qcjQ" name="_path" type="_tjWBYD3fEea-1_BGg-qcjQ" isReadOnly="true" aggregation="composite" association="_MjPmQD4bEea-1_BGg-qcjQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yxyk8D4bEea-1_BGg-qcjQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yxyk8j4bEea-1_BGg-qcjQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2ZlApC0oEeah7qIgVNfKeA" name="_notification" type="_tjWBYD3fEea-1_BGg-qcjQ" isReadOnly="true" aggregation="composite" association="_2ZlAoC0oEeah7qIgVNfKeA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NsX8QC0qEeah7qIgVNfKeA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NsX8Qi0qEeah7qIgVNfKeA" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_tjWBYD3fEea-1_BGg-qcjQ" name="ResourceSpec" isAbstract="true">
+        <generalization xmi:type="uml:Generalization" xmi:id="_JNBTID3gEea-1_BGg-qcjQ" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WjwG4D3kEea-1_BGg-qcjQ" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-nYf4EJuEea-2Meh9kw1kA" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_zC-54D3fEea-1_BGg-qcjQ" name="ServiceSpec" isAbstract="true">
+        <generalization xmi:type="uml:Generalization" xmi:id="_Iq9H4D3gEea-1_BGg-qcjQ" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_36HEED3jEea-1_BGg-qcjQ" name="serviceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4oopgEJuEea-2Meh9kw1kA" name="serviceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_It0sYEG-EeWMO5szP8dKiA" name="ServiceEndPoint" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_It0sYUG-EeWMO5szP8dKiA" annotatedElement="_It0sYEG-EeWMO5szP8dKiA">
+          <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
+The structure of LTP supports all transport protocols including circuit and packet forms.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_6frNwO_nEeWLlrwIF3w0vA" general="_tjWBYD3fEea-1_BGg-qcjQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qG8wcETZEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true" redefinedProperty="_WjwG4D3kEea-1_BGg-qcjQ">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_qG8wcUTZEead1bezhJG4aw" value="/Tapi:ServiceEndPoint"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wsEqUETZEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true" redefinedProperty="_-nYf4EJuEea-2Meh9kw1kA">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_wsEqUUTZEead1bezhJG4aw" value="/Tapi:Context/Tapi:_serviceEndPoint"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_aFAUM9nYEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" isReadOnly="true" aggregation="composite" association="_aFAUMNnYEeWIOYiRCk5bbQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c7QIkNnYEeWIOYiRCk5bbQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c7Z5kNnYEeWIOYiRCk5bbQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_S3giA-_tEeWLlrwIF3w0vA" name="_state" type="_oJg1UN79EeW-BtRsuJPbqg" isReadOnly="true" aggregation="composite" association="_S3giAO_tEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9hsOkKU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ" isReadOnly="true"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_aoZMoC5wEea0_JngOlSKcA" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_zSpnYNnjEeWIOYiRCk5bbQ" name="AdministrativeState" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_zSpnYdnjEeWIOYiRCk5bbQ" annotatedElement="_zSpnYNnjEeWIOYiRCk5bbQ">
+          <body>The possible values of the administrativeState.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_zSpnYtnjEeWIOYiRCk5bbQ" name="LOCKED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_zSpnY9njEeWIOYiRCk5bbQ" annotatedElement="_zSpnYtnjEeWIOYiRCk5bbQ">
+            <body>Users are administratively prohibited from making use of the resource.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_zSpnZNnjEeWIOYiRCk5bbQ" name="UNLOCKED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_zSpnZdnjEeWIOYiRCk5bbQ" annotatedElement="_zSpnZNnjEeWIOYiRCk5bbQ">
+            <body>Users are allowed to use the resource</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_6iCS8O-fEeWLlrwIF3w0vA" name="DateAndTime" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_6iCS8e-fEeWLlrwIF3w0vA" annotatedElement="_6iCS8O-fEeWLlrwIF3w0vA">
+          <body>This primitive type defines the date and time according to the following structure:&#xD;
+yyyyMMddhhmmss.s[Z|{+|-}HHMm] where:&#xD;
+yyyy	0000..9999	year&#xD;
+MM	01..12			month&#xD;
+dd		01..31			day&#xD;
+hh		00..23			hour&#xD;
+mm	00..59			minute&#xD;
+ss		00..59			second&#xD;
+s		.0...9			tenth of second (set to .0 if EMS or NE cannot support this granularity)&#xD;
+Z		Z				indicates UTC (rather than local time)&#xD;
+{+|-}	+ or -			delta from UTC&#xD;
+HH		00..23			time zone difference in hours&#xD;
+Mm	00..59			time zone difference in minutes.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l1ltgO-pEeWLlrwIF3w0vA" name="value" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_l1ltge-pEeWLlrwIF3w0vA" annotatedElement="_l1ltgO-pEeWLlrwIF3w0vA">
+            <body>The specific value of the universal id</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_l1ltgu-pEeWLlrwIF3w0vA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_l1ltg--pEeWLlrwIF3w0vA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_pGsZEN5qEeWd9KDn6x5Skg" name="DirectiveValue" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_u2nJQN5qEeWd9KDn6x5Skg" name="MINIMIZE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_v7ftsN5qEeWd9KDn6x5Skg" name="MAXIMIZE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ULsT4N5sEeWd9KDn6x5Skg" name="ALLOW"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VvXtIN5sEeWd9KDn6x5Skg" name="DISALLOW"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4rVysN5qEeWd9KDn6x5Skg" name="DONT_CARE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_PvuhcNnjEeWIOYiRCk5bbQ" name="ForwardingDirection" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_PvuhcdnjEeWIOYiRCk5bbQ" annotatedElement="_PvuhcNnjEeWIOYiRCk5bbQ">
+          <body>The directionality of a Forwarding entity.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PvuhctnjEeWIOYiRCk5bbQ" name="BIDIRECTIONAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Pvuhc9njEeWIOYiRCk5bbQ" annotatedElement="_PvuhctnjEeWIOYiRCk5bbQ">
+            <body>The Fowarding entity supports both BIDIRECTIONAL flows at all Ports (i.e. all Ports have both an INPUT flow and an OUTPUT flow defined)</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PvuhdNnjEeWIOYiRCk5bbQ" name="UNIDIRECTIONAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_PvuhddnjEeWIOYiRCk5bbQ" annotatedElement="_PvuhdNnjEeWIOYiRCk5bbQ">
+            <body>The Forwarding entity has Ports that are either INPUT or OUTPUT. It has no BIDIRECTIONAL Ports.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PvuhdtnjEeWIOYiRCk5bbQ" name="UNDEFINED_OR_UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Pvuhd9njEeWIOYiRCk5bbQ" annotatedElement="_PvuhdtnjEeWIOYiRCk5bbQ">
+            <body>Not a normal state. The system is unable to determine the correct value.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_i92HIL6PEeWRz-VHgA3LJQ" name="LayerProtocolName" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_mjS1wWkaEeWZEqTYAF8eqA">
+          <body>Provides a controlled list of layer protocol names and indicates the naming authority.&#xD;
+&#xD;
+Note that it is expected that attributes will be added to this structure to convey the naming authority name, the name of the layer protocol using a human readable string and any particular standard reference.&#xD;
+&#xD;
+Layer protocol names include:&#xD;
+-	Layer 1 (L1): OTU, ODU&#xD;
+-	Layer 2 (L2): Carrier Grade Ethernet (ETY, ETH), MPLS-TP (MT)&#xD;
+</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_o1nLwL6PEeWRz-VHgA3LJQ" name="OCH"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_p_JmsL6PEeWRz-VHgA3LJQ" name="ODU"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_q7QpoL6PEeWRz-VHgA3LJQ" name="ETH"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_se8C4L6PEeWRz-VHgA3LJQ" name="MPLS_TP"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_2wdyENnjEeWIOYiRCk5bbQ" name="LifecycleState" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyEdnjEeWIOYiRCk5bbQ" annotatedElement="_2wdyENnjEeWIOYiRCk5bbQ">
+          <body>The possible values of the lifecycleState.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2wdyEtnjEeWIOYiRCk5bbQ" name="PLANNED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyE9njEeWIOYiRCk5bbQ" annotatedElement="_2wdyEtnjEeWIOYiRCk5bbQ">
+            <body>The resource is planned but is not present in the network.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2wdyFNnjEeWIOYiRCk5bbQ" name="POTENTIAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyFdnjEeWIOYiRCk5bbQ" annotatedElement="_2wdyFNnjEeWIOYiRCk5bbQ">
+            <body>The supporting resources are present in the network but are shared with other clients; or require further configuration before they can be used; or both.&#xD;
+o	When a potential resource is configured and allocated to a client it is moved to the “installed” state for that client.&#xD;
+o	If the potential resource has been consumed (e.g. allocated to another client) it is moved to the “planned” state for all other clients.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2wdyFtnjEeWIOYiRCk5bbQ" name="INSTALLED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyF9njEeWIOYiRCk5bbQ" annotatedElement="_2wdyFtnjEeWIOYiRCk5bbQ">
+            <body>The resource is present in the network and is capable of providing the service expected.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_2wdyGNnjEeWIOYiRCk5bbQ" name="PENDING_REMOVAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyGdnjEeWIOYiRCk5bbQ" annotatedElement="_2wdyGNnjEeWIOYiRCk5bbQ">
+            <body>The resource has been marked for removal</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_6efrYNnVEeWIOYiRCk5bbQ" name="NameAndValue" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_6efrYdnVEeWIOYiRCk5bbQ" annotatedElement="_6efrYNnVEeWIOYiRCk5bbQ">
+          <body>A scoped name-value pair</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6efrYtnVEeWIOYiRCk5bbQ" name="valueName" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6efrY9nVEeWIOYiRCk5bbQ" annotatedElement="_6efrYtnVEeWIOYiRCk5bbQ">
+            <body>The name of the value. The value need not have a name.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6efrZNnVEeWIOYiRCk5bbQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6efrZdnVEeWIOYiRCk5bbQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6efrZtnVEeWIOYiRCk5bbQ" name="value" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6efrZ9nVEeWIOYiRCk5bbQ" annotatedElement="_6efrZtnVEeWIOYiRCk5bbQ">
+            <body>The value</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6efraNnVEeWIOYiRCk5bbQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6efradnVEeWIOYiRCk5bbQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_uINi0NnjEeWIOYiRCk5bbQ" name="OperationalState" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_uINi0dnjEeWIOYiRCk5bbQ" annotatedElement="_uINi0NnjEeWIOYiRCk5bbQ">
+          <body>The possible values of the operationalState.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_uINi0tnjEeWIOYiRCk5bbQ" name="DISABLED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_uINi09njEeWIOYiRCk5bbQ" annotatedElement="_uINi0tnjEeWIOYiRCk5bbQ">
+            <body>The resource is unable to meet the SLA of the user of the resource. If no (explicit) SLA is defined the resource is disabled if it is totally inoperable and unable to provide service to the user.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_uINi1NnjEeWIOYiRCk5bbQ" name="ENABLED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_uINi1dnjEeWIOYiRCk5bbQ" annotatedElement="_uINi1NnjEeWIOYiRCk5bbQ">
+            <body>The resource is partially or fully operable and available for use</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_dLDeINnjEeWIOYiRCk5bbQ" name="PortDirection" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_dLDeIdnjEeWIOYiRCk5bbQ" annotatedElement="_dLDeINnjEeWIOYiRCk5bbQ">
+          <body>The orientation of flow at the Port of a Forwarding entity</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dLDeItnjEeWIOYiRCk5bbQ" name="BIDIRECTIONAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_dLDeI9njEeWIOYiRCk5bbQ" annotatedElement="_dLDeItnjEeWIOYiRCk5bbQ">
+            <body>The Port has both an INPUT flow and an OUTPUT flow defined.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dLDeJNnjEeWIOYiRCk5bbQ" name="INPUT">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_dLDeJdnjEeWIOYiRCk5bbQ" annotatedElement="_dLDeJNnjEeWIOYiRCk5bbQ">
+            <body>The Port only has definition for a flow into the Forwarding entity (i.e. an ingress flow).</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dLDeJtnjEeWIOYiRCk5bbQ" name="OUTPUT">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_dLDeJ9njEeWIOYiRCk5bbQ" annotatedElement="_dLDeJtnjEeWIOYiRCk5bbQ">
+            <body>The Port only has definition for a flow out of the Forwarding entity (i.e. an egress flow).</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dLDeKNnjEeWIOYiRCk5bbQ" name="UNIDENTIFIED_OR_UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_dLDeKdnjEeWIOYiRCk5bbQ" annotatedElement="_dLDeKNnjEeWIOYiRCk5bbQ">
+            <body>Not a normal state. The system is unable to determine the correct value.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EILagL6PEeWRz-VHgA3LJQ" name="PortRole" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_i47c0WkaEeWZEqTYAF8eqA">
+          <body>The role of an end in the context of the function of the forwarding entity that it bounds</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PwxOQL6PEeWRz-VHgA3LJQ" name="SYMMETRIC"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Q6aW4L6PEeWRz-VHgA3LJQ" name="ROOT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Sia2gL6PEeWRz-VHgA3LJQ" name="LEAF"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Zfvo4C54Eea0_JngOlSKcA" name="UNKNOWN"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_Ydx2sNnjEeWIOYiRCk5bbQ" name="TerminationDirection" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Ydx2sdnjEeWIOYiRCk5bbQ" annotatedElement="_Ydx2sNnjEeWIOYiRCk5bbQ">
+          <body>The directionality of a termination entity</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ydx2stnjEeWIOYiRCk5bbQ" name="BIDIRECTIONAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Ydx2s9njEeWIOYiRCk5bbQ" annotatedElement="_Ydx2stnjEeWIOYiRCk5bbQ">
+            <body>A Termination with both SINK and SOURCE flows.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ydx2tNnjEeWIOYiRCk5bbQ" name="SINK">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Ydx2tdnjEeWIOYiRCk5bbQ" annotatedElement="_Ydx2tNnjEeWIOYiRCk5bbQ">
+            <body>The flow is up the layer stack from the server side to the client side. &#xD;
+Considering an example of a Termination function within the termination entity, a SINK flow:&#xD;
+- will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component&#xD;
+- then will be decoded and deconstructed &#xD;
+- then relevant parts of the flow will be sent out of the termination function (the client side) where it is essentially at an OUTPUT from the termination component&#xD;
+A SINK termination is one that only supports a SINK flow.&#xD;
+A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ydx2ttnjEeWIOYiRCk5bbQ" name="SOURCE">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Ydx2t9njEeWIOYiRCk5bbQ" annotatedElement="_Ydx2ttnjEeWIOYiRCk5bbQ">
+            <body>The flow is down the layer stack from the server side to the client side. &#xD;
+Considering an example of a Termination function within the termination entity, a SOURCE flow:&#xD;
+- will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component&#xD;
+- then will be assembled with various overheads etc and will be coded &#xD;
+- then coded form of the assembly of flow will be sent out of the termination function (the server side) where it is essentially at an OUTPUT from the termination component&#xD;
+A SOURCE termination is one that only supports a SOURCE flow.&#xD;
+A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ydx2uNnjEeWIOYiRCk5bbQ" name="UNDEFINED_OR_UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Ydx2udnjEeWIOYiRCk5bbQ" annotatedElement="_Ydx2uNnjEeWIOYiRCk5bbQ">
+            <body>Not a normal state. The system is unable to determine the correct value.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_adPI0NnqEeWIOYiRCk5bbQ" name="TerminationState" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_adPI0dnqEeWIOYiRCk5bbQ" annotatedElement="_adPI0NnqEeWIOYiRCk5bbQ">
+          <body>Provides support for the range of behaviours and specific states that an LP can take with respect to termination of the signal.&#xD;
+Indicates to what degree the LayerTermination is terminated.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI0tnqEeWIOYiRCk5bbQ" name="LP_CAN_NEVER_TERMINATE">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI09nqEeWIOYiRCk5bbQ" annotatedElement="_adPI0tnqEeWIOYiRCk5bbQ">
+            <body>A non-flexible case that can never be terminated.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI1NnqEeWIOYiRCk5bbQ" name="LT_NOT_TERMINATED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI1dnqEeWIOYiRCk5bbQ" annotatedElement="_adPI1NnqEeWIOYiRCk5bbQ">
+            <body>A flexible termination that can terminate but is currently not terminated.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI1tnqEeWIOYiRCk5bbQ" name="TERMINATED_SERVER_TO_CLIENT_FLOW">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI19nqEeWIOYiRCk5bbQ" annotatedElement="_adPI1tnqEeWIOYiRCk5bbQ">
+            <body>A flexible termination that is currently terminated for server to client flow only.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI2NnqEeWIOYiRCk5bbQ" name="TERMINATED_CLIENT_TO_SERVER_FLOW">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI2dnqEeWIOYiRCk5bbQ" annotatedElement="_adPI2NnqEeWIOYiRCk5bbQ">
+            <body>A flexible termination that is currently terminated for client to server flow only.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI2tnqEeWIOYiRCk5bbQ" name="TERMINATED_BIDIRECTIONAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI29nqEeWIOYiRCk5bbQ" annotatedElement="_adPI2tnqEeWIOYiRCk5bbQ">
+            <body>A flexible termination that is currently terminated in both directions of flow.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI3NnqEeWIOYiRCk5bbQ" name="LT_PERMENANTLY_TERMINATED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI3dnqEeWIOYiRCk5bbQ" annotatedElement="_adPI3NnqEeWIOYiRCk5bbQ">
+            <body>A non-flexible termination that is always terminated (in both directions of flow for a bidirectional case and in the one direction of flow for both unidirectional cases).</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_adPI3tnqEeWIOYiRCk5bbQ" name="TERMINATION_STATE_UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_adPI39nqEeWIOYiRCk5bbQ" annotatedElement="_adPI3tnqEeWIOYiRCk5bbQ">
+            <body>There TerminationState cannot be determined.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_FRi-QNnWEeWIOYiRCk5bbQ" name="UniversalId" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_FRi-QdnWEeWIOYiRCk5bbQ" annotatedElement="_FRi-QNnWEeWIOYiRCk5bbQ">
+          <body>The univeral ID value where the mechanism for generation is defned by some authority not directly referenced in the structure.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FRi-QtnWEeWIOYiRCk5bbQ" name="value" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_FRi-Q9nWEeWIOYiRCk5bbQ" annotatedElement="_FRi-QtnWEeWIOYiRCk5bbQ">
+            <body>The specific value of the universal id</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FRi-RNnWEeWIOYiRCk5bbQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FRi-RdnWEeWIOYiRCk5bbQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_cmHp5DA4Eea4fKwSGMr6CA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_59DPoDOEEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_59DPoTOEEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_59DPojOEEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_59DPozOEEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_59DPpDOEEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_59DPpTOEEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cmHp5TA4Eea4fKwSGMr6CA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cnm3mjA4Eea4fKwSGMr6CA" base_Element="_cOw5UDA4Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cnm3mzA4Eea4fKwSGMr6CA" base_Element="_cmHp5DA4Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nkyJ0b2OEeWdore3Cxez9g" base_StructuralFeature="_nkyJ0L2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qDhdIb2OEeWdore3Cxez9g" base_StructuralFeature="_qDhdIL2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pJr6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pE76nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pKb6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pH76nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pKr6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pI76nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6gSbINnVEeWIOYiRCk5bbQ" base_StructuralFeature="_6efrYtnVEeWIOYiRCk5bbQ" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6gSbIdnVEeWIOYiRCk5bbQ" base_StructuralFeature="_6efrZtnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FRsvQNnWEeWIOYiRCk5bbQ" base_StructuralFeature="_FRi-QtnWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_uIXT0dnjEeWIOYiRCk5bbQ" base_Element="_uINi0tnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_uIXT0tnjEeWIOYiRCk5bbQ" base_Element="_uINi1NnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_zSyxUdnjEeWIOYiRCk5bbQ" base_Element="_zSpnYtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Preliminary xmi:id="_zSyxUtnjEeWIOYiRCk5bbQ" base_Element="_zSpnZNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_2wdyG9njEeWIOYiRCk5bbQ" base_Element="_2wdyEtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_2wdyHNnjEeWIOYiRCk5bbQ" base_Element="_2wdyFNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_2wdyHdnjEeWIOYiRCk5bbQ" base_Element="_2wdyFtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_2wnjENnjEeWIOYiRCk5bbQ" base_Element="_2wdyGNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aepeEdnqEeWIOYiRCk5bbQ" base_Element="_adPI0tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aepeEtnqEeWIOYiRCk5bbQ" base_Element="_adPI1NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aeqFINnqEeWIOYiRCk5bbQ" base_Element="_adPI1tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aeqFIdnqEeWIOYiRCk5bbQ" base_Element="_adPI2NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aeqFItnqEeWIOYiRCk5bbQ" base_Element="_adPI2tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aeqsMNnqEeWIOYiRCk5bbQ" base_Element="_adPI3NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:Experimental xmi:id="_aeqsMdnqEeWIOYiRCk5bbQ" base_Element="_adPI3tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4ZaA0d78EeW-BtRsuJPbqg" base_StructuralFeature="_4ZaA0N78EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BY3PId79EeW-BtRsuJPbqg" base_StructuralFeature="_BY3PIN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ER7uAd79EeW-BtRsuJPbqg" base_StructuralFeature="_ER7uAN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TlA2h979EeW-BtRsuJPbqg" base_StructuralFeature="_TlA2g979EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TlA2iN79EeW-BtRsuJPbqg" base_StructuralFeature="_TlA2hN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oJg1Vt79EeW-BtRsuJPbqg" base_StructuralFeature="_oJg1U979EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsRN8AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjm98AEeW-BtRsuJPbqg" isInvariant="true" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsRd8AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjn98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsRt8AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjo98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dlarAd8qEeWT9tG0gGLRFw" base_StructuralFeature="_dlarAN8qEeWT9tG0gGLRFw" isInvariant="true" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l1lthO-pEeWLlrwIF3w0vA" base_StructuralFeature="_l1ltgO-pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0dR31EeaVEcfXx-aEqQ" base_Element="_r01pEb6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0dh31EeaVEcfXx-aEqQ" base_Element="_D65isN8sEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0dx31EeaVEcfXx-aEqQ" base_Element="__gLXQxrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0eB31EeaVEcfXx-aEqQ" base_Element="_r01pE76nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0eR31EeaVEcfXx-aEqQ" base_Element="_r01pFL6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0eh31EeaVEcfXx-aEqQ" base_Element="_r01pFb6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ex31EeaVEcfXx-aEqQ" base_Element="_r01pFr6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0fB31EeaVEcfXx-aEqQ" base_Element="_r01pH76nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0fR31EeaVEcfXx-aEqQ" base_Element="_r01pIL6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0fh31EeaVEcfXx-aEqQ" base_Element="_r01pIb6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0fx31EeaVEcfXx-aEqQ" base_Element="_r01pIr6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0gB31EeaVEcfXx-aEqQ" base_Element="_r01pI76nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0gR31EeaVEcfXx-aEqQ" base_Element="_r01pJL6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Qx31EeaVEcfXx-aEqQ" base_Element="_xEvjkd8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5RB31EeaVEcfXx-aEqQ" base_Element="_xEvjm98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5RR31EeaVEcfXx-aEqQ" base_Element="_xEvjnN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Rh31EeaVEcfXx-aEqQ" base_Element="_xEvjnd8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Rx31EeaVEcfXx-aEqQ" base_Element="_xEvjnt8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5SB31EeaVEcfXx-aEqQ" base_Element="_xEvjn98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5SR31EeaVEcfXx-aEqQ" base_Element="_xEvjoN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Sh31EeaVEcfXx-aEqQ" base_Element="_xEvjod8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Sx31EeaVEcfXx-aEqQ" base_Element="_xEvjot8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5TB31EeaVEcfXx-aEqQ" base_Element="_xEvjo98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5TR31EeaVEcfXx-aEqQ" base_Element="_xEvjpN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Th31EeaVEcfXx-aEqQ" base_Element="_xEvjpd8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Tx31EeaVEcfXx-aEqQ" base_Element="_xEvjpt8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5VR31EeaVEcfXx-aEqQ" base_Element="_UhrZod8qEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Vh31EeaVEcfXx-aEqQ" base_Element="_dlarAN8qEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqQR31EeaVEcfXx-aEqQ" base_Element="__hsSIN78EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqQh31EeaVEcfXx-aEqQ" base_Element="_4ZaA0N78EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqQx31EeaVEcfXx-aEqQ" base_Element="_BY3PIN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqRB31EeaVEcfXx-aEqQ" base_Element="_ER7uAN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqRh31EeaVEcfXx-aEqQ" base_Element="_oJg1Ud79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqRx31EeaVEcfXx-aEqQ" base_Element="_oJg1U979EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqSR31EeaVEcfXx-aEqQ" base_Element="_TlA2gd79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqSh31EeaVEcfXx-aEqQ" base_Element="_TlA2g979EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqSx31EeaVEcfXx-aEqQ" base_Element="_TlA2hN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqdx31EeaVEcfXx-aEqQ" base_Element="_qDhdIL2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqeB31EeaVEcfXx-aEqQ" base_Element="_8s_SoL2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqeR31EeaVEcfXx-aEqQ" base_Element="_8s_Sob2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqeh31EeaVEcfXx-aEqQ" base_Element="_nkyJ0L2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqex31EeaVEcfXx-aEqQ" base_Element="_651S8L2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqfB31EeaVEcfXx-aEqQ" base_Element="_65_D8L2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbRh31EeaVEcfXx-aEqQ" base_Element="_EILagL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbRx31EeaVEcfXx-aEqQ" base_Element="_i47c0WkaEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbSB31EeaVEcfXx-aEqQ" base_Element="_PwxOQL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbSR31EeaVEcfXx-aEqQ" base_Element="_Q6aW4L6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbSh31EeaVEcfXx-aEqQ" base_Element="_Sia2gL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbSx31EeaVEcfXx-aEqQ" base_Element="_i92HIL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbTB31EeaVEcfXx-aEqQ" base_Element="_mjS1wWkaEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbTR31EeaVEcfXx-aEqQ" base_Element="_o1nLwL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbTh31EeaVEcfXx-aEqQ" base_Element="_p_JmsL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbTx31EeaVEcfXx-aEqQ" base_Element="_q7QpoL6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbUB31EeaVEcfXx-aEqQ" base_Element="_se8C4L6PEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbUR31EeaVEcfXx-aEqQ" base_Element="_6efrYNnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbUh31EeaVEcfXx-aEqQ" base_Element="_6efrYdnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbUx31EeaVEcfXx-aEqQ" base_Element="_6efrYtnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbVB31EeaVEcfXx-aEqQ" base_Element="_6efrY9nVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbVR31EeaVEcfXx-aEqQ" base_Element="_6efrZNnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbVh31EeaVEcfXx-aEqQ" base_Element="_6efrZdnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbVx31EeaVEcfXx-aEqQ" base_Element="_6efrZtnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbWB31EeaVEcfXx-aEqQ" base_Element="_6efrZ9nVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbWR31EeaVEcfXx-aEqQ" base_Element="_6efraNnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbWh31EeaVEcfXx-aEqQ" base_Element="_6efradnVEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbWx31EeaVEcfXx-aEqQ" base_Element="_FRi-QNnWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbXB31EeaVEcfXx-aEqQ" base_Element="_FRi-QdnWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbXR31EeaVEcfXx-aEqQ" base_Element="_FRi-QtnWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbXh31EeaVEcfXx-aEqQ" base_Element="_FRi-Q9nWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbXx31EeaVEcfXx-aEqQ" base_Element="_FRi-RNnWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbYB31EeaVEcfXx-aEqQ" base_Element="_FRi-RdnWEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbYR31EeaVEcfXx-aEqQ" base_Element="_PvuhcNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbYh31EeaVEcfXx-aEqQ" base_Element="_PvuhcdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbYx31EeaVEcfXx-aEqQ" base_Element="_PvuhctnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbZB31EeaVEcfXx-aEqQ" base_Element="_Pvuhc9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbZR31EeaVEcfXx-aEqQ" base_Element="_PvuhdNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbZh31EeaVEcfXx-aEqQ" base_Element="_PvuhddnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbZx31EeaVEcfXx-aEqQ" base_Element="_PvuhdtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbaB31EeaVEcfXx-aEqQ" base_Element="_Pvuhd9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbaR31EeaVEcfXx-aEqQ" base_Element="_Ydx2sNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbah31EeaVEcfXx-aEqQ" base_Element="_Ydx2sdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbax31EeaVEcfXx-aEqQ" base_Element="_Ydx2stnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbbB31EeaVEcfXx-aEqQ" base_Element="_Ydx2s9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbbR31EeaVEcfXx-aEqQ" base_Element="_Ydx2tNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbbh31EeaVEcfXx-aEqQ" base_Element="_Ydx2tdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbbx31EeaVEcfXx-aEqQ" base_Element="_Ydx2ttnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbcB31EeaVEcfXx-aEqQ" base_Element="_Ydx2t9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbcR31EeaVEcfXx-aEqQ" base_Element="_Ydx2uNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbch31EeaVEcfXx-aEqQ" base_Element="_Ydx2udnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbcx31EeaVEcfXx-aEqQ" base_Element="_dLDeINnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbdB31EeaVEcfXx-aEqQ" base_Element="_dLDeIdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbdR31EeaVEcfXx-aEqQ" base_Element="_dLDeItnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbdh31EeaVEcfXx-aEqQ" base_Element="_dLDeI9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbdx31EeaVEcfXx-aEqQ" base_Element="_dLDeJNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbeB31EeaVEcfXx-aEqQ" base_Element="_dLDeJdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbeR31EeaVEcfXx-aEqQ" base_Element="_dLDeJtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbeh31EeaVEcfXx-aEqQ" base_Element="_dLDeJ9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbex31EeaVEcfXx-aEqQ" base_Element="_dLDeKNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbfB31EeaVEcfXx-aEqQ" base_Element="_dLDeKdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbfR31EeaVEcfXx-aEqQ" base_Element="_uINi0NnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbfh31EeaVEcfXx-aEqQ" base_Element="_uINi0dnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbfx31EeaVEcfXx-aEqQ" base_Element="_uINi0tnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbgB31EeaVEcfXx-aEqQ" base_Element="_uINi09njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbgR31EeaVEcfXx-aEqQ" base_Element="_uINi1NnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbgh31EeaVEcfXx-aEqQ" base_Element="_uINi1dnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbgx31EeaVEcfXx-aEqQ" base_Element="_zSpnYNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbhB31EeaVEcfXx-aEqQ" base_Element="_zSpnYdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbhR31EeaVEcfXx-aEqQ" base_Element="_zSpnYtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbhh31EeaVEcfXx-aEqQ" base_Element="_zSpnY9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbhx31EeaVEcfXx-aEqQ" base_Element="_zSpnZNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbiB31EeaVEcfXx-aEqQ" base_Element="_zSpnZdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbiR31EeaVEcfXx-aEqQ" base_Element="_2wdyENnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbih31EeaVEcfXx-aEqQ" base_Element="_2wdyEdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbix31EeaVEcfXx-aEqQ" base_Element="_2wdyEtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbjB31EeaVEcfXx-aEqQ" base_Element="_2wdyE9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbjR31EeaVEcfXx-aEqQ" base_Element="_2wdyFNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbjh31EeaVEcfXx-aEqQ" base_Element="_2wdyFdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbjx31EeaVEcfXx-aEqQ" base_Element="_2wdyFtnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbkB31EeaVEcfXx-aEqQ" base_Element="_2wdyF9njEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelMB31EeaVEcfXx-aEqQ" base_Element="_2wdyGNnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelMR31EeaVEcfXx-aEqQ" base_Element="_2wdyGdnjEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelMh31EeaVEcfXx-aEqQ" base_Element="_adPI0NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelMx31EeaVEcfXx-aEqQ" base_Element="_adPI0dnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelNB31EeaVEcfXx-aEqQ" base_Element="_adPI0tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelNR31EeaVEcfXx-aEqQ" base_Element="_adPI09nqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelNh31EeaVEcfXx-aEqQ" base_Element="_adPI1NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelNx31EeaVEcfXx-aEqQ" base_Element="_adPI1dnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelOB31EeaVEcfXx-aEqQ" base_Element="_adPI1tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelOR31EeaVEcfXx-aEqQ" base_Element="_adPI19nqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelOh31EeaVEcfXx-aEqQ" base_Element="_adPI2NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelOx31EeaVEcfXx-aEqQ" base_Element="_adPI2dnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelPB31EeaVEcfXx-aEqQ" base_Element="_adPI2tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelPR31EeaVEcfXx-aEqQ" base_Element="_adPI29nqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelPh31EeaVEcfXx-aEqQ" base_Element="_adPI3NnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwelPx31EeaVEcfXx-aEqQ" base_Element="_adPI3dnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWMB31EeaVEcfXx-aEqQ" base_Element="_adPI3tnqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWMR31EeaVEcfXx-aEqQ" base_Element="_adPI39nqEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWdB31EeaVEcfXx-aEqQ" base_Element="_pGsZEN5qEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWdR31EeaVEcfXx-aEqQ" base_Element="_u2nJQN5qEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWdh31EeaVEcfXx-aEqQ" base_Element="_v7ftsN5qEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWdx31EeaVEcfXx-aEqQ" base_Element="_ULsT4N5sEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWeB31EeaVEcfXx-aEqQ" base_Element="_VvXtIN5sEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWeR31EeaVEcfXx-aEqQ" base_Element="_4rVysN5qEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWeh31EeaVEcfXx-aEqQ" base_Element="_6iCS8O-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWex31EeaVEcfXx-aEqQ" base_Element="_6iCS8e-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWfB31EeaVEcfXx-aEqQ" base_Element="_l1ltgO-pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWfR31EeaVEcfXx-aEqQ" base_Element="_l1ltge-pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWfh31EeaVEcfXx-aEqQ" base_Element="_l1ltgu-pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWfx31EeaVEcfXx-aEqQ" base_Element="_l1ltg--pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RVB31EeaVEcfXx-aEqQ" base_Element="__gLXQBrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RVR31EeaVEcfXx-aEqQ" base_Element="__gLXRRrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ww7RVh31EeaVEcfXx-aEqQ" base_StructuralFeature="__gLXRRrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_EyzIwCNAEeaA8dOpokrEww" base_Association="__gLXQBrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqQB31EeaVEcfXx-aEqQ" base_Element="_j2GU0N78EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_j2GU1t78EeW-BtRsuJPbqg" base_Class="_j2GU0N78EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5VB31EeaVEcfXx-aEqQ" base_Element="_UhrZoN8qEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_UhrZst8qEeWT9tG0gGLRFw" base_Class="_UhrZoN8qEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqSB31EeaVEcfXx-aEqQ" base_Element="_TlA2gN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_TlA2hd79EeW-BtRsuJPbqg" base_Class="_TlA2gN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0dB31EeaVEcfXx-aEqQ" base_Element="_r01pEL6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_r01pJb6nEeWRz-VHgA3LJQ" base_Class="_r01pEL6nEeWRz-VHgA3LJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqdh31EeaVEcfXx-aEqQ" base_Element="_rBq8YO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_rBq8Yu-fEeWLlrwIF3w0vA" base_Class="_rBq8YO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqRR31EeaVEcfXx-aEqQ" base_Element="_oJg1UN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oJg1VN79EeW-BtRsuJPbqg" base_Class="_oJg1UN79EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5Qh31EeaVEcfXx-aEqQ" base_Element="_xEvjkN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_xGhsQN8AEeW-BtRsuJPbqg" base_Class="_xEvjkN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_XqB-EC5wEea0_JngOlSKcA" base_Element="_XqBXAC5wEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ZA31MS5wEea0_JngOlSKcA" base_Element="_ZA31MC5wEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aoZzsC5wEea0_JngOlSKcA" base_Element="_aoZMoC5wEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cDHeMC5wEea0_JngOlSKcA" base_Element="_cDG3IC5wEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Zf0hYC54Eea0_JngOlSKcA" base_Element="_Zfvo4C54Eea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_VZlVsC6BEea0_JngOlSKcA" base_Class="_VZkuoC6BEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VZl8wC6BEea0_JngOlSKcA" base_Element="_VZkuoC6BEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VZl8wS6BEea0_JngOlSKcA" base_Element="_VZkuoS6BEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VZl8wi6BEea0_JngOlSKcA" base_StructuralFeature="_VZkuoS6BEea0_JngOlSKcA" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VZmj0C6BEea0_JngOlSKcA" base_Element="_VZkuoi6BEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VZmj0S6BEea0_JngOlSKcA" base_Element="_VZkuoy6BEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__gLXRBrpEeaeisu1tQM3_Q" base_StructuralFeature="__gLXQxrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cKFNkTNtEea0Br-ajMxp_A" base_Element="_cKFNkDNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cKOXgTNtEea0Br-ajMxp_A" base_Element="_cKOXgDNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cKOXgjNtEea0Br-ajMxp_A" base_StructuralFeature="_cKOXgDNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cKOXhDNtEea0Br-ajMxp_A" base_Element="_cKOXgzNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cKOXhTNtEea0Br-ajMxp_A" base_StructuralFeature="_cKOXgzNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_m-o8UDNtEea0Br-ajMxp_A" base_Association="_cKFNkDNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_z89XcDNuEea0Br-ajMxp_A" base_StructuralFeature="_cKOXgDNtEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_1XSAYDNuEea0Br-ajMxp_A" base_StructuralFeature="__gLXQxrpEeaeisu1tQM3_Q"/>
+  <OpenModel_Profile:SpecReference xmi:id="_2v8ccDNuEea0Br-ajMxp_A" base_StructuralFeature="_VZkuoS6BEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yapTUTNyEea0Br-ajMxp_A" base_Element="_yapTUDNyEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yapTUzNyEea0Br-ajMxp_A" base_Element="_yapTUjNyEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2iUTUTNyEea0Br-ajMxp_A" base_Element="_2iUTUDNyEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2iUTUzNyEea0Br-ajMxp_A" base_Element="_2iUTUjNyEea0Br-ajMxp_A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_EGSwgTOFEeansfg7-s4Unw" base_StructuralFeature="_EGSwgDOFEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_EGSwgjOFEeansfg7-s4Unw" base_Element="_EGSwgDOFEeansfg7-s4Unw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_KcDYsDOFEeansfg7-s4Unw" base_StructuralFeature="_EGSwgDOFEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NdODoTOFEeansfg7-s4Unw" base_Element="_NdODoDOFEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NdODozOFEeansfg7-s4Unw" base_Element="_NdODojOFEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7HFlZEHHEeWqPKyD1j6LMg" base_StructuralFeature="_7HFlY0HHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_6le5oLoXEeWgnN4av0rtYw" base_Realization="_49C8MLoXEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LCDpMfEgEeWIT-EHROE-tg" base_StructuralFeature="_LCDpMPEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LIbaI_EkEeWIT-EHROE-tg" base_StructuralFeature="_LIbaIvEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gPX2VPEyEeWIT-EHROE-tg" base_StructuralFeature="_gPX2U_EyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GeUhVPTbEeWQB8HQFBfkJQ" base_StructuralFeature="_GeUhU_TbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuschh31EeaVEcfXx-aEqQ" base_Element="_sfccMeK0EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuschx31EeaVEcfXx-aEqQ" base_Element="_NqC_oO_iEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wusciB31EeaVEcfXx-aEqQ" base_Element="_LIbaIvEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wusciR31EeaVEcfXx-aEqQ" base_Element="_URpocPEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscih31EeaVEcfXx-aEqQ" base_Element="_URpocfEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscix31EeaVEcfXx-aEqQ" base_Element="_LCDpMPEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscjB31EeaVEcfXx-aEqQ" base_Element="_wuyz8PEjEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscjR31EeaVEcfXx-aEqQ" base_Element="_wuyz8fEjEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscjh31EeaVEcfXx-aEqQ" base_Element="_GeUhU_TbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscjx31EeaVEcfXx-aEqQ" base_Element="_Md-9sPTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wusckB31EeaVEcfXx-aEqQ" base_Element="_Md-9sfTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NgB31EeaVEcfXx-aEqQ" base_Element="_7HFlY0HHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NgR31EeaVEcfXx-aEqQ" base_Element="_FeLVAEHIEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Ngh31EeaVEcfXx-aEqQ" base_Element="_FeNKMEHIEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Ngx31EeaVEcfXx-aEqQ" base_Element="_gPX2U_EyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NhB31EeaVEcfXx-aEqQ" base_Element="_lzJn8PEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NhR31EeaVEcfXx-aEqQ" base_Element="_lzJn8fEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgWx31EeaVEcfXx-aEqQ" base_Element="_49C8MLoXEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MWFHRSz0EeaYO8M_h7XJ5A" base_Element="_MWFHRCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MWFHRiz0EeaYO8M_h7XJ5A" base_StructuralFeature="_MWFHRCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_mZtBMSz0EeaYO8M_h7XJ5A" base_Element="_mZtBMCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_mZtBMyz0EeaYO8M_h7XJ5A" base_Element="_mZtBMiz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2ZlApS0oEeah7qIgVNfKeA" base_StructuralFeature="_2ZlApC0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2ZlApi0oEeah7qIgVNfKeA" base_Element="_2ZlApC0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NsX8QS0qEeah7qIgVNfKeA" base_Element="_NsX8QC0qEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NsX8Qy0qEeah7qIgVNfKeA" base_Element="_NsX8Qi0qEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_sfccPOK0EeSq5fATALSQkQ" base_Class="_sfccMOK0EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_sfccQOK0EeSq5fATALSQkQ" base_Class="_sfccMOK0EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuschR31EeaVEcfXx-aEqQ" base_Element="_sfccMOK0EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_sfccQeK0EeSq5fATALSQkQ" base_Class="_sfccMOK0EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7HGMcUHHEeWqPKyD1j6LMg" base_StructuralFeature="_7HGMcEHHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LCDpM_EgEeWIT-EHROE-tg" base_StructuralFeature="_LCDpMvEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LIbaJfEkEeWIT-EHROE-tg" base_StructuralFeature="_LIbaJPEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gPX2VvEyEeWIT-EHROE-tg" base_StructuralFeature="_gPX2VfEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GeUhVvTbEeWQB8HQFBfkJQ" base_StructuralFeature="_GeUhVfTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWnR31EeaVEcfXx-aEqQ" base_Element="_7HFlYEHHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWnh31EeaVEcfXx-aEqQ" base_Element="_7HGMcEHHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWnx31EeaVEcfXx-aEqQ" base_Element="_2OgckKfzEeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWoB31EeaVEcfXx-aEqQ" base_Element="_2SbTQKfzEeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RMR31EeaVEcfXx-aEqQ" base_Element="_LIRpIPEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RMh31EeaVEcfXx-aEqQ" base_Element="_LIbaJPEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RMx31EeaVEcfXx-aEqQ" base_Element="_WiozoPEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RNB31EeaVEcfXx-aEqQ" base_Element="_WiozofEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RNR31EeaVEcfXx-aEqQ" base_Element="_LB6fQPEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RNh31EeaVEcfXx-aEqQ" base_Element="_LCDpMvEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RNx31EeaVEcfXx-aEqQ" base_Element="_xmTqwPEjEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7ROB31EeaVEcfXx-aEqQ" base_Element="_xmTqwfEjEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7ROR31EeaVEcfXx-aEqQ" base_Element="_gPX2UPEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7ROh31EeaVEcfXx-aEqQ" base_Element="_gPX2VfEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7ROx31EeaVEcfXx-aEqQ" base_Element="_mQnAAPEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RPB31EeaVEcfXx-aEqQ" base_Element="_mQnAAfEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RSR31EeaVEcfXx-aEqQ" base_Element="_GeUhUPTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RSh31EeaVEcfXx-aEqQ" base_Element="_GeUhVfTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RSx31EeaVEcfXx-aEqQ" base_Element="_OFGFcPTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RTB31EeaVEcfXx-aEqQ" base_Element="_OFGFcfTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MWFHQSz0EeaYO8M_h7XJ5A" base_Element="_MWFHQCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MWO4QSz0EeaYO8M_h7XJ5A" base_Element="_MWO4QCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MWO4Qiz0EeaYO8M_h7XJ5A" base_StructuralFeature="_MWO4QCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sEeLoSz0EeaYO8M_h7XJ5A" base_Element="_sEeLoCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sEeLoyz0EeaYO8M_h7XJ5A" base_Element="_sEeLoiz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2ZlAoS0oEeah7qIgVNfKeA" base_Element="_2ZlAoC0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2ZlAqC0oEeah7qIgVNfKeA" base_StructuralFeature="_2ZlApy0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2ZlAqS0oEeah7qIgVNfKeA" base_Element="_2ZlApy0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_tjWBYT3fEea-1_BGg-qcjQ" base_Element="_tjWBYD3fEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_tjWBYj3fEea-1_BGg-qcjQ" base_Class="_tjWBYD3fEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zC-54T3fEea-1_BGg-qcjQ" base_Element="_zC-54D3fEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_zC-54j3fEea-1_BGg-qcjQ" base_Class="_zC-54D3fEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Iq9H4T3gEea-1_BGg-qcjQ" base_Element="_Iq9H4D3gEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_JNBTIT3gEea-1_BGg-qcjQ" base_Element="_JNBTID3gEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_fTdecD3jEea-1_BGg-qcjQ" base_Association="_LIRpIPEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_g0qygD3jEea-1_BGg-qcjQ" base_Association="_7HFlYEHHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_iCNjsD3jEea-1_BGg-qcjQ" base_Association="_2ZlAoC0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_jdt4YD3jEea-1_BGg-qcjQ" base_Association="_LB6fQPEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_khRnID3jEea-1_BGg-qcjQ" base_Association="_gPX2UPEyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_ltpToD3jEea-1_BGg-qcjQ" base_Association="_GeUhUPTbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_mwVfsD3jEea-1_BGg-qcjQ" base_Association="_MWFHQCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_orqj8D3jEea-1_BGg-qcjQ" base_StructuralFeature="_LCDpMPEgEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_ppUfAD3jEea-1_BGg-qcjQ" base_StructuralFeature="_GeUhU_TbEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_qcyjUD3jEea-1_BGg-qcjQ" base_StructuralFeature="_gPX2U_EyEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_rQROsD3jEea-1_BGg-qcjQ" base_StructuralFeature="_MWFHRCz0EeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_sCQsUD3jEea-1_BGg-qcjQ" base_StructuralFeature="_LIbaIvEkEeWIT-EHROE-tg"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_s7uD4D3jEea-1_BGg-qcjQ" base_StructuralFeature="_7HFlY0HHEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_tuAccD3jEea-1_BGg-qcjQ" base_StructuralFeature="_2ZlApC0oEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_36HEET3jEea-1_BGg-qcjQ" base_Element="_36HEED3jEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_36HEEj3jEea-1_BGg-qcjQ" base_StructuralFeature="_36HEED3jEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:SpecReference xmi:id="_57aNcD3jEea-1_BGg-qcjQ" base_StructuralFeature="_36HEED3jEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WjwG4T3kEea-1_BGg-qcjQ" base_Element="_WjwG4D3kEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WjwG4j3kEea-1_BGg-qcjQ" base_StructuralFeature="_WjwG4D3kEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:SpecReference xmi:id="_X44t0D3kEea-1_BGg-qcjQ" base_StructuralFeature="_WjwG4D3kEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_L6VMIT4bEea-1_BGg-qcjQ" base_Element="_L6VMID4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_L6VMJT4bEea-1_BGg-qcjQ" base_Element="_L6VMJD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_L6VMJj4bEea-1_BGg-qcjQ" base_StructuralFeature="_L6VMJD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_L6VMKD4bEea-1_BGg-qcjQ" base_Element="_L6VMJz4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_L6VMKT4bEea-1_BGg-qcjQ" base_StructuralFeature="_L6VMJz4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MjPmQT4bEea-1_BGg-qcjQ" base_Element="_MjPmQD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MjPmRT4bEea-1_BGg-qcjQ" base_Element="_MjPmRD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MjPmRj4bEea-1_BGg-qcjQ" base_StructuralFeature="_MjPmRD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MjPmSD4bEea-1_BGg-qcjQ" base_Element="_MjPmRz4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MjPmST4bEea-1_BGg-qcjQ" base_StructuralFeature="_MjPmRz4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_urF1UT4bEea-1_BGg-qcjQ" base_Element="_urF1UD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_urF1Uz4bEea-1_BGg-qcjQ" base_Element="_urF1Uj4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yxyk8T4bEea-1_BGg-qcjQ" base_Element="_yxyk8D4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yxyk8z4bEea-1_BGg-qcjQ" base_Element="_yxyk8j4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_56jXYD4bEea-1_BGg-qcjQ" base_Association="_L6VMID4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_7HNXwD4bEea-1_BGg-qcjQ" base_Association="_MjPmQD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_Hi4OQD4cEea-1_BGg-qcjQ" base_StructuralFeature="_L6VMJD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_JLyFwD4cEea-1_BGg-qcjQ" base_StructuralFeature="_MjPmRD4bEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_4oopgUJuEea-2Meh9kw1kA" base_Element="_4oopgEJuEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4oopgkJuEea-2Meh9kw1kA" base_StructuralFeature="_4oopgEJuEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_-nYf4UJuEea-2Meh9kw1kA" base_Element="_-nYf4EJuEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-nYf4kJuEea-2Meh9kw1kA" base_StructuralFeature="_-nYf4EJuEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_gs3-gEJvEea-2Meh9kw1kA" base_StructuralFeature="_-nYf4EJuEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_q0H7UEJvEea-2Meh9kw1kA" base_StructuralFeature="_4oopgEJuEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_b5a4wUTvEead1bezhJG4aw" base_Element="_b5a4wETvEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b5a4xUTvEead1bezhJG4aw" base_StructuralFeature="_b5a4xETvEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_b5a4xkTvEead1bezhJG4aw" base_Element="_b5a4xETvEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_b5a4yETvEead1bezhJG4aw" base_StructuralFeature="_b5a4x0TvEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_b5a4yUTvEead1bezhJG4aw" base_Element="_b5a4x0TvEead1bezhJG4aw"/>
+  <OpenModel_Profile:DefinedBySpec xmi:id="_p7noMETvEead1bezhJG4aw" base_StructuralFeature="_b5a4xETvEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecifiedComposite xmi:id="_zQBnQET5Eead1bezhJG4aw" base_Association="_b5a4wETvEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9hsOkaU7EeWkWNPM1BHzGA" base_StructuralFeature="_9hsOkKU7EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_K97x8LocEeWgnN4av0rtYw" base_Realization="_32-2kLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aFAUNNnYEeWIOYiRCk5bbQ" base_StructuralFeature="_aFAUM9nYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aFAUNtnYEeWIOYiRCk5bbQ" base_StructuralFeature="_aFAUNdnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBO_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giA-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBu_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giBe_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIeB31EeaVEcfXx-aEqQ" base_Element="_It0sYUG-EeWMO5szP8dKiA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIeR31EeaVEcfXx-aEqQ" base_Element="_6frNwO_nEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIex31EeaVEcfXx-aEqQ" base_Element="_aFAUM9nYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIfB31EeaVEcfXx-aEqQ" base_Element="_c7QIkNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIfR31EeaVEcfXx-aEqQ" base_Element="_c7Z5kNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIhB31EeaVEcfXx-aEqQ" base_Element="_S3giA-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIhR31EeaVEcfXx-aEqQ" base_Element="_9hsOkKU7EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgWR31EeaVEcfXx-aEqQ" base_Element="_32-2kLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgZx31EeaVEcfXx-aEqQ" base_Element="_aFAUMNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgaB31EeaVEcfXx-aEqQ" base_Element="_aFAUNdnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RKR31EeaVEcfXx-aEqQ" base_Element="_S3giAO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RKh31EeaVEcfXx-aEqQ" base_Element="_S3giBe_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_2_jzcCzkEeaYO8M_h7XJ5A" base_Association="_S3giAO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIdx31EeaVEcfXx-aEqQ" base_Element="_It0sYEG-EeWMO5szP8dKiA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_It0sfkG-EeWMO5szP8dKiA" base_Class="_It0sYEG-EeWMO5szP8dKiA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_48dNwC6AEea0_JngOlSKcA" base_Association="_aFAUMNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qG8wckTZEead1bezhJG4aw" base_StructuralFeature="_qG8wcETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qG8wc0TZEead1bezhJG4aw" base_Element="_qG8wcETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qHPrYETZEead1bezhJG4aw" base_Element="_qG8wcUTZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wsEqUkTZEead1bezhJG4aw" base_StructuralFeature="_wsEqUETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wsEqU0TZEead1bezhJG4aw" base_Element="_wsEqUETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wsEqVETZEead1bezhJG4aw" base_Element="_wsEqUUTZEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_z53cAETZEead1bezhJG4aw" base_StructuralFeature="_qG8wcETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_1Vz1kETZEead1bezhJG4aw" base_StructuralFeature="_wsEqUETZEead1bezhJG4aw"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiConnectivity.uml
+++ b/xmi2yang tool-v2.0/project/TapiConnectivity.uml
@@ -1,0 +1,1010 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_6fxZsDA4Eea4fKwSGMr6CA" name="TapiConnectivity">
+    <packagedElement xmi:type="uml:Package" xmi:id="_UwxxoC5zEea0_JngOlSKcA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_TPT-AO_tEeWLlrwIF3w0vA" name="ConnEPHasStatePac" memberEnd="_TPT-A-_tEeWLlrwIF3w0vA _TPT-Be_tEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TPT-Ae_tEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TPT-Au_tEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_TPT-Be_tEeWLlrwIF3w0vA" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_TPT-AO_tEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nttnAGkFEeWZEqTYAF8eqA" name="ConnectionHasConnectionPorts" memberEnd="_nttnA2kFEeWZEqTYAF8eqA _nttnBWkFEeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nttnAWkFEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nttnAmkFEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nttnBWkFEeWZEqTYAF8eqA" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_nttnAGkFEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wVJW4GkFEeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wVJW4WkFEeWZEqTYAF8eqA" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ZiXD4EUcEeWEwNCluy4jrw" name="ConnectionHasRoutes" memberEnd="_ZiYSAEUcEeWEwNCluy4jrw _ZiZgIEUcEeWEwNCluy4jrw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZiXq8EUcEeWEwNCluy4jrw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ZiXq8UUcEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ZiZgIEUcEeWEwNCluy4jrw" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_ZiXD4EUcEeWEwNCluy4jrw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_B0rIkO_sEeWLlrwIF3w0vA" name="ConnectionHasStatePac" memberEnd="_B0rIk-_sEeWLlrwIF3w0vA _B00SgO_sEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B0rIke_sEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B0rIku_sEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_B00SgO_sEeWLlrwIF3w0vA" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_B0rIkO_sEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_hv9NsNnYEeWIOYiRCk5bbQ" name="ConnEPIncludesLP" memberEnd="_hv9Ns9nYEeWIOYiRCk5bbQ _hv9NtdnYEeWIOYiRCk5bbQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hv9NsdnYEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hv9NstnYEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_hv9NtdnYEeWIOYiRCk5bbQ" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_WFlH4O_qEeWLlrwIF3w0vA" name="ConnServiceHasConnConstraints" memberEnd="_WFu44u_qEeWLlrwIF3w0vA _WFu45O_qEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WFu44O_qEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WFu44e_qEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_WFu45O_qEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_oP678O_rEeWLlrwIF3w0vA" name="ConnServiceHasSchedule" memberEnd="_oP678-_rEeWLlrwIF3w0vA _oP679e_rEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oP678e_rEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oP678u_rEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_oP679e_rEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_oP678O_rEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_4Es8MGkIEeWZEqTYAF8eqA" name="ConnServiceHasServicePorts" memberEnd="_4Es8M2kIEeWZEqTYAF8eqA _4Es8NWkIEeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4Es8MWkIEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Es8MmkIEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_4Es8NWkIEeWZEqTYAF8eqA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_4Es8MGkIEeWZEqTYAF8eqA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nfDxoO_pEeWLlrwIF3w0vA" name="ConnServiceHasStatePac" memberEnd="_nfDxo-_pEeWLlrwIF3w0vA _nfDxpe_pEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nfDxoe_pEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nfDxou_pEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nfDxpe_pEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_nfDxoO_pEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_KpFD8L2YEeWdore3Cxez9g" name="CreatesUpdatesDeletesConnectivityService" client="_WHPN4FJvEeWcs7ZjyujtOg" supplier="_TQ0awC5zEea0_JngOlSKcA"/>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_-kp8kLolEeWadf5Yweab7g" name="Connection" client="_IZ3vcEHbEeWqPKyD1j6LMg">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGqmC1LNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_xKCWELobEeWgnN4av0rtYw" name="ConnectionEndPoint" client="_oC2ZEEG_EeWAMMFKXSVi-w">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_eEpDMFX4EeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_7JaaUBLxEeaKWshOutOQ8g" name="ConnectionHasConnectionPorts" client="_nttnAGkFEeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_gqbSgFYgEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_h-_t0J1UEeWJ0fWjnLbawA" name="ConnectionHasRoutes" client="_ZiXD4EUcEeWEwNCluy4jrw">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_A8YzcFYgEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_WU5eMJ1UEeWJ0fWjnLbawA" name="ConnectionIsContainedByNode">
+        <client xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+        <supplier xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_3joqgLodEeWgnN4av0rtYw" name="ConnectionPort" client="_sIutIGh-EeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_b_lUAFYgEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_8Td9ELolEeWadf5Yweab7g" name="ConnectivityService" client="_kuDzQEHaEeWqPKyD1j6LMg">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGqmC1LNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_2qy-ALodEeWgnN4av0rtYw" name="ConnectivityServicePort" client="_MIWTIGh5EeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_b_lUAFYgEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_FqiAYJ1ZEeWAQercC81WNA" name="ConnEPConnectsToPeerConnEP" client="_cfZ_cIbpEeWLkaOCu--9xg">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_CHToEFYYEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_tAq5QJ1ZEeWAQercC81WNA" name="ConnEPHasClientNodeEP" client="_Zb5MoH5NEeWWkJKpap4S3A">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_3ZB88FYWEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_7EmuEJ1ZEeWAQercC81WNA" name="ConnEPHasServerNodeEP">
+        <client xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_3ZB88FYWEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_mdngIJ1SEeWJ0fWjnLbawA" name="ConnPortTerminatesOnConnEP" client="_ijcPoGkHEeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_Ixb_8FYnEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_9P92MLpUEeWadf5Yweab7g" name="ConnServiceHasServicePorts" client="_4Es8MGkIEeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_gqbSgFYgEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="__fISQJ1REeWJ0fWjnLbawA" name="ConnServiceHasTopLevelConnections" client="_4ErWsEUcEeWEwNCluy4jrw">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_i7cIUFYfEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_hckBEJ1SEeWJ0fWjnLbawA" name="ConnServicePortTerminatesOnServiceEP" client="_YyfoEGkJEeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_Ixb_8FYnEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_7WX0gJ1OEeWJ0fWjnLbawA" name="Route" client="_kkzTEEUbEeWKAbXi7_SowQ">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_9UVusFYfEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_IngzEJ1SEeWJ0fWjnLbawA" name="RouteIsDescribedByLowerConnections">
+        <client xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_Cakh4FaSEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_niJd8GkKEeWZEqTYAF8eqA" name="ConnectionIsContainedByNode" memberEnd="_niJd82kKEeWZEqTYAF8eqA _niJd9WkKEeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_niJd8WkKEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_niJd8mkKEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_niJd82kKEeWZEqTYAF8eqA" name="_conectionRefList" type="_IZ3vcEHbEeWqPKyD1j6LMg" aggregation="shared" association="_niJd8GkKEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0hPKkGkKEeWZEqTYAF8eqA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0hPKkWkKEeWZEqTYAF8eqA" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_cfZ_cIbpEeWLkaOCu--9xg" name="ConnEPConnectsToPeerConnEP" memberEnd="_cfZ_c4bpEeWLkaOCu--9xg _cfjJYIbpEeWLkaOCu--9xg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cfZ_cYbpEeWLkaOCu--9xg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cfZ_cobpEeWLkaOCu--9xg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_cfjJYIbpEeWLkaOCu--9xg" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_cfZ_cIbpEeWLkaOCu--9xg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_Zb5MoH5NEeWWkJKpap4S3A" name="ConnEPHasClientNodeEPs" memberEnd="_Zb_6UH5NEeWWkJKpap4S3A _ZcC9oH5NEeWWkJKpap4S3A">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Zb_TQH5NEeWWkJKpap4S3A" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Zb_TQX5NEeWWkJKpap4S3A" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ZcC9oH5NEeWWkJKpap4S3A" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_Zb5MoH5NEeWWkJKpap4S3A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_B3JLoEHCEeWqPKyD1j6LMg" name="ConnEPHasServerNodeEP" memberEnd="_B3KZwUHCEeWqPKyD1j6LMg _B3Ln4EHCEeWqPKyD1j6LMg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B3JysEHCEeWqPKyD1j6LMg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B3KZwEHCEeWqPKyD1j6LMg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_B3KZwUHCEeWqPKyD1j6LMg" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" aggregation="shared" association="_B3JLoEHCEeWqPKyD1j6LMg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_T8JpMEHCEeWqPKyD1j6LMg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_T8LeYEHCEeWqPKyD1j6LMg" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ijcPoGkHEeWZEqTYAF8eqA" name="ConnPortTerminatesOnConnEP" memberEnd="_ijcPo2kHEeWZEqTYAF8eqA _ijcPpWkHEeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ijcPoWkHEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ijcPomkHEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ijcPpWkHEeWZEqTYAF8eqA" name="_connPort" type="_sIutIGh-EeWZEqTYAF8eqA" association="_ijcPoGkHEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IhU9EKRZEeW4kbhK1FSdyw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IirA4KRZEeW4kbhK1FSdyw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_4ErWsEUcEeWEwNCluy4jrw" name="ConnServiceHasTopLevelConnections" memberEnd="_4EtL4EUcEeWEwNCluy4jrw _4EuaAEUcEeWEwNCluy4jrw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4ErWsUUcEeWEwNCluy4jrw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Esk0EUcEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_4EuaAEUcEeWEwNCluy4jrw" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_4ErWsEUcEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZQn-MEUdEeWEwNCluy4jrw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZQqacEUdEeWEwNCluy4jrw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_YyfoEGkJEeWZEqTYAF8eqA" name="ConnServicePortTerminatesOnServiceEP" memberEnd="_YyoyAmkJEeWZEqTYAF8eqA _YyoyBGkJEeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_YyoyAGkJEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_YyoyAWkJEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_YyoyBGkJEeWZEqTYAF8eqA" name="_connServicePort" type="_MIWTIGh5EeWZEqTYAF8eqA" association="_YyfoEGkJEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ja2G0GkJEeWZEqTYAF8eqA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ja2G0WkJEeWZEqTYAF8eqA" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_p4w_sEUeEeWEwNCluy4jrw" name="RouteIsDescribedByLowerConnections" memberEnd="_p4y04EUeEeWEwNCluy4jrw _p40DAEUeEeWEwNCluy4jrw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_p4yN0EUeEeWEwNCluy4jrw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_p4yN0UUeEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_p4y04EUeEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" association="_p4w_sEUeEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_x40xEEUfEeWEwNCluy4jrw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x430YEUfEeWEwNCluy4jrw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_yUEvUDLEEeaULOmJRJKM0Q" name="ConnConstrHasExcludePath" memberEnd="_yUEvVDLEEeaULOmJRJKM0Q _yUOgUDLEEeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_yUEvUjLEEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_yUEvUzLEEeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_yUOgUDLEEeaULOmJRJKM0Q" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_yUEvUDLEEeaULOmJRJKM0Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_kUSasDLEEeaULOmJRJKM0Q" name="ConnConstrHasIncludePath" memberEnd="_kUbkojLEEeaULOmJRJKM0Q _kUbkpTLEEeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_kUbkoDLEEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_kUbkoTLEEeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_kUbkpTLEEeaULOmJRJKM0Q" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_kUSasDLEEeaULOmJRJKM0Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_c8MLwDLEEeaULOmJRJKM0Q" name="ConnConstrHasAvoidTopology" memberEnd="_c8MLxDLEEeaULOmJRJKM0Q _c8MLxzLEEeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_c8MLwjLEEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_c8MLwzLEEeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_c8MLxzLEEeaULOmJRJKM0Q" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_c8MLwDLEEeaULOmJRJKM0Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nxS_ADLCEeaULOmJRJKM0Q" name="ConnConstrHasIncludeTopology" memberEnd="_nxcI8jLCEeaULOmJRJKM0Q _nxl58DLCEeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nxcI8DLCEeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nxcI8TLCEeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nxl58DLCEeaULOmJRJKM0Q" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_nxS_ADLCEeaULOmJRJKM0Q"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TQ0awC5zEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_wt9DUEXOEeaB8vMnkFQLXQ" name="ConnConstrHasDiversityExc" memberEnd="_wt-RckXOEeaB8vMnkFQLXQ _wuAGoEXOEeaB8vMnkFQLXQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_wt-RcEXOEeaB8vMnkFQLXQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_wt-RcUXOEeaB8vMnkFQLXQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_wuAGoEXOEeaB8vMnkFQLXQ" name="_connectivityConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" association="_wt9DUEXOEeaB8vMnkFQLXQ"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_PfNxYC5zEea0_JngOlSKcA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="__-wDgDA7Eea4fKwSGMr6CA">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_WktNoDBFEeam35bpdXJzEw">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_QjobwC5zEea0_JngOlSKcA" name="Interfaces">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_WHPN4FJvEeWcs7ZjyujtOg" name="ConnectivityService" isLeaf="true">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN5VJvEeWcs7ZjyujtOg" name="getConnectionDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_7BwFULvMEeWYrqoqXLgguw" name="serviceIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN5lJvEeWcs7ZjyujtOg" name="connectionIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN51JvEeWcs7ZjyujtOg" name="connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN6FJvEeWcs7ZjyujtOg" name="getConnectivityServiceList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN6lJvEeWcs7ZjyujtOg" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WHPN61JvEeWcs7ZjyujtOg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WHPN7FJvEeWcs7ZjyujtOg" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN7VJvEeWcs7ZjyujtOg" name="getConnectionEndPointDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_uLSxAN6OEeWd9KDn6x5Skg" name="serviceIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_wH0IEN6OEeWd9KDn6x5Skg" name="connectionIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN7lJvEeWcs7ZjyujtOg" name="connEPIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN71JvEeWcs7ZjyujtOg" name="connEP" type="_oC2ZEEG_EeWAMMFKXSVi-w" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN8FJvEeWcs7ZjyujtOg" name="getServiceEndPointDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8VJvEeWcs7ZjyujtOg" name="serviceEPIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN8lJvEeWcs7ZjyujtOg" name="serviceEndPoint" direction="out" effect="read">
+            <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN81JvEeWcs7ZjyujtOg" name="getConnectivityServiceDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9FJvEeWcs7ZjyujtOg" name="serviceIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPN9VJvEeWcs7ZjyujtOg" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPOAFJvEeWcs7ZjyujtOg" name="getServiceEndPointList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_WHPOAlJvEeWcs7ZjyujtOg" name="serviceEndPoint" direction="out" effect="read">
+            <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WHPOA1JvEeWcs7ZjyujtOg"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WHPOBFJvEeWcs7ZjyujtOg" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_AnTcAKU5EeWkWNPM1BHzGA" name="createConnectivityService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_T9ChoKU5EeWkWNPM1BHzGA" name="servicePort" type="_MIWTIGh5EeWZEqTYAF8eqA" isUnique="false" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hoAc0KU5EeWkWNPM1BHzGA" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hoJmwKU5EeWkWNPM1BHzGA" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SK70ML2KEeWdore3Cxez9g" name="connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_xuBqsL2OEeWdore3Cxez9g" name="connSchedule" isUnique="false" effect="read">
+            <type xmi:type="uml:Class" href="Tapi.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_zEZcML2YEeWdore3Cxez9g" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_qH8fkL2NEeWdore3Cxez9g" name="updateConnectivityService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_JqtJcL2TEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YRJ1cL2TEeWdore3Cxez9g" name="connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qzgEYL2VEeWdore3Cxez9g" name="connSchedule" isUnique="false" effect="read">
+            <type xmi:type="uml:Class" href="Tapi.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_L70owL2ZEeWdore3Cxez9g" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="update"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_lQR28L2WEeWdore3Cxez9g" name="deleteConnectivityService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_zDaPoL2WEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Y9jZsL2ZEeWdore3Cxez9g" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" direction="out" effect="delete"/>
+        </ownedOperation>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_VsSXoC5zEea0_JngOlSKcA" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_IZ3vcEHbEeWqPKyD1j6LMg" name="Connection" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_IZ3vcUHbEeWqPKyD1j6LMg" annotatedElement="_IZ3vcEHbEeWqPKyD1j6LMg">
+          <body>The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.&#xD;
+&#xD;
+At the lowest level of recursion, a FC represents a cross-connection within an NE.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_ttEd8O_nEeWLlrwIF3w0vA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NmluUETZEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_NmluUUTZEead1bezhJG4aw" value="/TapiConnectivity:Connection"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UkkNEETZEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_UkkNEUTZEead1bezhJG4aw" value="/Tapi:Context/Tapi:_connection"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nttnA2kFEeWZEqTYAF8eqA" name="_connectionPort" type="_sIutIGh-EeWZEqTYAF8eqA" isReadOnly="true" aggregation="composite" association="_nttnAGkFEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sA_aEGkFEeWZEqTYAF8eqA" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sA_aEWkFEeWZEqTYAF8eqA" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" isReadOnly="true" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_obpMUEUcEeWEwNCluy4jrw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_obsPoEUcEeWEwNCluy4jrw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_niJd9WkKEeWZEqTYAF8eqA" name="_node" isReadOnly="true" association="_niJd8GkKEeWZEqTYAF8eqA">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Aoh_oN5TEeWHTPgMsm3CIw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Aokb4N5TEeWHTPgMsm3CIw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_B0rIk-_sEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_B0rIkO_sEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="Tapi.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IZ3vc0HbEeWqPKyD1j6LMg" name="layerProtocolName" visibility="public" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IZ3vdEHbEeWqPKyD1j6LMg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IZ3vdUHbEeWqPKyD1j6LMg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_V2I0INnlEeWIOYiRCk5bbQ" name="direction" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_oC2ZEEG_EeWAMMFKXSVi-w" name="ConnectionEndPoint" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_oC2ZEUG_EeWAMMFKXSVi-w" annotatedElement="_oC2ZEEG_EeWAMMFKXSVi-w">
+          <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
+The structure of LTP supports all transport protocols including circuit and packet forms.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_89GScO_nEeWLlrwIF3w0vA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_28FwsET2Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_28FwsUT2Eead1bezhJG4aw" value="/TapiConnectivity:ConnectionEndPoint"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7siA4ET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7siA4UT2Eead1bezhJG4aw" value=""/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_layerProtocol" isReadOnly="true" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">
+          <type xmi:type="uml:Class" href="Tapi.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ldi5wNnYEeWIOYiRCk5bbQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ldi5wdnYEeWIOYiRCk5bbQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Zb_6UH5NEeWWkJKpap4S3A" name="_clientNodeEdgePoint" isReadOnly="true" aggregation="shared" association="_Zb5MoH5NEeWWkJKpap4S3A">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XMYckH5XEeWWkJKpap4S3A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XNugYH5XEeWWkJKpap4S3A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_B3Ln4EHCEeWqPKyD1j6LMg" name="_serverNodeEdgePoint" isReadOnly="true" association="_B3JLoEHCEeWqPKyD1j6LMg">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WeYVYEHCEeWqPKyD1j6LMg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WeZjgEHCEeWqPKyD1j6LMg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cfZ_c4bpEeWLkaOCu--9xg" name="_peerConnectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" association="_cfZ_cIbpEeWLkaOCu--9xg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="Tapi.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_6a7R8KU7EeWkWNPM1BHzGA" name="direction" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_Ydx2sNnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_sIutIGh-EeWZEqTYAF8eqA" name="ConnectionPort" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sIutIWh-EeWZEqTYAF8eqA" annotatedElement="_sIutIGh-EeWZEqTYAF8eqA">
+          <body>The association of the FC to LTPs is made via EndPoints.&#xD;
+The EndPoint (EP) object class models the access to the FC function. &#xD;
+The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  &#xD;
+In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. &#xD;
+It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.&#xD;
+The EP replaces the Protection Unit of a traditional protection model. &#xD;
+The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_XaztcN8rEeWT9tG0gGLRFw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ijcPo2kHEeWZEqTYAF8eqA" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" isReadOnly="true" aggregation="composite" association="_ijcPoGkHEeWZEqTYAF8eqA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sIutJ2h-EeWZEqTYAF8eqA" name="role" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sIutKGh-EeWZEqTYAF8eqA" annotatedElement="_sIutJ2h-EeWZEqTYAF8eqA">
+            <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sIutKWh-EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sIutKmh-EeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sIutK2h-EeWZEqTYAF8eqA" name="direction" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sIutLGh-EeWZEqTYAF8eqA" annotatedElement="_sIutK2h-EeWZEqTYAF8eqA">
+            <body>The orientation of defined flow at the EndPoint.</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sIutLWh-EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sIutLmh-EeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
+        <generalization xmi:type="uml:Generalization" xmi:id="_r33L0D4zEea-1_BGg-qcjQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw" isReadOnly="true"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8GC6UL2BEeWdore3Cxez9g">
+            <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cE7T8L2REeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cE7T8b2REeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_SWwL11EeWdore3Cxez9g" name="serviceLayer" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p_hKEL2SEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p_q7EL2SEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-YtW8L11EeWdore3Cxez9g" name="requestedCapacity" isReadOnly="true">
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
+            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rhdgwr2HEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rhdgw72HEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GqeeMb2JEeWdore3Cxez9g" annotatedElement="_GqeeML2JEeWdore3Cxez9g">
+            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GqeeMr2JEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GqeeM72JEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_wt-RckXOEeaB8vMnkFQLXQ" name="_diversityExclusion" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_wt9DUEXOEeaB8vMnkFQLXQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Oi89IEXPEeaB8vMnkFQLXQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OjBOkEXPEeaB8vMnkFQLXQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nxcI8jLCEeaULOmJRJKM0Q" name="_includeTopology" isReadOnly="true" association="_nxS_ADLCEeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YQFpADLEEeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YQFpAjLEEeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_c8MLxDLEEeaULOmJRJKM0Q" name="_avoidTopology" isReadOnly="true" association="_c8MLwDLEEeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hUfowDLEEeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hUfowjLEEeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kUbkojLEEeaULOmJRJKM0Q" name="_includePath" isReadOnly="true" aggregation="composite" association="_kUSasDLEEeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_v3sMcDLEEeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_v3sMcjLEEeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yUEvVDLEEeaULOmJRJKM0Q" name="_excludePath" isReadOnly="true" aggregation="composite" association="_yUEvUDLEEeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4SnxYDLEEeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4SnxYjLEEeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_kuDzQEHaEeWqPKyD1j6LMg" name="ConnectivityService" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_kuDzQUHaEeWqPKyD1j6LMg" annotatedElement="_kuDzQEHaEeWqPKyD1j6LMg">
+          <body>The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.&#xD;
+&#xD;
+At the lowest level of recursion, a FC represents a cross-connection within an NE.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_ntHGoO_nEeWLlrwIF3w0vA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zPdpkETYEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_zPdpkUTYEead1bezhJG4aw" value="/TapiConnectivity:ConnectivityService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_36HEED3jEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7PT1AETYEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7PT1AUTYEead1bezhJG4aw" value="/Tapi:Context/Tapi:_connectivityService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_4oopgEJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4EtL4EUcEeWEwNCluy4jrw" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="composite" association="_4ErWsEUcEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YteN0EUdEeWEwNCluy4jrw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YtgqEEUdEeWEwNCluy4jrw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4Es8M2kIEeWZEqTYAF8eqA" name="_servicePort" type="_MIWTIGh5EeWZEqTYAF8eqA" aggregation="composite" association="_4Es8MGkIEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9mgX4GkIEeWZEqTYAF8eqA" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9mgX4WkIEeWZEqTYAF8eqA" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WFu44u_qEeWLlrwIF3w0vA" name="_connConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" aggregation="composite" association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oP678-_rEeWLlrwIF3w0vA" name="_schedule" aggregation="composite" association="_oP678O_rEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="Tapi.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nfDxo-_pEeWLlrwIF3w0vA" name="_state" aggregation="composite" association="_nfDxoO_pEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="Tapi.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_caIFkNnlEeWIOYiRCk5bbQ" name="direction">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kuDzQ0HaEeWqPKyD1j6LMg" name="layerProtocolName" visibility="public">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kuDzREHaEeWqPKyD1j6LMg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kuDzRUHaEeWqPKyD1j6LMg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_MIWTIGh5EeWZEqTYAF8eqA" name="ConnectivityServicePort" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTIWh5EeWZEqTYAF8eqA" annotatedElement="_MIWTIGh5EeWZEqTYAF8eqA">
+          <body>The association of the FC to LTPs is made via EndPoints.&#xD;
+The EndPoint (EP) object class models the access to the FC function. &#xD;
+The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  &#xD;
+In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. &#xD;
+It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.&#xD;
+The EP replaces the Protection Unit of a traditional protection model. &#xD;
+The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_Wx2QAN8rEeWT9tG0gGLRFw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YyoyAmkJEeWZEqTYAF8eqA" name="_serviceEndPoint" isReadOnly="true" association="_YyfoEGkJEeWZEqTYAF8eqA">
+          <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTJ2h5EeWZEqTYAF8eqA" name="role" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTKGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTJ2h5EeWZEqTYAF8eqA">
+            <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MIWTKWh5EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MIWTKmh5EeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MIWTK2h5EeWZEqTYAF8eqA" name="direction" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTLGh5EeWZEqTYAF8eqA" annotatedElement="_MIWTK2h5EeWZEqTYAF8eqA">
+            <body>The orientation of defined flow at the EndPoint.</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_MIWTLWh5EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_MIWTLmh5EeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GU9nEN6MEeWd9KDn6x5Skg" name="serviceLayer" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GU9nEd6MEeWd9KDn6x5Skg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GU9nEt6MEeWd9KDn6x5Skg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Route" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_kkzTEUUbEeWKAbXi7_SowQ" annotatedElement="_kkzTEEUbEeWKAbXi7_SowQ">
+          <body>The FC Route (FcRoute) object class models the individual routes of an FC. &#xD;
+The route of an FC object is represented by a list of FCs at a lower level. &#xD;
+Note that depending on the service supported by an FC, an the FC can have multiple routes.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_HOnysN8rEeWT9tG0gGLRFw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_p40DAEUeEeWEwNCluy4jrw" name="_lowerConnection" type="_IZ3vcEHbEeWqPKyD1j6LMg" isReadOnly="true" aggregation="composite" association="_p4w_sEUeEeWEwNCluy4jrw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tAZCgEUfEeWEwNCluy4jrw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tAd7AEUfEeWEwNCluy4jrw" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="__4jwIC5zEea0_JngOlSKcA" name="Rules">
+      <ownedRule xmi:type="uml:Constraint" xmi:id="_CIxSkLrhEeWYrqoqXLgguw" name="XOR: ConnectionContainment" constrainedElement="_4ErWsEUcEeWEwNCluy4jrw _p4w_sEUeEeWEwNCluy4jrw">
+        <specification xmi:type="uml:LiteralString" xmi:id="_nOJNQLriEeWYrqoqXLgguw" name="XOR: ConnectionContainment" value="ServiceComponent ⊕ RouteComponent"/>
+      </ownedRule>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_W1hQkC5zEea0_JngOlSKcA" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_0-X6sLvZEeWYrqoqXLgguw" name="ServiceType" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1OME8L1xEeWdore3Cxez9g" name="POINT_TO_POINT_CONNECTIVITY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4mNJoL1xEeWdore3Cxez9g" name="POINT_TO_MULTIPOINT_CONNECTIVTY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8UPhoL1xEeWdore3Cxez9g" name="MULTIPOINT_CONNECTIVITY"/>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_63RUNDA4Eea4fKwSGMr6CA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_A_VxMDOGEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_A_VxMTOGEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_A_VxMjOGEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_A_VxMzOGEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_A_VxNDOGEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_A_VxNTOGEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_63RUNTA4Eea4fKwSGMr6CA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_64UdqzA4Eea4fKwSGMr6CA" base_Element="_6fxZsDA4Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_64UdrDA4Eea4fKwSGMr6CA" base_Element="_63RUNDA4Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_B3KZwkHCEeWqPKyD1j6LMg" base_StructuralFeature="_B3KZwUHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_B3Ln4UHCEeWqPKyD1j6LMg" base_StructuralFeature="_B3Ln4EHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kuEaUEHaEeWqPKyD1j6LMg" base_StructuralFeature="_kuDzQ0HaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IZ49kEHbEeWqPKyD1j6LMg" base_StructuralFeature="_IZ3vc0HbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZiYSAUUcEeWEwNCluy4jrw" base_StructuralFeature="_ZiYSAEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZiZgIUUcEeWEwNCluy4jrw" base_StructuralFeature="_ZiZgIEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4EtL4UUcEeWEwNCluy4jrw" base_StructuralFeature="_4EtL4EUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4EuaAUUcEeWEwNCluy4jrw" base_StructuralFeature="_4EuaAEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_p4y04UUeEeWEwNCluy4jrw" base_StructuralFeature="_p4y04EUeEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_p40qEEUeEeWEwNCluy4jrw" base_StructuralFeature="_p40DAEUeEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelInterface xmi:id="_WKk1wFJvEeWcs7ZjyujtOg" base_Interface="_WHPN4FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1xVJvEeWcs7ZjyujtOg" base_Parameter="_WHPN5lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1xlJvEeWcs7ZjyujtOg" base_Parameter="_WHPN51JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1yVJvEeWcs7ZjyujtOg" base_Parameter="_WHPN6lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1y1JvEeWcs7ZjyujtOg" base_Parameter="_WHPN7lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1zFJvEeWcs7ZjyujtOg" base_Parameter="_WHPN71JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1zlJvEeWcs7ZjyujtOg" base_Parameter="_WHPN8VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk1z1JvEeWcs7ZjyujtOg" base_Parameter="_WHPN8lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk10VJvEeWcs7ZjyujtOg" base_Parameter="_WHPN9FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKk10lJvEeWcs7ZjyujtOg" base_Parameter="_WHPN9VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_WKq8YlJvEeWcs7ZjyujtOg" base_Parameter="_WHPOAlJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MIWTMWh5EeWZEqTYAF8eqA" base_StructuralFeature="_MIWTJ2h5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MIWTMmh5EeWZEqTYAF8eqA" base_StructuralFeature="_MIWTK2h5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sKhc4mh-EeWZEqTYAF8eqA" base_StructuralFeature="_sIutJ2h-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sKhc42h-EeWZEqTYAF8eqA" base_StructuralFeature="_sIutK2h-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nttnBGkFEeWZEqTYAF8eqA" base_StructuralFeature="_nttnA2kFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ijcPpGkHEeWZEqTYAF8eqA" base_StructuralFeature="_ijcPo2kHEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ijcPpmkHEeWZEqTYAF8eqA" base_StructuralFeature="_ijcPpWkHEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4Es8NGkIEeWZEqTYAF8eqA" base_StructuralFeature="_4Es8M2kIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4Es8NmkIEeWZEqTYAF8eqA" base_StructuralFeature="_4Es8NWkIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YyoyA2kJEeWZEqTYAF8eqA" base_StructuralFeature="_YyoyAmkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YyoyBWkJEeWZEqTYAF8eqA" base_StructuralFeature="_YyoyBGkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_niJd9GkKEeWZEqTYAF8eqA" base_StructuralFeature="_niJd82kKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_niJd9mkKEeWZEqTYAF8eqA" base_StructuralFeature="_niJd9WkKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZcAhYH5NEeWWkJKpap4S3A" base_StructuralFeature="_Zb_6UH5NEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ZcC9oX5NEeWWkJKpap4S3A" base_StructuralFeature="_ZcC9oH5NEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cfZ_dIbpEeWLkaOCu--9xg" base_StructuralFeature="_cfZ_c4bpEeWLkaOCu--9xg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cfjJYYbpEeWLkaOCu--9xg" base_StructuralFeature="_cfjJYIbpEeWLkaOCu--9xg"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_4uSigJ1PEeWJ0fWjnLbawA" base_Realization="_7WX0gJ1OEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_AwNfoJ1SEeWJ0fWjnLbawA" base_Realization="__fISQJ1REeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_O33W0J1SEeWJ0fWjnLbawA" base_Realization="_IngzEJ1SEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_pONYcJ1SEeWJ0fWjnLbawA" base_Realization="_mdngIJ1SEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_rR35UJ1SEeWJ0fWjnLbawA" base_Realization="_hckBEJ1SEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_cS8J8J1UEeWJ0fWjnLbawA" base_Realization="_WU5eMJ1UEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_jzVZQJ1UEeWJ0fWjnLbawA" base_Realization="_h-_t0J1UEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_lwpoQJ1ZEeWAQercC81WNA" base_Realization="_FqiAYJ1ZEeWAQercC81WNA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_5QQbkJ1ZEeWAQercC81WNA" base_Realization="_tAq5QJ1ZEeWAQercC81WNA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_-7Q2kJ1ZEeWAQercC81WNA" base_Realization="_7EmuEJ1ZEeWAQercC81WNA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_89uDEKH_EeWqgMj1FXPlrA" base_StructuralFeature="_Zb_6UH5NEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_-uVsIKH_EeWqgMj1FXPlrA" base_StructuralFeature="_B3Ln4EHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_ARbPgKIAEeWqgMj1FXPlrA" base_StructuralFeature="_cfZ_c4bpEeWLkaOCu--9xg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_W7PVAKIAEeWqgMj1FXPlrA" base_StructuralFeature="_niJd9WkKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_T9ChoaU5EeWkWNPM1BHzGA" base_Parameter="_T9ChoKU5EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_6a7R8aU7EeWkWNPM1BHzGA" base_StructuralFeature="_6a7R8KU7EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_1u950LobEeWgnN4av0rtYw" base_Realization="_xKCWELobEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_4dzMsLodEeWgnN4av0rtYw" base_Realization="_3joqgLodEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="__BN2YLodEeWgnN4av0rtYw" base_Realization="_2qy-ALodEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_9hkH4LolEeWadf5Yweab7g" base_Realization="_8Td9ELolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_Kx8_4LomEeWadf5Yweab7g" base_Realization="_-kp8kLolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="__zos0LpUEeWadf5Yweab7g" base_Realization="_9P92MLpUEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_7BwFUbvMEeWYrqoqXLgguw" base_Parameter="_7BwFULvMEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_7WdUkLvNEeWYrqoqXLgguw" base_StructuralFeature="_YyoyAmkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mO0PoLvREeWYrqoqXLgguw" base_StructuralFeature="_p40DAEUeEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lY2XUbvZEeWYrqoqXLgguw" base_StructuralFeature="_lY2XULvZEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3_SWwb11EeWdore3Cxez9g" base_StructuralFeature="_3_SWwL11EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-YtW8b11EeWdore3Cxez9g" base_StructuralFeature="_-YtW8L11EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3bhE4b2BEeWdore3Cxez9g" base_StructuralFeature="_3bhE4L2BEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RhdgxL2HEeWdore3Cxez9g" base_StructuralFeature="_RhdgwL2HEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GqeeNL2JEeWdore3Cxez9g" base_StructuralFeature="_GqeeML2JEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_SK70Mb2KEeWdore3Cxez9g" base_Parameter="_SK70ML2KEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_xuBqsb2OEeWdore3Cxez9g" base_Parameter="_xuBqsL2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_JqtJcb2TEeWdore3Cxez9g" base_Parameter="_JqtJcL2TEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_YRJ1cb2TEeWdore3Cxez9g" base_Parameter="_YRJ1cL2TEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_qzgEYb2VEeWdore3Cxez9g" base_Parameter="_qzgEYL2VEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_zDaPob2WEeWdore3Cxez9g" base_Parameter="_zDaPoL2WEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_zEZcMb2YEeWdore3Cxez9g" base_Parameter="_zEZcML2YEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_L70owb2ZEeWdore3Cxez9g" base_Parameter="_L70owL2ZEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Y9jZsb2ZEeWdore3Cxez9g" base_Parameter="_Y9jZsL2ZEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hv9NtNnYEeWIOYiRCk5bbQ" base_StructuralFeature="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_hv9NttnYEeWIOYiRCk5bbQ" base_StructuralFeature="_hv9NtdnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_V2I0IdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_V2I0INnlEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_caIFkdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_caIFkNnlEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GU9nE96MEeWd9KDn6x5Skg" base_StructuralFeature="_GU9nEN6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_uLSxAd6OEeWd9KDn6x5Skg" base_Parameter="_uLSxAN6OEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_wH0IEd6OEeWd9KDn6x5Skg" base_Parameter="_wH0IEN6OEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpO_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxo-_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpu_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxpe_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WFu44-_qEeWLlrwIF3w0vA" base_StructuralFeature="_WFu44u_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WFu45e_qEeWLlrwIF3w0vA" base_StructuralFeature="_WFu45O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oP679O_rEeWLlrwIF3w0vA" base_StructuralFeature="_oP678-_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oP679u_rEeWLlrwIF3w0vA" base_StructuralFeature="_oP679e_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_B0rIlO_sEeWLlrwIF3w0vA" base_StructuralFeature="_B0rIk-_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_B00Sge_sEeWLlrwIF3w0vA" base_StructuralFeature="_B00SgO_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TPT-BO_tEeWLlrwIF3w0vA" base_StructuralFeature="_TPT-A-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TPT-Bu_tEeWLlrwIF3w0vA" base_StructuralFeature="_TPT-Be_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_M8RX8BLyEeaKWshOutOQ8g" base_Realization="_7JaaUBLxEeaKWshOutOQ8g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIhx31EeaVEcfXx-aEqQ" base_Element="_oC2ZEUG_EeWAMMFKXSVi-w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIiB31EeaVEcfXx-aEqQ" base_Element="_89GScO_nEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIih31EeaVEcfXx-aEqQ" base_Element="_hv9Ns9nYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSYB31EeaVEcfXx-aEqQ" base_Element="_ldi5wNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSYR31EeaVEcfXx-aEqQ" base_Element="_ldi5wdnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSYh31EeaVEcfXx-aEqQ" base_Element="_Zb_6UH5NEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSYx31EeaVEcfXx-aEqQ" base_Element="_XMYckH5XEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSZB31EeaVEcfXx-aEqQ" base_Element="_XNugYH5XEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSZR31EeaVEcfXx-aEqQ" base_Element="_B3Ln4EHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSZh31EeaVEcfXx-aEqQ" base_Element="_WeYVYEHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSZx31EeaVEcfXx-aEqQ" base_Element="_WeZjgEHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSaB31EeaVEcfXx-aEqQ" base_Element="_cfZ_c4bpEeWLkaOCu--9xg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSaR31EeaVEcfXx-aEqQ" base_Element="_TPT-A-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSah31EeaVEcfXx-aEqQ" base_Element="_6a7R8KU7EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSbB31EeaVEcfXx-aEqQ" base_Element="_kuDzQUHaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSbR31EeaVEcfXx-aEqQ" base_Element="_ntHGoO_nEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSbh31EeaVEcfXx-aEqQ" base_Element="_4EtL4EUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSbx31EeaVEcfXx-aEqQ" base_Element="_YteN0EUdEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSScB31EeaVEcfXx-aEqQ" base_Element="_YtgqEEUdEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSScR31EeaVEcfXx-aEqQ" base_Element="_4Es8M2kIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSch31EeaVEcfXx-aEqQ" base_Element="_9mgX4GkIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSScx31EeaVEcfXx-aEqQ" base_Element="_9mgX4WkIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSdB31EeaVEcfXx-aEqQ" base_Element="_WFu44u_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSdR31EeaVEcfXx-aEqQ" base_Element="_oP678-_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSdh31EeaVEcfXx-aEqQ" base_Element="_nfDxo-_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSdx31EeaVEcfXx-aEqQ" base_Element="_kuDzQ0HaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSeB31EeaVEcfXx-aEqQ" base_Element="_kuDzREHaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSeR31EeaVEcfXx-aEqQ" base_Element="_kuDzRUHaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSeh31EeaVEcfXx-aEqQ" base_Element="_caIFkNnlEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSfB31EeaVEcfXx-aEqQ" base_Element="_IZ3vcUHbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSfR31EeaVEcfXx-aEqQ" base_Element="_ttEd8O_nEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSfh31EeaVEcfXx-aEqQ" base_Element="_nttnA2kFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSfx31EeaVEcfXx-aEqQ" base_Element="_sA_aEGkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSgB31EeaVEcfXx-aEqQ" base_Element="_sA_aEWkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSgR31EeaVEcfXx-aEqQ" base_Element="_ZiYSAEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSgh31EeaVEcfXx-aEqQ" base_Element="_obpMUEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSgx31EeaVEcfXx-aEqQ" base_Element="_obsPoEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSShB31EeaVEcfXx-aEqQ" base_Element="_niJd9WkKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSShR31EeaVEcfXx-aEqQ" base_Element="_Aoh_oN5TEeWHTPgMsm3CIw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSShh31EeaVEcfXx-aEqQ" base_Element="_Aokb4N5TEeWHTPgMsm3CIw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSShx31EeaVEcfXx-aEqQ" base_Element="_B0rIk-_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSiB31EeaVEcfXx-aEqQ" base_Element="_IZ3vc0HbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSiR31EeaVEcfXx-aEqQ" base_Element="_IZ3vdEHbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSih31EeaVEcfXx-aEqQ" base_Element="_IZ3vdUHbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSix31EeaVEcfXx-aEqQ" base_Element="_V2I0INnlEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSjR31EeaVEcfXx-aEqQ" base_Element="_kkzTEUUbEeWKAbXi7_SowQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSjh31EeaVEcfXx-aEqQ" base_Element="_HOnysN8rEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDYB31EeaVEcfXx-aEqQ" base_Element="_p40DAEUeEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDYR31EeaVEcfXx-aEqQ" base_Element="_tAZCgEUfEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDYh31EeaVEcfXx-aEqQ" base_Element="_tAd7AEUfEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDch31EeaVEcfXx-aEqQ" base_Element="_MIWTIWh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDcx31EeaVEcfXx-aEqQ" base_Element="_Wx2QAN8rEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDdB31EeaVEcfXx-aEqQ" base_Element="_YyoyAmkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDdR31EeaVEcfXx-aEqQ" base_Element="_MIWTJ2h5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDdh31EeaVEcfXx-aEqQ" base_Element="_MIWTKGh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDdx31EeaVEcfXx-aEqQ" base_Element="_MIWTKWh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0YB31EeaVEcfXx-aEqQ" base_Element="_MIWTKmh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0YR31EeaVEcfXx-aEqQ" base_Element="_MIWTK2h5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0Yh31EeaVEcfXx-aEqQ" base_Element="_MIWTLGh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0Yx31EeaVEcfXx-aEqQ" base_Element="_MIWTLWh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ZB31EeaVEcfXx-aEqQ" base_Element="_MIWTLmh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ZR31EeaVEcfXx-aEqQ" base_Element="_GU9nEN6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0Zh31EeaVEcfXx-aEqQ" base_Element="_GU9nEd6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0Zx31EeaVEcfXx-aEqQ" base_Element="_GU9nEt6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0aR31EeaVEcfXx-aEqQ" base_Element="_sIutIWh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ah31EeaVEcfXx-aEqQ" base_Element="_XaztcN8rEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ax31EeaVEcfXx-aEqQ" base_Element="_ijcPo2kHEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0bB31EeaVEcfXx-aEqQ" base_Element="_sIutJ2h-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0bR31EeaVEcfXx-aEqQ" base_Element="_sIutKGh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0bh31EeaVEcfXx-aEqQ" base_Element="_sIutKWh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0bx31EeaVEcfXx-aEqQ" base_Element="_sIutKmh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0cB31EeaVEcfXx-aEqQ" base_Element="_sIutK2h-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0cR31EeaVEcfXx-aEqQ" base_Element="_sIutLGh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ch31EeaVEcfXx-aEqQ" base_Element="_sIutLWh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0cx31EeaVEcfXx-aEqQ" base_Element="_sIutLmh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqTR31EeaVEcfXx-aEqQ" base_Element="_lY2XULvZEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqTh31EeaVEcfXx-aEqQ" base_Element="_3bhE4L2BEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqTx31EeaVEcfXx-aEqQ" base_Element="_8GC6UL2BEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqUB31EeaVEcfXx-aEqQ" base_Element="_cE7T8L2REeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqUR31EeaVEcfXx-aEqQ" base_Element="_cE7T8b2REeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqUh31EeaVEcfXx-aEqQ" base_Element="_3_SWwL11EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqUx31EeaVEcfXx-aEqQ" base_Element="_p_hKEL2SEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqVB31EeaVEcfXx-aEqQ" base_Element="_p_q7EL2SEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqVR31EeaVEcfXx-aEqQ" base_Element="_-YtW8L11EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqVh31EeaVEcfXx-aEqQ" base_Element="_RhdgwL2HEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqVx31EeaVEcfXx-aEqQ" base_Element="_Rhdgwb2HEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqWB31EeaVEcfXx-aEqQ" base_Element="_Rhdgwr2HEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqWR31EeaVEcfXx-aEqQ" base_Element="_Rhdgw72HEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqXh31EeaVEcfXx-aEqQ" base_Element="_GqeeML2JEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqXx31EeaVEcfXx-aEqQ" base_Element="_GqeeMb2JEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqYB31EeaVEcfXx-aEqQ" base_Element="_GqeeMr2JEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqYR31EeaVEcfXx-aEqQ" base_Element="_GqeeM72JEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqtB31EeaVEcfXx-aEqQ" base_Element="_0-X6sLvZEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqtR31EeaVEcfXx-aEqQ" base_Element="_1OME8L1xEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqth31EeaVEcfXx-aEqQ" base_Element="_4mNJoL1xEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqtx31EeaVEcfXx-aEqQ" base_Element="_8UPhoL1xEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWmR31EeaVEcfXx-aEqQ" base_Element="_B3JLoEHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWmh31EeaVEcfXx-aEqQ" base_Element="_B3KZwUHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWmx31EeaVEcfXx-aEqQ" base_Element="_T8JpMEHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWnB31EeaVEcfXx-aEqQ" base_Element="_T8LeYEHCEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWoh31EeaVEcfXx-aEqQ" base_Element="_ZiZgIEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWox31EeaVEcfXx-aEqQ" base_Element="_p4w_sEUeEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWpB31EeaVEcfXx-aEqQ" base_Element="_p4y04EUeEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWpR31EeaVEcfXx-aEqQ" base_Element="_x40xEEUfEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWph31EeaVEcfXx-aEqQ" base_Element="_x430YEUfEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWpx31EeaVEcfXx-aEqQ" base_Element="_4ErWsEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWqB31EeaVEcfXx-aEqQ" base_Element="_4EuaAEUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWqR31EeaVEcfXx-aEqQ" base_Element="_ZQn-MEUdEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWqh31EeaVEcfXx-aEqQ" base_Element="_ZQqacEUdEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWsx31EeaVEcfXx-aEqQ" base_Element="_wVJW4GkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgIR31EeaVEcfXx-aEqQ" base_Element="_niJd8GkKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgIh31EeaVEcfXx-aEqQ" base_Element="_niJd82kKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgIx31EeaVEcfXx-aEqQ" base_Element="_0hPKkGkKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgJB31EeaVEcfXx-aEqQ" base_Element="_0hPKkWkKEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgJR31EeaVEcfXx-aEqQ" base_Element="_ijcPoGkHEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgJh31EeaVEcfXx-aEqQ" base_Element="_ijcPpWkHEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgJx31EeaVEcfXx-aEqQ" base_Element="_IhU9EKRZEeW4kbhK1FSdyw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgKB31EeaVEcfXx-aEqQ" base_Element="_IirA4KRZEeW4kbhK1FSdyw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgKR31EeaVEcfXx-aEqQ" base_Element="_YyfoEGkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgKh31EeaVEcfXx-aEqQ" base_Element="_YyoyBGkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgKx31EeaVEcfXx-aEqQ" base_Element="_ja2G0GkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgLB31EeaVEcfXx-aEqQ" base_Element="_ja2G0WkJEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgLh31EeaVEcfXx-aEqQ" base_Element="_4Es8NWkIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgLx31EeaVEcfXx-aEqQ" base_Element="_Zb5MoH5NEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgMB31EeaVEcfXx-aEqQ" base_Element="_ZcC9oH5NEeWWkJKpap4S3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgOx31EeaVEcfXx-aEqQ" base_Element="_cfZ_cIbpEeWLkaOCu--9xg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgPB31EeaVEcfXx-aEqQ" base_Element="_cfjJYIbpEeWLkaOCu--9xg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgPR31EeaVEcfXx-aEqQ" base_Element="_7WX0gJ1OEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgQB31EeaVEcfXx-aEqQ" base_Element="__fISQJ1REeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgQR31EeaVEcfXx-aEqQ" base_Element="_IngzEJ1SEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgQh31EeaVEcfXx-aEqQ" base_Element="_hckBEJ1SEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgQx31EeaVEcfXx-aEqQ" base_Element="_mdngIJ1SEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgRB31EeaVEcfXx-aEqQ" base_Element="_WU5eMJ1UEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgRR31EeaVEcfXx-aEqQ" base_Element="_h-_t0J1UEeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgRh31EeaVEcfXx-aEqQ" base_Element="_FqiAYJ1ZEeWAQercC81WNA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgRx31EeaVEcfXx-aEqQ" base_Element="_tAq5QJ1ZEeWAQercC81WNA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgSB31EeaVEcfXx-aEqQ" base_Element="_7EmuEJ1ZEeWAQercC81WNA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgUB31EeaVEcfXx-aEqQ" base_Element="_2qy-ALodEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgUR31EeaVEcfXx-aEqQ" base_Element="_3joqgLodEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgUh31EeaVEcfXx-aEqQ" base_Element="_8Td9ELolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgUx31EeaVEcfXx-aEqQ" base_Element="_-kp8kLolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgWh31EeaVEcfXx-aEqQ" base_Element="_xKCWELobEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgYR31EeaVEcfXx-aEqQ" base_Element="_9P92MLpUEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgYh31EeaVEcfXx-aEqQ" base_Element="_KpFD8L2YEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgYx31EeaVEcfXx-aEqQ" base_Element="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgZB31EeaVEcfXx-aEqQ" base_Element="_hv9NtdnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxglB31EeaVEcfXx-aEqQ" base_Element="_B00SgO_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxglR31EeaVEcfXx-aEqQ" base_Element="_TPT-AO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RIB31EeaVEcfXx-aEqQ" base_Element="_TPT-Be_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RIh31EeaVEcfXx-aEqQ" base_Element="_WFu45O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RJB31EeaVEcfXx-aEqQ" base_Element="_oP679e_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RJh31EeaVEcfXx-aEqQ" base_Element="_nfDxpe_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RUx31EeaVEcfXx-aEqQ" base_Element="_7JaaUBLxEeaKWshOutOQ8g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rdx31EeaVEcfXx-aEqQ" base_Element="_WHPN4FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7ReR31EeaVEcfXx-aEqQ" base_Element="_7BwFULvMEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Reh31EeaVEcfXx-aEqQ" base_Element="_WHPN5lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rex31EeaVEcfXx-aEqQ" base_Element="_WHPN51JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RfR31EeaVEcfXx-aEqQ" base_Element="_WHPN6lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rfh31EeaVEcfXx-aEqQ" base_Element="_WHPN61JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rfx31EeaVEcfXx-aEqQ" base_Element="_WHPN7FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RgR31EeaVEcfXx-aEqQ" base_Element="_uLSxAN6OEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rgh31EeaVEcfXx-aEqQ" base_Element="_wH0IEN6OEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rgx31EeaVEcfXx-aEqQ" base_Element="_WHPN7lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RhB31EeaVEcfXx-aEqQ" base_Element="_WHPN71JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rhh31EeaVEcfXx-aEqQ" base_Element="_WHPN8VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rhx31EeaVEcfXx-aEqQ" base_Element="_WHPN8lJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RiR31EeaVEcfXx-aEqQ" base_Element="_WHPN9FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rih31EeaVEcfXx-aEqQ" base_Element="_WHPN9VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RjB31EeaVEcfXx-aEqQ" base_Element="_WHPOAlJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RjR31EeaVEcfXx-aEqQ" base_Element="_WHPOA1JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rjh31EeaVEcfXx-aEqQ" base_Element="_WHPOBFJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RkB31EeaVEcfXx-aEqQ" base_Element="_T9ChoKU5EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RkR31EeaVEcfXx-aEqQ" base_Element="_hoAc0KU5EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rkh31EeaVEcfXx-aEqQ" base_Element="_hoJmwKU5EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rkx31EeaVEcfXx-aEqQ" base_Element="_SK70ML2KEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RlB31EeaVEcfXx-aEqQ" base_Element="_xuBqsL2OEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RlR31EeaVEcfXx-aEqQ" base_Element="_zEZcML2YEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rlx31EeaVEcfXx-aEqQ" base_Element="_JqtJcL2TEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RmB31EeaVEcfXx-aEqQ" base_Element="_YRJ1cL2TEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RmR31EeaVEcfXx-aEqQ" base_Element="_qzgEYL2VEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rmh31EeaVEcfXx-aEqQ" base_Element="_L70owL2ZEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RnB31EeaVEcfXx-aEqQ" base_Element="_zDaPoL2WEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RnR31EeaVEcfXx-aEqQ" base_Element="_Y9jZsL2ZEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCRx31EeaVEcfXx-aEqQ" base_Element="_CIxSkLrhEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCSB31EeaVEcfXx-aEqQ" base_Element="_nOJNQLriEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_5oSYICM_EeaA8dOpokrEww" base_Association="_TPT-AO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWsR31EeaVEcfXx-aEqQ" base_Element="_nttnAGkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_u3zggBXrEeaOevPmmmHXcA" base_Association="_nttnAGkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWoR31EeaVEcfXx-aEqQ" base_Element="_ZiXD4EUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgkx31EeaVEcfXx-aEqQ" base_Element="_B0rIkO_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_HjcCMO_sEeWLlrwIF3w0vA" base_Association="_B0rIkO_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RJR31EeaVEcfXx-aEqQ" base_Element="_nfDxoO_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_GeF1oO_qEeWLlrwIF3w0vA" base_Association="_nfDxoO_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RIx31EeaVEcfXx-aEqQ" base_Element="_oP678O_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_zr86YO_rEeWLlrwIF3w0vA" base_Association="_oP678O_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgLR31EeaVEcfXx-aEqQ" base_Element="_4Es8MGkIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_IDwVUBYdEeaOevPmmmHXcA" base_Association="_4Es8MGkIEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RIR31EeaVEcfXx-aEqQ" base_Element="_WFlH4O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_b1QngO_qEeWLlrwIF3w0vA" base_Association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSex31EeaVEcfXx-aEqQ" base_Element="_IZ3vcEHbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_IZ4WgEHbEeWqPKyD1j6LMg" base_Class="_IZ3vcEHbEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0aB31EeaVEcfXx-aEqQ" base_Element="_sIutIGh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_sKhc4Gh-EeWZEqTYAF8eqA" base_Class="_sIutIGh-EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDcR31EeaVEcfXx-aEqQ" base_Element="_MIWTIGh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_MIWTL2h5EeWZEqTYAF8eqA" base_Class="_MIWTIGh5EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSax31EeaVEcfXx-aEqQ" base_Element="_kuDzQEHaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_kuDzWEHaEeWqPKyD1j6LMg" base_Class="_kuDzQEHaEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqTB31EeaVEcfXx-aEqQ" base_Element="_DOEi4O-IEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_DPthoO-IEeWLlrwIF3w0vA" base_Class="_DOEi4O-IEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvSSjB31EeaVEcfXx-aEqQ" base_Element="_kkzTEEUbEeWKAbXi7_SowQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_kkzTFkUbEeWKAbXi7_SowQ" base_Class="_kkzTEEUbEeWKAbXi7_SowQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIhh31EeaVEcfXx-aEqQ" base_Element="_oC2ZEEG_EeWAMMFKXSVi-w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oC6DcEG_EeWAMMFKXSVi-w" base_Class="_oC2ZEEG_EeWAMMFKXSVi-w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rjx31EeaVEcfXx-aEqQ" base_Element="_AnTcAKU5EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_ApPVsKU5EeWkWNPM1BHzGA" base_Operation="_AnTcAKU5EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rmx31EeaVEcfXx-aEqQ" base_Element="_lQR28L2WEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_lQR28b2WEeWdore3Cxez9g" base_Operation="_lQR28L2WEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7ReB31EeaVEcfXx-aEqQ" base_Element="_WHPN5VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1xFJvEeWcs7ZjyujtOg" base_Operation="_WHPN5VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RgB31EeaVEcfXx-aEqQ" base_Element="_WHPN7VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1ylJvEeWcs7ZjyujtOg" base_Operation="_WHPN7VJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RiB31EeaVEcfXx-aEqQ" base_Element="_WHPN81JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk10FJvEeWcs7ZjyujtOg" base_Operation="_WHPN81JvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RfB31EeaVEcfXx-aEqQ" base_Element="_WHPN6FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1x1JvEeWcs7ZjyujtOg" base_Operation="_WHPN6FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RhR31EeaVEcfXx-aEqQ" base_Element="_WHPN8FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKk1zVJvEeWcs7ZjyujtOg" base_Operation="_WHPN8FJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rix31EeaVEcfXx-aEqQ" base_Element="_WHPOAFJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_WKq8YFJvEeWcs7ZjyujtOg" base_Operation="_WHPOAFJvEeWcs7ZjyujtOg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rlh31EeaVEcfXx-aEqQ" base_Element="_qH8fkL2NEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_qH8fkb2NEeWdore3Cxez9g" base_Operation="_qH8fkL2NEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_PfNxYS5zEea0_JngOlSKcA" base_Element="_PfNxYC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_QjpC0C5zEea0_JngOlSKcA" base_Element="_QjobwC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_TQ0awS5zEea0_JngOlSKcA" base_Element="_TQ0awC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_UwyYsC5zEea0_JngOlSKcA" base_Element="_UwxxoC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VsSXoS5zEea0_JngOlSKcA" base_Element="_VsSXoC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_W1hQkS5zEea0_JngOlSKcA" base_Element="_W1hQkC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__4jwIS5zEea0_JngOlSKcA" base_Element="__4jwIC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_6FRP8C6AEea0_JngOlSKcA" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__-wDgTA7Eea4fKwSGMr6CA" base_Element="__-wDgDA7Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WktNoTBFEeam35bpdXJzEw" base_Element="_WktNoDBFEeam35bpdXJzEw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_F9PskDI8EeamvfKYyWmELQ" base_StructuralFeature="_nttnBWkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F9PskTI8EeamvfKYyWmELQ" base_Element="_nttnBWkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F9PskjI8EeamvfKYyWmELQ" base_Element="_wVJW4WkFEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_nxS_ATLCEeaULOmJRJKM0Q" base_Element="_nxS_ADLCEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nxcI8zLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxcI8jLCEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_nxcI9DLCEeaULOmJRJKM0Q" base_Element="_nxcI8jLCEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YQFpATLEEeaULOmJRJKM0Q" base_Element="_YQFpADLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YQFpAzLEEeaULOmJRJKM0Q" base_Element="_YQFpAjLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_c8MLwTLEEeaULOmJRJKM0Q" base_Element="_c8MLwDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLxTLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_c8MLxjLEEeaULOmJRJKM0Q" base_Element="_c8MLxDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hUfowTLEEeaULOmJRJKM0Q" base_Element="_hUfowDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hUfowzLEEeaULOmJRJKM0Q" base_Element="_hUfowjLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_kUSasTLEEeaULOmJRJKM0Q" base_Element="_kUSasDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kUbkozLEEeaULOmJRJKM0Q" base_StructuralFeature="_kUbkojLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_kUbkpDLEEeaULOmJRJKM0Q" base_Element="_kUbkojLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_v3sMcTLEEeaULOmJRJKM0Q" base_Element="_v3sMcDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_v3sMczLEEeaULOmJRJKM0Q" base_Element="_v3sMcjLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yUEvUTLEEeaULOmJRJKM0Q" base_Element="_yUEvUDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yUEvVTLEEeaULOmJRJKM0Q" base_StructuralFeature="_yUEvVDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yUEvVjLEEeaULOmJRJKM0Q" base_Element="_yUEvVDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_4SnxYTLEEeaULOmJRJKM0Q" base_Element="_4SnxYDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_4SnxYzLEEeaULOmJRJKM0Q" base_Element="_4SnxYjLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nxl58TLCEeaULOmJRJKM0Q" base_StructuralFeature="_nxl58DLCEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_pW8uMDLCEeaULOmJRJKM0Q" base_Element="_nxl58DLCEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_c8MLyDLEEeaULOmJRJKM0Q" base_StructuralFeature="_c8MLxzLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_c8MLyTLEEeaULOmJRJKM0Q" base_Element="_c8MLxzLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kUbkpjLEEeaULOmJRJKM0Q" base_StructuralFeature="_kUbkpTLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_kUbkpzLEEeaULOmJRJKM0Q" base_Element="_kUbkpTLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yUOgUTLEEeaULOmJRJKM0Q" base_StructuralFeature="_yUOgUDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yUOgUjLEEeaULOmJRJKM0Q" base_Element="_yUOgUDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Zby70DNAEeaULOmJRJKM0Q" base_Association="_ZiXD4EUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_znbeYD4ZEea-1_BGg-qcjQ" base_StructuralFeature="_4EtL4EUcEeWEwNCluy4jrw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_r4A80D4zEea-1_BGg-qcjQ" base_Element="_r33L0D4zEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_8PoZkD41Eea-1_BGg-qcjQ" base_Association="_yUEvUDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_9-UwAD41Eea-1_BGg-qcjQ" base_Association="_kUSasDLEEeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zPdpkkTYEead1bezhJG4aw" base_StructuralFeature="_zPdpkETYEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zPdpk0TYEead1bezhJG4aw" base_Element="_zPdpkETYEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zPdplETYEead1bezhJG4aw" base_Element="_zPdpkUTYEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7PT1AkTYEead1bezhJG4aw" base_StructuralFeature="_7PT1AETYEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7PT1A0TYEead1bezhJG4aw" base_Element="_7PT1AETYEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7PT1BETYEead1bezhJG4aw" base_Element="_7PT1AUTYEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_-d_-kETYEead1bezhJG4aw" base_StructuralFeature="_zPdpkETYEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_AUxS8ETZEead1bezhJG4aw" base_StructuralFeature="_7PT1AETYEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NmluUkTZEead1bezhJG4aw" base_StructuralFeature="_NmluUETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NmluU0TZEead1bezhJG4aw" base_Element="_NmluUETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NmluVETZEead1bezhJG4aw" base_Element="_NmluUUTZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_UkkNEkTZEead1bezhJG4aw" base_StructuralFeature="_UkkNEETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_UkkNE0TZEead1bezhJG4aw" base_Element="_UkkNEETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_UkkNFETZEead1bezhJG4aw" base_Element="_UkkNEUTZEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_ZA7DoETZEead1bezhJG4aw" base_StructuralFeature="_NmluUETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_a0hIMETZEead1bezhJG4aw" base_StructuralFeature="_UkkNEETZEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_28FwskT2Eead1bezhJG4aw" base_StructuralFeature="_28FwsET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_28Fws0T2Eead1bezhJG4aw" base_Element="_28FwsET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_28FwtET2Eead1bezhJG4aw" base_Element="_28FwsUT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7siA4kT2Eead1bezhJG4aw" base_StructuralFeature="_7siA4ET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7siA40T2Eead1bezhJG4aw" base_Element="_7siA4ET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7siA5ET2Eead1bezhJG4aw" base_Element="_7siA4UT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_-R0oIET2Eead1bezhJG4aw" base_StructuralFeature="_28FwsET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="__r-R8ET2Eead1bezhJG4aw" base_StructuralFeature="_7siA4ET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wt9DUUXOEeaB8vMnkFQLXQ" base_Element="_wt9DUEXOEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wt-Rc0XOEeaB8vMnkFQLXQ" base_Element="_wt-RckXOEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wt-RdEXOEeaB8vMnkFQLXQ" base_StructuralFeature="_wt-RckXOEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuAGoUXOEeaB8vMnkFQLXQ" base_Element="_wuAGoEXOEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_wuAGokXOEeaB8vMnkFQLXQ" base_StructuralFeature="_wuAGoEXOEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Oi89IUXPEeaB8vMnkFQLXQ" base_Element="_Oi89IEXPEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_OjBOkUXPEeaB8vMnkFQLXQ" base_Element="_OjBOkEXPEeaB8vMnkFQLXQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiEth.uml
+++ b/xmi2yang tool-v2.0/project/TapiEth.uml
@@ -1,0 +1,4696 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14" xmlns:OpenModel_Profile_1="http:///schemas/OpenModel_Profile/_NDJbQJNqEeWP45fAG0gIqg/12" xmlns:OpenModel_Profile_2="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14 ../OpenModelProfile/OpenModel_Profile.profile.uml http:///schemas/OpenModel_Profile/_NDJbQJNqEeWP45fAG0gIqg/12 ../OpenModelProfile/OpenModel_Profile.profile.uml http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_FOdHAJKmEdybINoKQq_hfQ" name="TapiEth">
+    <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FOdHAZKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_MP5wgJKmEdybINoKQq_hfQ" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_IyE4kEWsEeaB8vMnkFQLXQ" name="NodeEPSpecHasTerminationPac" memberEnd="_IyOCgkWsEeaB8vMnkFQLXQ _IyOChUWsEeaB8vMnkFQLXQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IyOCgEWsEeaB8vMnkFQLXQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IyOCgUWsEeaB8vMnkFQLXQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_IyOChUWsEeaB8vMnkFQLXQ" name="_lpSpec" type="__0LJcEWrEeaB8vMnkFQLXQ" association="_IyE4kEWsEeaB8vMnkFQLXQ"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_SdNnUJKmEdybINoKQq_hfQ" name="ObjectClasses">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SdNnUZKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_7ySKwOuGEeGZr5p9Vdkojw" name="ConnectionPointAndAdapterPac">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7ySKweuGEeGZr5p9Vdkojw" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Osz7EOuHEeGZr5p9Vdkojw" name="auxiliaryFunctionPositionSequence" visibility="public" isOrdered="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_UtlxwOuHEeGZr5p9Vdkojw" annotatedElement="_Osz7EOuHEeGZr5p9Vdkojw">
+            <body>This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_njp40OuHEeGZr5p9Vdkojw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_njp40euHEeGZr5p9Vdkojw" value="*"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTGRcCFqEeWrHvhCHfosZA" value="">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VAOosziEEeGKKvtWtO2aIg" name="vlanConfig" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_VAOotDiEEeGKKvtWtO2aIg" annotatedElement="_VAOosziEEeGKKvtWtO2aIg">
+            <body>This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTer8CFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-A0TI5MuEeCKK9uc7Khnmg" name="csfRdiFdiEnable" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hbwIsMNpEeCUp9m8vv2E5A" annotatedElement="_-A0TI5MuEeCKK9uc7Khnmg">
+            <body>This attribute models the MI_CSFrdifdiEnable information defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_j0ycoMNpEeCUp9m8vv2E5A">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hBZhA5MvEeCKK9uc7Khnmg" name="csfReport" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_HVNoMMNqEeCUp9m8vv2E5A" annotatedElement="_hBZhA5MvEeCKK9uc7Khnmg">
+            <body>This attribute models the MI_CSF_Reported information defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_JSFkkMNqEeCUp9m8vv2E5A">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LpAAEJMvEeCKK9uc7Khnmg" name="filterConfigSnk" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_LpAAEZMvEeCKK9uc7Khnmg" annotatedElement="_LpAAEJMvEeCKK9uc7Khnmg">
+            <body>This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:&#xD;
+01-80-C2-00-00-10, &#xD;
+01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and &#xD;
+01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
+The filter action is Pass or Block. &#xD;
+If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
+If none of the above addresses match, the ETH_CI_D is passed.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_t9NOIOuCEeGZr5p9Vdkojw" value="33"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_t9NOIeuCEeGZr5p9Vdkojw" value="33"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xo3rYJMvEeCKK9uc7Khnmg" name="macLength" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_eyLeYMNpEeCUp9m8vv2E5A" annotatedElement="_Xo3rYJMvEeCKK9uc7Khnmg">
+            <body>This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3lSysMNpEeCUp9m8vv2E5A" value="2000">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__7TK8C01EeC5VOR5P4wONQ" name="filterConfig" visibility="public" type="_s3CEAK2EEeKoWKjPsL4xyQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_YiP1YI3gEeGyj-TNVzlOGQ" annotatedElement="__7TK8C01EeC5VOR5P4wONQ">
+            <body>This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:&#xD;
+- All bridges address: 01-80-C2-00-00-10,&#xD;
+- Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,&#xD;
+- GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
+The filter action is Pass or Block. &#xD;
+If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
+If none of the above addresses match, the ETH_CI_D is passed.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hDbuEOt8EeGPOswgCwFOKw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hDbuEet8EeGPOswgCwFOKw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSTAMSFqEeWrHvhCHfosZA" type="_s3CEAK2EEeKoWKjPsL4xyQ" value="See data type">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0_3YIC01EeC5VOR5P4wONQ" name="isSsfReported" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_M0ktUI3gEeGyj-TNVzlOGQ" annotatedElement="_0_3YIC01EeC5VOR5P4wONQ">
+            <body>This attribute provisions whether the SSF defect should be reported as fault cause or not.&#xD;
+It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_NSrloI3gEeGyj-TNVzlOGQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pU1bwC0yEeC5VOR5P4wONQ" name="pllThr" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_u4IrADBNEeC_I_YldZCMxA" annotatedElement="_pU1bwC0yEeC5VOR5P4wONQ">
+            <body>This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_6WJhwEXMEeKyK7rRd9C5sg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6WJhwUXMEeKyK7rRd9C5sg" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Styy4C0xEeC5VOR5P4wONQ" name="actorOperKey" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5QEaEDBLEeC_I_YldZCMxA" annotatedElement="_Styy4C0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+The current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.&#xD;
+The meaning of particular Key values is of local significance.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSUOUCFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ny8pgC0xEeC5VOR5P4wONQ" name="actorSystemId" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_p-lNADBLEeC_I_YldZCMxA" annotatedElement="_Ny8pgC0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+A MAC address used as a unique identifier for the System that contains this Aggregator.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSTnQCFqEeWrHvhCHfosZA" type="_hYZs0BWEEd-Si5Ih_dYBog" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QsAhUC0xEeC5VOR5P4wONQ" name="actorSystemPriority" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_v4BFkDBLEeC_I_YldZCMxA" annotatedElement="_QsAhUC0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+Indicating the priority associated with the Actor’s System ID.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSTnQSFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dOaR8C0xEeC5VOR5P4wONQ" name="collectorMaxDelay" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Bywz4DBMEeC_I_YldZCMxA" annotatedElement="_dOaR8C0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+The value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSVccCFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_bXqLsC0xEeC5VOR5P4wONQ" name="dataRate" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_BRiWIDBMEeC_I_YldZCMxA" annotatedElement="_bXqLsC0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+The current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSU1YSFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Zg5eYC0xEeC5VOR5P4wONQ" name="partnerOperKey" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AuX-sDBMEeC_I_YldZCMxA" annotatedElement="_Zg5eYC0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+The current operational value of the Key for the Aggregator’s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSU1YCFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VVbjgC0xEeC5VOR5P4wONQ" name="partnerSystemId" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_-NcTADBLEeC_I_YldZCMxA" annotatedElement="_VVbjgC0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+A MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSUOUSFqEeWrHvhCHfosZA" type="_hYZs0BWEEd-Si5Ih_dYBog" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Xkn-8C0xEeC5VOR5P4wONQ" name="partnerSystemPriority" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_AJH8kDBMEeC_I_YldZCMxA" annotatedElement="_Xkn-8C0xEeC5VOR5P4wONQ">
+            <body>See 802.1AX:&#xD;
+Indicates the priority associated with the Partner’s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSUOUiFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ukk3kDqaEeCu35lketJ8Yg" name="csfConfig" visibility="public" type="_10eLcKNEEeKZoeGA12VHIQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4eC1EMNoEeCUp9m8vv2E5A" annotatedElement="_ukk3kDqaEeCu35lketJ8Yg">
+            <body>This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_T7cP0DN7Eea40e5DA9KE3w" name="ConnectionEndPointLpSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_zsepwEWpEeaB8vMnkFQLXQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xTg3MEW9EeaB8vMnkFQLXQ" name="extensionsSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_Kjj_IEW-EeaB8vMnkFQLXQ" value="/TapiEth:ConnectionEndPointLpSpec"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_VZkuoS6BEea0_JngOlSKcA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_03vL4EW9EeaB8vMnkFQLXQ" name="extensionsSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_G88dwEW-EeaB8vMnkFQLXQ" value="/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_EGSwgDOFEeansfg7-s4Unw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__18Z0jN9Eea40e5DA9KE3w" name="_terminationSpec" type="_ACUEMOxFEeGzwM2Uvwf5Xw" aggregation="composite" association="__17LsDN9Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JC0N0EWtEeaB8vMnkFQLXQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JC0N0kWtEeaB8vMnkFQLXQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ITjfUjN-Eea40e5DA9KE3w" name="_adapterSpec" type="_7ySKwOuGEeGZr5p9Vdkojw" aggregation="composite" association="_ITi4QDN-Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ds3bAEWtEeaB8vMnkFQLXQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ds3bAkWtEeaB8vMnkFQLXQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_ACUEMOxFEeGzwM2Uvwf5Xw" name="EthTerminationPac">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ACUEMexFEeGzwM2Uvwf5Xw" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ACUEMuxFEeGzwM2Uvwf5Xw" annotatedElement="_ACUEMOxFEeGzwM2Uvwf5Xw">
+          <body>This object class models the Ethernet Flow Termination function located at a layer boundary.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_upySMHnOEd2GobjTM4neEA" name="priorityRegenerate" visibility="public" type="_GjpskCbKEd-tK43JMxNtYw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_kYZu0CEkEd-ysdtezPKi3w" annotatedElement="_upySMHnOEd2GobjTM4neEA">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AEiUECbKEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AEiUESbKEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTdd0CFqEeWrHvhCHfosZA" type="_GjpskCbKEd-tK43JMxNtYw" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vOIbgHp1Ed2F76X026nNcA" name="etherType" visibility="public" type="_kQIFACelEd-sQoLP0EY2BQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_musQwCEkEd-ysdtezPKi3w" annotatedElement="_vOIbgHp1Ed2F76X026nNcA">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTeE4CFqEeWrHvhCHfosZA" type="_kQIFACelEd-sQoLP0EY2BQ" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__KuU8HnOEd2GobjTM4neEA" name="filterConfig" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_odulcCEkEd-ysdtezPKi3w" annotatedElement="__KuU8HnOEd2GobjTM4neEA">
+            <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.&#xD;
+It indicates the configured filter action for each of the 33 group MAC addresses for control frames.&#xD;
+&#xD;
+The 33 MAC addresses are:&#xD;
+01-80-C2-00-00-10, &#xD;
+01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and &#xD;
+01-80-C2-00-00-20 to 01-80-C2-00-00-2F.&#xD;
+&#xD;
+The filter action is Pass or Block. &#xD;
+If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. &#xD;
+If none of the above addresses match, the ETH_CI_D is passed.&#xD;
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fJJ9YOxmEeGzwM2Uvwf5Xw" value="33"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fJJ9YexmEeGzwM2Uvwf5Xw" value="33"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTeE4SFqEeWrHvhCHfosZA" type="_hYZs0BWEEd-Si5Ih_dYBog" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0_GOcHnOEd2GobjTM4neEA" name="frametypeConfig" visibility="public" type="_n3YdgCEsEd-ysdtezPKi3w">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_n4a48CEkEd-ysdtezPKi3w" annotatedElement="_0_GOcHnOEd2GobjTM4neEA">
+            <body>This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_zkGjUCEsEd-ysdtezPKi3w" name="AllowUntaggedOnly" type="_n3YdgCEsEd-ysdtezPKi3w" instance="_tKgkACEsEd-ysdtezPKi3w"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zDHp8HnOEd2GobjTM4neEA" name="portVid" visibility="public" type="_d1LyACbNEd-tK43JMxNtYw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lDqSUCEkEd-ysdtezPKi3w" annotatedElement="_zDHp8HnOEd2GobjTM4neEA">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_G82S4CbOEd-tK43JMxNtYw" type="_d1LyACbNEd-tK43JMxNtYw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_q7yL8nnNEd2GobjTM4neEA" name="priorityCodePointConfig" visibility="public" type="_tjBD8CdpEd-sQoLP0EY2BQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_loFOACEkEd-ysdtezPKi3w" annotatedElement="_q7yL8nnNEd2GobjTM4neEA">
+            <body>This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTdd0SFqEeWrHvhCHfosZA" type="_tjBD8CdpEd-sQoLP0EY2BQ" value="8P0D">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_fzLz0OxQEeGzwM2Uvwf5Xw" name="EtyTerminationPac">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fzLz0exQEeGzwM2Uvwf5Xw" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_J3_wsHzUEd2S7rQMqMRYLA" name="isFtsEnabled" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_vwvUUOxeEeGzwM2Uvwf5Xw" annotatedElement="_J3_wsHzUEd2S7rQMqMRYLA">
+            <body>This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_yCn3YOxeEeGzwM2Uvwf5Xw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ibtJIC0kEeC5VOR5P4wONQ" name="isTxPauseEnabled" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yXiUQOxaEeGzwM2Uvwf5Xw" annotatedElement="_ibtJIC0kEeC5VOR5P4wONQ">
+            <body>This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_4Xiu4OxaEeGzwM2Uvwf5Xw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PFLnQHzUEd2S7rQMqMRYLA" name="phyType" visibility="public" type="_AdKOUOxfEeGzwM2Uvwf5Xw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_39t80OxeEeGzwM2Uvwf5Xw" annotatedElement="_PFLnQHzUEd2S7rQMqMRYLA">
+            <body>This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_iICjoNHUEeKzI4N0oSjmcw" name="UNKNOWN" type="_AdKOUOxfEeGzwM2Uvwf5Xw" instance="_I44dcOxfEeGzwM2Uvwf5Xw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QoRxsHzUEd2S7rQMqMRYLA" name="phyTypeList" visibility="public" type="_AdKOUOxfEeGzwM2Uvwf5Xw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_q3xvYOxgEeGzwM2Uvwf5Xw" annotatedElement="_QoRxsHzUEd2S7rQMqMRYLA">
+            <body>This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_R5yc4HzUEd2S7rQMqMRYLA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_R5yc4XzUEd2S7rQMqMRYLA" value="*"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSlUECFqEeWrHvhCHfosZA" type="_AdKOUOxfEeGzwM2Uvwf5Xw" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_8QR1UK4wEeGjbtFXtCFKWg" name="TrafficConditioningPac">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8QR1Ua4wEeGjbtFXtCFKWg" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_zib-AOuSEeGZr5p9Vdkojw" annotatedElement="_8QR1UK4wEeGjbtFXtCFKWg">
+          <body>This object class models the ETH traffic conditioning function as defined in G.8021.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_I4OBgFBDEeWBGOds9dR2yw" annotatedElement="_8QR1UK4wEeGjbtFXtCFKWg">
+          <body>Basic attributes: codirectional, condConfigList, prioConfigList</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Tg7zoOhhEeG35t-G7oiZlg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4ctfoOuSEeGZr5p9Vdkojw" annotatedElement="_Tg7zoOhhEeG35t-G7oiZlg">
+            <body>This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ThE9kehhEeG35t-G7oiZlg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ThE9kOhhEeG35t-G7oiZlg" value="8"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSLEYSFqEeWrHvhCHfosZA" type="_inWUgK5KEeGXRumldg-1oA" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QR1U64wEeGjbtFXtCFKWg" name="condConfigList" visibility="public" type="_l70IMK5FEeGvr_m5yJYoog" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_aeY1QOuTEeGZr5p9Vdkojw" annotatedElement="_8QR1U64wEeGjbtFXtCFKWg">
+            <body>This attribute indicates for the conditioner process the conditioning parameters:&#xD;
+- Queue ID: Indicates the Queue ID&#xD;
+- Committed Information Rate (CIR): number of bits per second&#xD;
+- Committed Burst Size (CBS): number of bytes&#xD;
+- Excess Information Rate (EIR): number of bits per second&#xD;
+- Excess Burst Size (EBS): number of bytes&#xD;
+- Coupling flag (CF): 0 or 1&#xD;
+- Color mode (CM): color-blind and color-aware.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8QR1Va4wEeGjbtFXtCFKWg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8QR1VK4wEeGjbtFXtCFKWg" value="8"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSLrcCFqEeWrHvhCHfosZA" type="_l70IMK5FEeGvr_m5yJYoog" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PHrv4LoIEeGh2ojTLz6Azw" name="codirectional" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_XllKMOuVEeGZr5p9Vdkojw" annotatedElement="_PHrv4LoIEeGh2ojTLz6Azw">
+            <body>This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSNgoCFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_8QIrYK4wEeGjbtFXtCFKWg" name="TrafficShapingPac">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8QIrYa4wEeGjbtFXtCFKWg" source="http://www.eclipse.org/uml2/2.0.0/UML"/>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ju-k8OuVEeGZr5p9Vdkojw" annotatedElement="_8QIrYK4wEeGjbtFXtCFKWg">
+          <body>This object class models the ETH traffic shaping function as defined in G.8021.</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Ql3CoFBDEeWBGOds9dR2yw" annotatedElement="_8QIrYK4wEeGjbtFXtCFKWg">
+          <body>Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QIrYq4wEeGjbtFXtCFKWg" name="prioConfigList" visibility="public" type="_inWUgK5KEeGXRumldg-1oA" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_nCRhsOuVEeGZr5p9Vdkojw" annotatedElement="_8QIrYq4wEeGjbtFXtCFKWg">
+            <body>This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3gl0QK5KEeGXRumldg-1oA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3gl0Qa5KEeGXRumldg-1oA" value="8"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSOHsCFqEeWrHvhCHfosZA" type="_inWUgK5KEeGXRumldg-1oA" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8QIrY64wEeGjbtFXtCFKWg" name="queueConfigList" visibility="public" type="_fDoLkK5JEeGXRumldg-1oA" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_6ePLIOuVEeGZr5p9Vdkojw" annotatedElement="_8QIrY64wEeGjbtFXtCFKWg">
+            <body>This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8QIrZa4wEeGjbtFXtCFKWg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8QIrZK4wEeGjbtFXtCFKWg" value="8"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSOHsSFqEeWrHvhCHfosZA" type="_fDoLkK5JEeGXRumldg-1oA" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_UtUisLoIEeGh2ojTLz6Azw" name="schedConfig" visibility="public" type="_ZadywOuWEeGZr5p9Vdkojw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_T7Y68OuWEeGZr5p9Vdkojw" annotatedElement="_UtUisLoIEeGh2ojTLz6Azw">
+            <body>This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.&#xD;
+Scheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).&#xD;
+Note that the only significance of the GTCS function defined in G.8021 is the use of a common scheduler for shaping. Given that, G.8052 models the common scheduler feature by having a common value for this attribute.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSOuwCFqEeWrHvhCHfosZA" type="_ZadywOuWEeGZr5p9Vdkojw" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u4pyoOuWEeGZr5p9Vdkojw" name="codirectional" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_u4pyoeuWEeGZr5p9Vdkojw" annotatedElement="_u4pyoOuWEeGZr5p9Vdkojw">
+            <body>This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VSOuwSFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="__0LJcEWrEeaB8vMnkFQLXQ" name="NodeEdgePointLpSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_D9VXMEWsEeaB8vMnkFQLXQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_fcjcsEW9EeaB8vMnkFQLXQ" name="extensionsSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_Oh75MEW-EeaB8vMnkFQLXQ" value="/TapiEth:NodeEdgePointLpSpec"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_VZkuoS6BEea0_JngOlSKcA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_koShwEW9EeaB8vMnkFQLXQ" name="extensionsSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_B8c_YEW-EeaB8vMnkFQLXQ" value="/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_EGSwgDOFEeansfg7-s4Unw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IyOCgkWsEeaB8vMnkFQLXQ" name="_terminationSpec" type="_fzLz0OxQEeGzwM2Uvwf5Xw" aggregation="composite" association="_IyE4kEWsEeaB8vMnkFQLXQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_EqOc8EWtEeaB8vMnkFQLXQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_EqOc8kWtEeaB8vMnkFQLXQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_dP6U4JKmEdybINoKQq_hfQ" name="TypeDefinitions">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_dQAbgJKmEdybINoKQq_hfQ" source="uml2.diagrams"/>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_inWUgK5KEeGXRumldg-1oA" name="PriorityConfiguration">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_inWUgq5KEeGXRumldg-1oA" name="priority" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTTs0SFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_inWUga5KEeGXRumldg-1oA" name="queueId" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTUT4CFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_fDoLkK5JEeGXRumldg-1oA" name="QueueConfiguration">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lUUGgK5JEeGXRumldg-1oA" name="queueId" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_74ZzENHDEeKzI4N0oSjmcw" annotatedElement="_lUUGgK5JEeGXRumldg-1oA">
+            <body>This attribute indicates the queue id.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTUT4SFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u9XrcK5JEeGXRumldg-1oA" name="queueDepth" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_NN7kcOuWEeGZr5p9Vdkojw" annotatedElement="_u9XrcK5JEeGXRumldg-1oA">
+            <body>This attribute defines the depth of the queue in bytes.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTUT4iFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vWtYgK5JEeGXRumldg-1oA" name="queueThreshold" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_QELY0OuWEeGZr5p9Vdkojw" annotatedElement="_vWtYgK5JEeGXRumldg-1oA">
+            <body>This attribute defines the threshold of the queue in bytes.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTU68CFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_l70IMK5FEeGvr_m5yJYoog" name="TrafficConditioningConfiguration">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ru2d0K5FEeGvr_m5yJYoog" name="cir" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Cl4SkOuUEeGZr5p9Vdkojw" annotatedElement="_ru2d0K5FEeGvr_m5yJYoog">
+            <body>This attribute indicates the Committed Information Rate in bits/s.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTU68SFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_DFS_0K5GEeGvr_m5yJYoog" name="cbs" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_DNEOYOuUEeGZr5p9Vdkojw" annotatedElement="_DFS_0K5GEeGvr_m5yJYoog">
+            <body>This attribute indicates the Committed Burst Size in bytes.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTViACFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Dc1WEK5GEeGvr_m5yJYoog" name="eir" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EXk5sOuUEeGZr5p9Vdkojw" annotatedElement="_Dc1WEK5GEeGvr_m5yJYoog">
+            <body>This attribute indicates the Excess Information Rate in bits/s.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTViASFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Dw9L8K5GEeGvr_m5yJYoog" name="ebs" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_DuSsIOuUEeGZr5p9Vdkojw" annotatedElement="_Dw9L8K5GEeGvr_m5yJYoog">
+            <body>This attribute indicates the Excess Burst Size in bytes.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTViAiFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KSMrYK5GEeGvr_m5yJYoog" name="couplingFlag" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_G5PDQNHEEeKzI4N0oSjmcw" annotatedElement="_KSMrYK5GEeGvr_m5yJYoog">
+            <body>This attribute indicates the coupling flag.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTWJECFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KnNSEK5GEeGvr_m5yJYoog" name="colourMode" visibility="public" type="_Tw2XIK5GEeGvr_m5yJYoog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_DUNdUNHEEeKzI4N0oSjmcw" annotatedElement="_KnNSEK5GEeGvr_m5yJYoog">
+            <body>This attribute indicates the colour mode.</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTWJESFqEeWrHvhCHfosZA" type="_Tw2XIK5GEeGvr_m5yJYoog" value="NA">
+            <name xsi:nil="true"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nQw7kOuTEeGZr5p9Vdkojw" name="queueId" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_CAefcOuUEeGZr5p9Vdkojw" annotatedElement="_nQw7kOuTEeGZr5p9Vdkojw">
+            <body>This attribute indicates the queue id.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_VTWwICFqEeWrHvhCHfosZA" value="NA">
+            <name xsi:nil="true"/>
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_hYZs0BWEEd-Si5Ih_dYBog" name="MacAddress">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_vtSuwBWEEd-Si5Ih_dYBog" annotatedElement="_hYZs0BWEEd-Si5Ih_dYBog">
+          <body>This primitive data type contains an Ethernet MAC address defined by IEEE 802a. The format of the address consists of 12 hexadecimal characters, grouped in pairs and separated by &quot;-&quot; (e.g., 03-27-AC-75-3E-1D).</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_GjpskCbKEd-tK43JMxNtYw" name="PriorityMapping">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_b0Lq8CbKEd-tK43JMxNtYw" annotatedElement="_GjpskCbKEd-tK43JMxNtYw">
+          <body>This data type provides the priority mapping done in the &quot;P Regenerate&quot; process defined in G.8021.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_JJfGYCbKEd-tK43JMxNtYw" name="Priority0" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0U3LcCbKEd-tK43JMxNtYw" annotatedElement="_JJfGYCbKEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 0.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JJfGYibKEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JJfGYSbKEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_OTrTUCbKEd-tK43JMxNtYw">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3BAMICbLEd-tK43JMxNtYw" name="Priority1" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3BAMISbLEd-tK43JMxNtYw" annotatedElement="_3BAMICbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 1.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3BAMIybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3BAMIibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3BAMJCbLEd-tK43JMxNtYw" value="1">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3ey7YCbLEd-tK43JMxNtYw" name="Priority2" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3ey7YSbLEd-tK43JMxNtYw" annotatedElement="_3ey7YCbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 2.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3ey7YybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3ey7YibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3ey7ZCbLEd-tK43JMxNtYw" value="2">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3-PQcCbLEd-tK43JMxNtYw" name="Priority3" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3-PQcSbLEd-tK43JMxNtYw" annotatedElement="_3-PQcCbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 3.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_3-PQcybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_3-PQcibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_3-PQdCbLEd-tK43JMxNtYw" value="3">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4T_eACbLEd-tK43JMxNtYw" name="Priority4" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4T_eASbLEd-tK43JMxNtYw" annotatedElement="_4T_eACbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 4.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4T_eAybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4T_eAibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_4T_eBCbLEd-tK43JMxNtYw" value="4">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4mnfECbLEd-tK43JMxNtYw" name="Priority5" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4mnfESbLEd-tK43JMxNtYw" annotatedElement="_4mnfECbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 5.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_4mnfEybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_4mnfEibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_4mnfFCbLEd-tK43JMxNtYw" value="5">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_46SB8CbLEd-tK43JMxNtYw" name="Priority6" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_46SB8SbLEd-tK43JMxNtYw" annotatedElement="_46SB8CbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 6.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_46SB8ybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_46SB8ibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_46SB9CbLEd-tK43JMxNtYw" value="6">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5ND0ACbLEd-tK43JMxNtYw" name="Priority7" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5ND0ASbLEd-tK43JMxNtYw" annotatedElement="_5ND0ACbLEd-tK43JMxNtYw">
+            <body>This attribute defines the new priority value for the old priority value 7.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5ND0AybLEd-tK43JMxNtYw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5ND0AibLEd-tK43JMxNtYw" value="1"/>
+          <defaultValue xmi:type="uml:LiteralInteger" xmi:id="_5ND0BCbLEd-tK43JMxNtYw" value="7">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_d1LyACbNEd-tK43JMxNtYw" name="Vid">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_976d4CbNEd-tK43JMxNtYw" annotatedElement="_d1LyACbNEd-tK43JMxNtYw">
+          <body>This primitive type models the 12 Bit VLAN identifier of a VLAN tag.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_7hrFkJHNEeCZGJGlR2UAKg" name="ModifyCrossConnectionData"/>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_traBgLFXEeC6XaWwVljZZQ" name="AddressTuple">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_GkCQEKtIEeKnAKpr1sW3qQ" annotatedElement="_traBgLFXEeC6XaWwVljZZQ">
+          <body>This data type contains an address tuple consisting of a MAC address and a corresponding port list.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u99zIKtGEeKnAKpr1sW3qQ" name="address" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_u99zIatGEeKnAKpr1sW3qQ" annotatedElement="_u99zIKtGEeKnAKpr1sW3qQ">
+            <body>This attribute contains the MAC address of the address tuple.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3jh6wKtGEeKnAKpr1sW3qQ" name="portList" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_3jh6watGEeKnAKpr1sW3qQ" annotatedElement="_3jh6wKtGEeKnAKpr1sW3qQ">
+            <body>This attribute contains the ports associated to the MAC address in the address tuple.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YVEeMKtHEeKnAKpr1sW3qQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YVEeMatHEeKnAKpr1sW3qQ" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_ZadywOuWEeGZr5p9Vdkojw" name="SchedulingConfiguration">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_dtr7cOuWEeGZr5p9Vdkojw" annotatedElement="_ZadywOuWEeGZr5p9Vdkojw">
+          <body>The syntax of this dataType is pending on the specification in G.8021, which is for further study.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_s3CEAK2EEeKoWKjPsL4xyQ" name="ControlFrameFilter">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_JRR3EK2FEeKoWKjPsL4xyQ" annotatedElement="_s3CEAK2EEeKoWKjPsL4xyQ">
+          <body>This data type identifies the filter action for each of the 33 group MAC addresses (control frames).&#xD;
+&#xD;
+Value &quot;false&quot; means block: The frame is discarded by the filter process.&#xD;
+Value &quot;true&quot; means pass: The frame is passed unchanged through the filter process.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rIRxQK2GEeKoWKjPsL4xyQ" name="01-80-C2-00-00-10" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_F_KUIK2HEeKoWKjPsL4xyQ" annotatedElement="_rIRxQK2GEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the &quot;All LANs Bridge Management Group Address&quot;.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_xMmrMK2GEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_G-8WIK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-00" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_G-8WIa2HEeKoWKjPsL4xyQ" annotatedElement="_G-8WIK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the STP/RSTP/MSTP protocol address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_G-8WIq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lUPgoK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-01" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lUPgoa2HEeKoWKjPsL4xyQ" annotatedElement="_lUPgoK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the IEEE MAC-specific Control Protocols group address (PAUSE protocol).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_lUPgoq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lz-woK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-02" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lz-woa2HEeKoWKjPsL4xyQ" annotatedElement="_lz-woK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the IEEE 802.3 Slow_Protocols_Multicast address (LACP/LAMP or Link OAM protocols).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_lz-woq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_mKelEK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-03" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mKelEa2HEeKoWKjPsL4xyQ" annotatedElement="_mKelEK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Nearest non-TPMR Bridge group address (Port Authentication protocol).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_mKelEq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_mczrMK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-04" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mczrMa2HEeKoWKjPsL4xyQ" annotatedElement="_mczrMK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the IEEE MAC-specific Control Protocols group address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_mczrMq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_musscK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-05" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_mussca2HEeKoWKjPsL4xyQ" annotatedElement="_musscK2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_musscq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nAuQkK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-06" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_nAuQka2HEeKoWKjPsL4xyQ" annotatedElement="_nAuQkK2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_nAuQkq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_naW4kK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-07" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_naW4ka2HEeKoWKjPsL4xyQ" annotatedElement="_naW4kK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Metro Ethernet Forum E-LMI protocol group address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_naW4kq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ntlWkK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-08" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ntlWka2HEeKoWKjPsL4xyQ" annotatedElement="_ntlWkK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Provider Bridge Group address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_ntlWkq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_n_6csK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-09" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_n_6csa2HEeKoWKjPsL4xyQ" annotatedElement="_n_6csK2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_n_6csq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oRWK8K2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-0A" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_oRWK8a2HEeKoWKjPsL4xyQ" annotatedElement="_oRWK8K2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_oRWK8q2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ol6FsK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-0B" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_ol6Fsa2HEeKoWKjPsL4xyQ" annotatedElement="_ol6FsK2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_ol6Fsq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_o4PL0K2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-0C" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_o4PL0a2HEeKoWKjPsL4xyQ" annotatedElement="_o4PL0K2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_o4PL0q2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pM83kK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-0D" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pM83ka2HEeKoWKjPsL4xyQ" annotatedElement="_pM83kK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Provider Bridge MVRP address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_pM83kq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_phOecK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-0E" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_phOeca2HEeKoWKjPsL4xyQ" annotatedElement="_phOecK2HEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Individual LAN Scope group address, Nearest Bridge group address (LLDP protocol).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_phOecq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_p1yZMK2HEeKoWKjPsL4xyQ" name="01-80-C2-00-00-0F" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_p1yZMa2HEeKoWKjPsL4xyQ" annotatedElement="_p1yZMK2HEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_p1yZMq2HEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_bebnMK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-20" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_bebnMa2JEeKoWKjPsL4xyQ" annotatedElement="_bebnMK2JEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Customer and Provider Bridge MMRP address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_bebnMq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_frjH4K2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-21" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_frjH4a2JEeKoWKjPsL4xyQ" annotatedElement="_frjH4K2JEeKoWKjPsL4xyQ">
+            <body>This attribute identifies the Customer Bridge MVRP address.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_frjH4q2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gN0ugK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-22" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_gN0uga2JEeKoWKjPsL4xyQ" annotatedElement="_gN0ugK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_gN0ugq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gkeT8K2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-23" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_gkeT8a2JEeKoWKjPsL4xyQ" annotatedElement="_gkeT8K2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_gkeT8q2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_g5VJoK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-24" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_g5VJoa2JEeKoWKjPsL4xyQ" annotatedElement="_g5VJoK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_g5VJoq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hOVwUK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-25" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hOVwUa2JEeKoWKjPsL4xyQ" annotatedElement="_hOVwUK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_hOVwUq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hjWXAK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-26" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hjWXAa2JEeKoWKjPsL4xyQ" annotatedElement="_hjWXAK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_hjWXAq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_h3Ub4K2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-27" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_h3Ub4a2JEeKoWKjPsL4xyQ" annotatedElement="_h3Ub4K2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_h3Ub4q2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iNrGYK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-28" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_iNrGYa2JEeKoWKjPsL4xyQ" annotatedElement="_iNrGYK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_iNrGYq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_igTHcK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-29" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_igTHca2JEeKoWKjPsL4xyQ" annotatedElement="_igTHcK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_igTHcq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_i1AzMK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-2A" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_i1AzMa2JEeKoWKjPsL4xyQ" annotatedElement="_i1AzMK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_i1AzMq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jJbkAK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-2B" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jJbkAa2JEeKoWKjPsL4xyQ" annotatedElement="_jJbkAK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_jJbkAq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jf7YcK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-2C" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jf7Yca2JEeKoWKjPsL4xyQ" annotatedElement="_jf7YcK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_jf7Ycq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jzJ2cK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-2D" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_jzJ2ca2JEeKoWKjPsL4xyQ" annotatedElement="_jzJ2cK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_jzJ2cq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kIwTAK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-2E" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_kIwTAa2JEeKoWKjPsL4xyQ" annotatedElement="_kIwTAK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_kIwTAq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lBOzIK2JEeKoWKjPsL4xyQ" name="01-80-C2-00-00-2F" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_lBOzIa2JEeKoWKjPsL4xyQ" annotatedElement="_lBOzIK2JEeKoWKjPsL4xyQ">
+            <body>Reserved for future standardization.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_lBOzIq2JEeKoWKjPsL4xyQ">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_MCQ3QHu-EeSSGKd_EdTB1w" name="BandwidthReport">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_qmnxcHu-EeSSGKd_EdTB1w" annotatedElement="_MCQ3QHu-EeSSGKd_EdTB1w">
+          <body>Data type for the bandwidth report.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RGPHcHu-EeSSGKd_EdTB1w" name="sourceMacAddress" visibility="public" type="_hYZs0BWEEd-Si5Ih_dYBog">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_FJxgAHu_EeSSGKd_EdTB1w" annotatedElement="_RGPHcHu-EeSSGKd_EdTB1w">
+            <body>The sourceMacAddress is the address from the far end.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Vt2y0Hu-EeSSGKd_EdTB1w" name="portId" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_4zPoMHu-EeSSGKd_EdTB1w" annotatedElement="_Vt2y0Hu-EeSSGKd_EdTB1w">
+            <body>This attribute returns the far end port identifier.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_aARqQHu-EeSSGKd_EdTB1w" name="nominalBandwidth" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_0ghOwHu-EeSSGKd_EdTB1w" annotatedElement="_aARqQHu-EeSSGKd_EdTB1w">
+            <body>This attribute returns the configured bandwidth</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gbmu8Hu-EeSSGKd_EdTB1w" name="currentBandwidth" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_w3TsYHu-EeSSGKd_EdTB1w" annotatedElement="_gbmu8Hu-EeSSGKd_EdTB1w">
+            <body>This attribute returns the current bandwidth.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_KPwN0Hm9Ed2GobjTM4neEA" name="AdminState">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MmZ8IHm9Ed2GobjTM4neEA" name="LOCK"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Pa3AwHm9Ed2GobjTM4neEA" name="NORMAL"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_Tw2XIK5GEeGvr_m5yJYoog" name="ColourMode">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ZKac0K5GEeGvr_m5yJYoog" name="COLOUR_BLIND"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_b62kIK5GEeGvr_m5yJYoog" name="COLOUR_AWARE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_10eLcKNEEeKZoeGA12VHIQ" name="CsfConfig">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4HsLQKNEEeKZoeGA12VHIQ" name="DISABLED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_DCbagKNFEeKZoeGA12VHIQ" annotatedElement="_4HsLQKNEEeKZoeGA12VHIQ">
+            <body>This literal covers the following states of the CSF related MI informations:&#xD;
+- MI_CSF_Enable is false&#xD;
+- MI_CSFrdifdi_Enable is false&#xD;
+- MI_CSFdci_Enable is false.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_R1RjwKNFEeKZoeGA12VHIQ" name="ENABLED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_R1RjwaNFEeKZoeGA12VHIQ" annotatedElement="_R1RjwKNFEeKZoeGA12VHIQ">
+            <body>This literal covers the following states of the CSF related MI informations:&#xD;
+- MI_CSF_Enable is true&#xD;
+- MI_CSFrdifdi_Enable is false&#xD;
+- MI_CSFdci_Enable is false.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_aDI9EKNFEeKZoeGA12VHIQ" name="ENABLED_WITH_RDI_FDI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_aDI9EaNFEeKZoeGA12VHIQ" annotatedElement="_aDI9EKNFEeKZoeGA12VHIQ">
+            <body>This literal covers the following states of the CSF related MI informations:&#xD;
+- MI_CSF_Enable is true&#xD;
+- MI_CSFrdifdi_Enable is true&#xD;
+- MI_CSFdci_Enable is false.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_i2jTcKNFEeKZoeGA12VHIQ" name="ENABLED_WITH_RDI_FDI_DCI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_i2jTcaNFEeKZoeGA12VHIQ" annotatedElement="_i2jTcKNFEeKZoeGA12VHIQ">
+            <body>This literal covers the following states of the CSF related MI informations:&#xD;
+- MI_CSF_Enable is true&#xD;
+- MI_CSFrdifdi_Enable is true&#xD;
+- MI_CSFdci_Enable is true.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_nh6PUKNFEeKZoeGA12VHIQ" name="ENABLED_WITH_DCI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_nh6PUaNFEeKZoeGA12VHIQ" annotatedElement="_nh6PUKNFEeKZoeGA12VHIQ">
+            <body>This literal covers the following states of the CSF related MI informations:&#xD;
+- MI_CSF_Enable is true&#xD;
+- MI_CSFrdifdi_Enable is false&#xD;
+- MI_CSFdci_Enable is true.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_AdKOUOxfEeGzwM2Uvwf5Xw" name="ETY_PhyType">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_HbwYIOxfEeGzwM2Uvwf5Xw" name="OTHER"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_I44dcOxfEeGzwM2Uvwf5Xw" name="UNKNOWN"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LGmSMOxfEeGzwM2Uvwf5Xw" name="NONE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MWUNoOxfEeGzwM2Uvwf5Xw" name="2BASE_TL"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Rv4TUOxfEeGzwM2Uvwf5Xw" name="10MBIT/S"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VpLgIOxfEeGzwM2Uvwf5Xw" name="10PASS_TS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_cqwFcOxfEeGzwM2Uvwf5Xw" name="100BASE_T4"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gh9nkOxfEeGzwM2Uvwf5Xw" name="100BASE_X"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_j1jfQOxfEeGzwM2Uvwf5Xw" name="100BASE_T2"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mUjRQOxfEeGzwM2Uvwf5Xw" name="1000BASE_X"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oohfAOxfEeGzwM2Uvwf5Xw" name="1000BASE_T"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_rUCDAOxfEeGzwM2Uvwf5Xw" name="10GBASE-X"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_tu3GsOxfEeGzwM2Uvwf5Xw" name="10GBASE_R"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_wY4c8OxfEeGzwM2Uvwf5Xw" name="10GBASE_W"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_n3YdgCEsEd-ysdtezPKi3w" name="FrameType">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_q3c8QCEsEd-ysdtezPKi3w" name="ADMIT_ONLY_VLAN_TAGGED_FRAMES"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_tKgkACEsEd-ysdtezPKi3w" name="ADMIT_ONLY_UNTAGGED_AND_PRIORITY_TAGGED_FRAMES"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_vRp2sCEsEd-ysdtezPKi3w" name="ADMIT_ALL_FRAMES"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_XmBCIHmuEd2GobjTM4neEA" name="OamPeriod">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_1v9S4GfMEd6DJYBL2b692Q" annotatedElement="_XmBCIHmuEd2GobjTM4neEA">
+          <body>Provides the frequency for the OAM PDU insertion.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_auSaoHmuEd2GobjTM4neEA" name="3,33MS">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_v_-4UGfMEd6DJYBL2b692Q" annotatedElement="_auSaoHmuEd2GobjTM4neEA">
+            <body>Default for protection.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_clyu0HmuEd2GobjTM4neEA" name="10MS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dwJpIHmuEd2GobjTM4neEA" name="100MS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_e6NogHmuEd2GobjTM4neEA" name="1S"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gBSlUHmuEd2GobjTM4neEA" name="10S"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_hFFkoHmuEd2GobjTM4neEA" name="1MIN"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iRiJoHmuEd2GobjTM4neEA" name="10MIN"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_tjBD8CdpEd-sQoLP0EY2BQ" name="PcpCoding">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ZJwZ4CdrEd-sQoLP0EY2BQ" annotatedElement="_tjBD8CdpEd-sQoLP0EY2BQ">
+          <body>This enum models the coding of the Priority Code Point as defined in section &quot;Priority Code Point encoding&quot; of IEEE 802.1Q.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8pdeoCdpEd-sQoLP0EY2BQ" name="8P0D"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__Lsx4CdpEd-sQoLP0EY2BQ" name="7P1D"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_BYL3kCdqEd-sQoLP0EY2BQ" name="6P2D"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_DW94cCdqEd-sQoLP0EY2BQ" name="5P3D"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_HRtPsCdqEd-sQoLP0EY2BQ" name="DEI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_W7UW8CdsEd-sQoLP0EY2BQ" annotatedElement="_HRtPsCdqEd-sQoLP0EY2BQ">
+            <body>This enumeration value means that all priorities should be drop eligible.&#xD;
+DEI = Drop Eligibility Indicator</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_kQIFACelEd-sQoLP0EY2BQ" name="VlanType">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_vsEHYCemEd-sQoLP0EY2BQ" annotatedElement="_kQIFACelEd-sQoLP0EY2BQ">
+          <body>This enumeration contains the Ethertypes defined in IEEE 802.1Q.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_rJUxcCelEd-sQoLP0EY2BQ" name="C_Tag">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Wiv5kCemEd-sQoLP0EY2BQ" annotatedElement="_rJUxcCelEd-sQoLP0EY2BQ">
+            <body>0x8100</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_x-pDcCelEd-sQoLP0EY2BQ" name="S_Tag">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_YVN8wCemEd-sQoLP0EY2BQ" annotatedElement="_x-pDcCelEd-sQoLP0EY2BQ">
+            <body>0x88a8</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_zPRk4CelEd-sQoLP0EY2BQ" name="I_Tag">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_afPkUCemEd-sQoLP0EY2BQ" annotatedElement="_zPRk4CelEd-sQoLP0EY2BQ">
+            <body>88-e7</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_x3G-wDxBEeaRI-H69PghuA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_ITi4QDN-Eea40e5DA9KE3w" name="LpSpecHasAdapterPac" memberEnd="_ITjfUjN-Eea40e5DA9KE3w _ITkGYDN-Eea40e5DA9KE3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ITjfUDN-Eea40e5DA9KE3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ITjfUTN-Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ITkGYDN-Eea40e5DA9KE3w" name="_lpSpec" type="_T7cP0DN7Eea40e5DA9KE3w" association="_ITi4QDN-Eea40e5DA9KE3w"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_3Dz-kDO5Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficCondPac" memberEnd="_3D1zwTO5Eea40e5DA9KE3w _3D3B4DO5Eea40e5DA9KE3w" navigableOwnedEnd="_3D1zwTO5Eea40e5DA9KE3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3D1MsDO5Eea40e5DA9KE3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3D1zwDO5Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_3D3B4DO5Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_3Dz-kDO5Eea40e5DA9KE3w"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_3D1zwTO5Eea40e5DA9KE3w" name="_trafficConditioning" type="_8QR1UK4wEeGjbtFXtCFKWg" aggregation="composite" association="_3Dz-kDO5Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pTncDO5Eea40e5DA9KE3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pcxYDO5Eea40e5DA9KE3w" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_AbxMcDO6Eea40e5DA9KE3w" name="ConnEPSpecHasTrafficShapingPac" memberEnd="_AbyakjO6Eea40e5DA9KE3w _AbzosDO6Eea40e5DA9KE3w" navigableOwnedEnd="_AbyakjO6Eea40e5DA9KE3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AbyakDO6Eea40e5DA9KE3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AbyakTO6Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_AbzosDO6Eea40e5DA9KE3w" name="connectionpointandadapterspec_tapi_eth" type="_7ySKwOuGEeGZr5p9Vdkojw" association="_AbxMcDO6Eea40e5DA9KE3w"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_AbyakjO6Eea40e5DA9KE3w" name="_trafficShaping" type="_8QIrYK4wEeGjbtFXtCFKWg" aggregation="composite" association="_AbxMcDO6Eea40e5DA9KE3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C7qWUDO6Eea40e5DA9KE3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C7ySIDO6Eea40e5DA9KE3w" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="__17LsDN9Eea40e5DA9KE3w" name="LpSpecHasTerminationPac" memberEnd="__18Z0jN9Eea40e5DA9KE3w __19A4DN9Eea40e5DA9KE3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__18Z0DN9Eea40e5DA9KE3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__18Z0TN9Eea40e5DA9KE3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="__19A4DN9Eea40e5DA9KE3w" name="_lpSpec" type="_T7cP0DN7Eea40e5DA9KE3w" association="__17LsDN9Eea40e5DA9KE3w"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_fhZtAEWoEeaB8vMnkFQLXQ" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_kV26gEWoEeaB8vMnkFQLXQ">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_kWJ1cEWoEeaB8vMnkFQLXQ">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_kWcwYEWoEeaB8vMnkFQLXQ">
+        <importedPackage xmi:type="uml:Model" href="TapiConnectivity.uml#_6fxZsDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_Wz7t8EWlEeaB8vMnkFQLXQ">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_W0iLBUWlEeaB8vMnkFQLXQ" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W0iLBkWlEeaB8vMnkFQLXQ" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W0iLB0WlEeaB8vMnkFQLXQ" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W0iLCEWlEeaB8vMnkFQLXQ" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W0iLCUWlEeaB8vMnkFQLXQ" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W0iLCkWlEeaB8vMnkFQLXQ" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_W0Fe8EWlEeaB8vMnkFQLXQ" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <ecore:EAnnotation xmi:id="_U1TiMCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1TiMSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1TiMiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1TiMyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UJQCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UJQSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UJQiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UJQyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UJRCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UJRSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UJRiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UJRyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UJSCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UJSSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UwUCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UwUSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UwUiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UwUyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1UwVCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1UwVSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1VXYCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1VXYSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1VXYiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1VXYyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1VXZCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1VXZSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1VXZiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1VXZyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1VXaCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1V-cCFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1V-cSFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1V-ciFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1V-cyFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1V-dCFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1V-dSFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1V-diFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1V-dyFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1V-eCFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1WlgCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1WlgSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1WlgiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1WlgyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1WlhCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1WlhSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XMkCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XMkSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XMkiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XMkyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XMlCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XMlSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XMliFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XMlyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XMmCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XMmSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XzoCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XzoSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XzoiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XzoyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XzpCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XzpSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1XzpiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1XzpyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1YasCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1YasSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1YasiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1YasyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1YatCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1YatSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1YatiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1YatyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1YauCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1YauSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1Zo0CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1Zo0SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1Zo0iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1Zo0yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1Zo1CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1Zo1SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1Zo1iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1Zo1yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1Zo2CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1Zo2SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1Zo2iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1Zo2yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1aP4CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1aP4SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1aP4iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1aP4yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1aP5CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1aP5SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1aP5iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1aP5yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1a28CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1a28SFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1a28iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1a28yFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1a29CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1a29SFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1a29iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1a29yFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1beACFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1beASFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1beAiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1beAyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1beBCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1beBSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1beBiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1beByFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1beCCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1beCSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1cFECFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1cFESFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1cFEiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1cFEyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1cFFCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1cFFSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1cFFiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1cFFyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1cFGCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1cFGSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1csICFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1csISFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1csIiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1csIyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1csJCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1csJSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1csJiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1csJyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1csKCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1csKSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1dTMCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1dTMSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1dTMiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1dTMyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1dTNCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1dTNSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1dTNiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1dTNyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1dTOCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1dTOSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1dTOiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1dTOyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1d6QCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1d6QSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1d6QiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1d6QyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1d6RCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1d6RSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1d6RiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1d6RyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1d6SCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1d6SSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1ehUCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1ehUSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1ehUiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1ehUyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1ehVCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1ehVSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1ehViFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1ehVyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1ehWCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1ehWSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1ehWiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1ehWyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fIYCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fIYSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fIYiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fIYyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fIZCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fIZSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fIZiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fIZyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fIaCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fIaSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fvcCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fvcSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fvciFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fvcyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1fvdCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1fvdSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1gWgCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1gWgSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1g9kCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1g9kSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1g9kiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1g9kyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1g9lCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1g9lSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1g9liFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1g9lyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1g9mCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1g9mSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1hkoCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1hkoSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1hkoiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1hkoyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1hkpCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1hkpSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1hkpiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1hkpyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1hkqCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1hkqSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iLsCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iLsSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iLsiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iLsyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iLtCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iLtSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iywCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iywSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iywiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iywyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iyxCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iyxSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iyxiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iyxyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iyyCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iyySFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1iyyiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1iyyyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1jZ0CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1jZ0SFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1jZ0iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1jZ0yFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1jZ1CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1jZ1SFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1jZ1iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1jZ1yFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1kA4CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1kA4SFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1kn8CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1kn8SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1kn8iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1kn8yFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1kn9CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1kn9SFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1kn9iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1kn9yFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1lPACFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1lPASFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1lPAiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1lPAyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1lPBCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1lPBSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1l2ECFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1l2ESFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1l2EiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1l2EyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1l2FCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1l2FSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1l2FiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1l2FyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1mdICFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1mdISFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nEMCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nEMSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nEMiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nEMyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nENCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nENSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nENiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nENyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nEOCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nEOSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nrQCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nrQSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nrQiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nrQyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nrRCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nrRSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nrRiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nrRyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nrSCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nrSSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1nrSiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1nrSyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1oSUCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1oSUSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1oSUiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1oSUyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1oSVCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1oSVSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1oSViFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1oSVyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1oSWCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1oSWSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1o5YCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1o5YSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1o5YiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1o5YyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1o5ZCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1o5ZSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1o5ZiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1o5ZyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1o5aCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1o5aSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1pgcCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1pgcSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1pgciFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1pgcyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1pgdCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1pgdSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1pgdiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1pgdyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1pgeCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1pgeSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1qHgCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1qHgSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1qHgiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1qHgyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1qHhCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1qHhSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1qHhiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1qHhyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1rVoCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1rVoSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1rVoiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1rVoyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1rVpCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1rVpSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1r8sCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1r8sSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1sjwCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1sjwSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tK0CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tK0SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tK0iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tK0yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tK1CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tK1SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tK1iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tK1yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tK2CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tK2SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tx4CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tx4SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1tx4iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1tx4yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1uY8CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1uY8SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1uY8iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1uY8yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1uY9CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1uY9SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1uY9iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1uY9yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1uY-CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1uY-SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vAACFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vAASFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vAAiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vAAyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vABCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vABSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vABiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vAByFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vACCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vACSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vnECFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vnESFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vnEiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vnEyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vnFCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vnFSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vnFiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vnFyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1vnGCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1vnGSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1wOICFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1wOISFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1wOIiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1wOIyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1wOJCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1wOJSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1wOJiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1wOJyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1wOKCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1wOKSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1wOKiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1w1MCFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1w1MSFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1w1MiFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1w1MyFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1w1NCFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1w1NSFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1w1NiFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1w1NyFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1w1OCFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1w1OSFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1w1OiFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1xcQCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1xcQSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1xcQiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1xcQyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1xcRCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1xcRSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1xcRiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1xcRyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1yDUCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1yDUSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1yDUiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1yDUyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1yDVCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1yDVSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1yDViFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1yDVyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1yqYCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1yqYSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1zRcCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1zRcSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1z4gCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1z4gSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1z4giFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1z4gyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1z4hCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1z4hSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1z4hiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1z4hyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1z4iCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1z4iSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U10fkCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U10fkSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U10fkiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U10fkyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U10flCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U10flSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U10fliFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U10flyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U10fmCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U10fmSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U10fmiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U10fmyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11GoCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11GoSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11GoiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11GoyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11GpCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11GpSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11GpiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11GpyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11GqCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11GqSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11tsCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11tsSFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U11tsiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U11tsyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U12UwCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U12UwSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U12UwiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U12UwyFqEeWrHvhCHfosZA" showParent="QualifiedName"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U12UxCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U12UxSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U12UxiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U12UxyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U12UyCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U12UySFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1270CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1270SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1270iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1270yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1271CFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1271SFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U1271iFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U1271yFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GMYCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GMYSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GzcCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GzcSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GzciFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GzcyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GzdCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GzdSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GzdiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GzdyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GzeCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GzeSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2GzeiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2GzeyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2HagCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2HagSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2HagiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2HagyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2HahCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2HahSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2IBkCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2IBkSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2IBkiFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2IBkyFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <ecore:EAnnotation xmi:id="_U2IBlCFqEeWrHvhCHfosZA" source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <contents xmi:type="ecore:EObject" xmi:id="_U2IBlSFqEeWrHvhCHfosZA" showParent="Name"/>
+  </ecore:EAnnotation>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbTA4CvQEeWNKd-GIYRskA" base_Class="_LH3dQJNdEdyK0-bKI_zx1A" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbTA4SvQEeWNKd-GIYRskA" base_StructuralFeature="_yvHlUXnNEd2GobjTM4neEA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbTA4ivQEeWNKd-GIYRskA" base_Class="_jIOd8JNoEdyK0-bKI_zx1A" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbTA4yvQEeWNKd-GIYRskA" base_StructuralFeature="_G3-DkHnGEd2GobjTM4neEA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbZHgCvQEeWNKd-GIYRskA" base_Class="_9YdbEJNpEdyK0-bKI_zx1A" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHgSvQEeWNKd-GIYRskA" base_StructuralFeature="_dOFTUJQvEdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbZHgivQEeWNKd-GIYRskA" base_Class="_KlqYAJNxEdyK0-bKI_zx1A" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHgyvQEeWNKd-GIYRskA" base_StructuralFeature="_dORgkJQvEdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHhCvQEeWNKd-GIYRskA" base_StructuralFeature="_G3-Dk3nGEd2GobjTM4neEA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHhSvQEeWNKd-GIYRskA" base_StructuralFeature="_yvRWUHnNEd2GobjTM4neEA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbZHhivQEeWNKd-GIYRskA" base_Class="_2bNC8Hs1Ed2PiqoIrXuTbA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHhyvQEeWNKd-GIYRskA" base_StructuralFeature="_PzqLAHmsEd2GobjTM4neEA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..8191" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbZHiCvQEeWNKd-GIYRskA" base_Class="_5tTs4Hs1Ed2PiqoIrXuTbA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHiSvQEeWNKd-GIYRskA" base_StructuralFeature="_w3AmUJNhEdyK0-bKI_zx1A" attributeValueChangeNotification="YES" valueRange="0..8191" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHiivQEeWNKd-GIYRskA" base_StructuralFeature="_NrL8UHtREd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHiyvQEeWNKd-GIYRskA" base_StructuralFeature="_NrCLUXtREd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHjCvQEeWNKd-GIYRskA" base_StructuralFeature="_W4OTpHtREd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHjSvQEeWNKd-GIYRskA" base_StructuralFeature="_W4OToXtREd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbZHjivQEeWNKd-GIYRskA" base_Class="_hTWOsHtREd2PiqoIrXuTbA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbZHjyvQEeWNKd-GIYRskA" base_Class="_7tJM8HtREd2PiqoIrXuTbA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHkCvQEeWNKd-GIYRskA" base_StructuralFeature="_g6M5cHtSEd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbZHkSvQEeWNKd-GIYRskA" base_StructuralFeature="_g6DIcXtSEd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOICvQEeWNKd-GIYRskA" base_StructuralFeature="_zsbCVHtSEd2PiqoIrXuTbA" valueRange="eth_connectionterminationpointsource valueRange" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOISvQEeWNKd-GIYRskA" base_StructuralFeature="_zsbCUXtSEd2PiqoIrXuTbA" valueRange="mepsource valueRange" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOIivQEeWNKd-GIYRskA" base_StructuralFeature="_BVoqAntTEd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOIyvQEeWNKd-GIYRskA" base_StructuralFeature="_BVe5AXtTEd2PiqoIrXuTbA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbfOJCvQEeWNKd-GIYRskA" base_Class="_q3kNQHzNEd2S7rQMqMRYLA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbfOJSvQEeWNKd-GIYRskA" base_Operation="_PwxOYFGdEd6JXKS-hDEWDw" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbfOJivQEeWNKd-GIYRskA" base_Operation="_U3G2EFGdEd6JXKS-hDEWDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOJyvQEeWNKd-GIYRskA" base_StructuralFeature="_17X49HzNEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOKCvQEeWNKd-GIYRskA" base_StructuralFeature="_17X48XzNEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOKSvQEeWNKd-GIYRskA" base_StructuralFeature="_4Hl45HzNEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOKivQEeWNKd-GIYRskA" base_StructuralFeature="_4Hl44XzNEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOKyvQEeWNKd-GIYRskA" base_StructuralFeature="_FXBuonzOEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOLCvQEeWNKd-GIYRskA" base_StructuralFeature="_FW39oXzOEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOLSvQEeWNKd-GIYRskA" base_StructuralFeature="_TBbCE3zOEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOLivQEeWNKd-GIYRskA" base_StructuralFeature="_TBbCEHzOEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbfOLyvQEeWNKd-GIYRskA" base_Class="_y-K5QHzTEd2S7rQMqMRYLA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOMCvQEeWNKd-GIYRskA" base_StructuralFeature="_J3_wsHzUEd2S7rQMqMRYLA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbfOMSvQEeWNKd-GIYRskA" base_StructuralFeature="_PFLnQHzUEd2S7rQMqMRYLA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUwCvQEeWNKd-GIYRskA" base_StructuralFeature="_QoRxsHzUEd2S7rQMqMRYLA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mblUwSvQEeWNKd-GIYRskA" base_Class="_eo4lsHzUEd2S7rQMqMRYLA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mblUwivQEeWNKd-GIYRskA" base_Class="_PuDIoHzVEd2S7rQMqMRYLA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUwyvQEeWNKd-GIYRskA" base_StructuralFeature="_PuMSknzVEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUxCvQEeWNKd-GIYRskA" base_StructuralFeature="_PuMSoXzVEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUxSvQEeWNKd-GIYRskA" base_StructuralFeature="_s0Va9HzYEd2S7rQMqMRYLA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUxivQEeWNKd-GIYRskA" base_StructuralFeature="_s0Va8XzYEd2S7rQMqMRYLA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mblUxyvQEeWNKd-GIYRskA" base_Class="_n4NGYLFVEd2MOdzuQUV2bQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUyCvQEeWNKd-GIYRskA" base_StructuralFeature="_WztYsLFXEd2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUySvQEeWNKd-GIYRskA" base_StructuralFeature="_jBTYULGWEd2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mblUyivQEeWNKd-GIYRskA" base_Class="_hq-gYLFbEd2MOdzuQUV2bQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUyyvQEeWNKd-GIYRskA" base_StructuralFeature="_9PcskLFcEd2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUzCvQEeWNKd-GIYRskA" base_StructuralFeature="_1dFfMFGcEd6JXKS-hDEWDw" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUzSvQEeWNKd-GIYRskA" base_StructuralFeature="_O9UTJLF2Ed2MOdzuQUV2bQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUzivQEeWNKd-GIYRskA" base_StructuralFeature="_O9UTIbF2Ed2MOdzuQUV2bQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblUzyvQEeWNKd-GIYRskA" base_StructuralFeature="_qbzBgLF2Ed2MOdzuQUV2bQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mblU0CvQEeWNKd-GIYRskA" base_StructuralFeature="_qbp3kbF2Ed2MOdzuQUV2bQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mblU0SvQEeWNKd-GIYRskA" base_Class="_OUb0kLF-Ed2MOdzuQUV2bQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbYCvQEeWNKd-GIYRskA" base_StructuralFeature="_OUb0lLF-Ed2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbYSvQEeWNKd-GIYRskA" base_StructuralFeature="_ETNv0LGVEd2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbrbYivQEeWNKd-GIYRskA" base_Class="_AwH-MLGCEd2MOdzuQUV2bQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbYyvQEeWNKd-GIYRskA" base_StructuralFeature="_G4s2QLGTEd2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbZCvQEeWNKd-GIYRskA" base_StructuralFeature="_37XpYLGUEd2MOdzuQUV2bQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbrbZSvQEeWNKd-GIYRskA" base_Class="_pSB6ELGXEd2MOdzuQUV2bQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbZivQEeWNKd-GIYRskA" base_StructuralFeature="_pSB6FLGXEd2MOdzuQUV2bQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbZyvQEeWNKd-GIYRskA" base_StructuralFeature="_9l4sNLJEEd2akMdVSPw5LA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbaCvQEeWNKd-GIYRskA" base_StructuralFeature="_9l4sMbJEEd2akMdVSPw5LA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbaSvQEeWNKd-GIYRskA" base_StructuralFeature="_Mhyq0LJFEd2akMdVSPw5LA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbaivQEeWNKd-GIYRskA" base_StructuralFeature="_Mhpg4bJFEd2akMdVSPw5LA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbayvQEeWNKd-GIYRskA" base_StructuralFeature="_dCbyoLJFEd2akMdVSPw5LA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbrbbCvQEeWNKd-GIYRskA" base_StructuralFeature="_dCSosbJFEd2akMdVSPw5LA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbrbbSvQEeWNKd-GIYRskA" base_Class="_aoUckMa9Ed2dpqWvHBkVSw" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbrbbivQEeWNKd-GIYRskA" base_Class="_udkZQEVwEd6WrOYSXNJbnw" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbrbbyvQEeWNKd-GIYRskA" base_Class="_hGuCQFEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbcCvQEeWNKd-GIYRskA" base_Operation="_hGuCQ1EIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbcSvQEeWNKd-GIYRskA" base_Operation="_hGuCRFEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbcivQEeWNKd-GIYRskA" base_Operation="_hGuCRVEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbcyvQEeWNKd-GIYRskA" base_Operation="_hGuCRlEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbdCvQEeWNKd-GIYRskA" base_Operation="_hGuCSFEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbdSvQEeWNKd-GIYRskA" base_Operation="_hGuCSVEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbdivQEeWNKd-GIYRskA" base_Operation="_hGuCSlEIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbrbdyvQEeWNKd-GIYRskA" base_Operation="_hGuCS1EIEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbrbeCvQEeWNKd-GIYRskA" base_Class="_ShisIFEJEd6VSrclB-Ybig" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiACvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEs1EWEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiASvQEeWNKd-GIYRskA" base_StructuralFeature="_tsg8wFEWEd6VSrclB-Ybig" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiAivQEeWNKd-GIYRskA" base_StructuralFeature="_vJKg8FEWEd6VSrclB-Ybig" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiAyvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEsFEWEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiBCvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEtFEWEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See corresponding Enum." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiBSvQEeWNKd-GIYRskA" base_StructuralFeature="_3vQ0EFEWEd6VSrclB-Ybig" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiBivQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEslEWEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0, 1, 2, 3, 4, 5, 6, 7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiByvQEeWNKd-GIYRskA" base_StructuralFeature="_ShisIVEJEd6VSrclB-Ybig" attributeValueChangeNotification="YES" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiCCvQEeWNKd-GIYRskA" base_Operation="_ShisIlEJEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbxiCSvQEeWNKd-GIYRskA" base_Class="_ShisI1EJEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiCivQEeWNKd-GIYRskA" base_StructuralFeature="_DCDeUFEUEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiCyvQEeWNKd-GIYRskA" base_StructuralFeature="_IqBMYFEUEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiDCvQEeWNKd-GIYRskA" base_StructuralFeature="_biD4JFEOEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiDSvQEeWNKd-GIYRskA" base_StructuralFeature="_biD4IVEOEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiDivQEeWNKd-GIYRskA" base_StructuralFeature="_juKW5FEOEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbxiDyvQEeWNKd-GIYRskA" base_StructuralFeature="_juKW4VEOEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbxiECvQEeWNKd-GIYRskA" base_Class="_pH_vEFEeEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiESvQEeWNKd-GIYRskA" base_Operation="_3vbxAVEHEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiEivQEeWNKd-GIYRskA" base_Operation="_3vbxAlEHEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiEyvQEeWNKd-GIYRskA" base_Operation="_3vbxAFEHEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiFCvQEeWNKd-GIYRskA" base_Operation="__u--VFEDEd6VSrclB-Ybig" isOperationIdempotent="true" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mbxiFSvQEeWNKd-GIYRskA" base_Class="_mFSZwFEjEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiFivQEeWNKd-GIYRskA" base_Operation="_mFSZzlEjEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiFyvQEeWNKd-GIYRskA" base_Operation="_mFSZ1FEjEd6VSrclB-Ybig" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mbxiGCvQEeWNKd-GIYRskA" base_Operation="__u--UlEDEd6VSrclB-Ybig" isOperationIdempotent="true" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3ooCvQEeWNKd-GIYRskA" base_StructuralFeature="_gIj0LbGXEd2MOdzuQUV2bQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3ooSvQEeWNKd-GIYRskA" base_StructuralFeature="_gIj0L7GXEd2MOdzuQUV2bQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3ooivQEeWNKd-GIYRskA" base_StructuralFeature="_oF4ZgVEYEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3ooyvQEeWNKd-GIYRskA" base_StructuralFeature="_oF4Zg1EYEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3opCvQEeWNKd-GIYRskA" base_StructuralFeature="_oGBjcVEYEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3opSvQEeWNKd-GIYRskA" base_StructuralFeature="_uyMrEVEZEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3opivQEeWNKd-GIYRskA" base_StructuralFeature="_uyMrE1EZEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3opyvQEeWNKd-GIYRskA" base_StructuralFeature="_uyMrFVEZEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3oqCvQEeWNKd-GIYRskA" base_StructuralFeature="_zeuZsVEbEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3oqSvQEeWNKd-GIYRskA" base_StructuralFeature="_zeuZt1EbEd6VSrclB-Ybig" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mb3oqivQEeWNKd-GIYRskA" base_Class="_YQhwIJKuEdybINoKQq_hfQ" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mb3oqyvQEeWNKd-GIYRskA" base_Class="_YybDQHzBEd2S7rQMqMRYLA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3orCvQEeWNKd-GIYRskA" base_StructuralFeature="_n-WkYH2REd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3orSvQEeWNKd-GIYRskA" base_StructuralFeature="_uGZgsH2REd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3orivQEeWNKd-GIYRskA" base_StructuralFeature="_3k8M0X2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3oryvQEeWNKd-GIYRskA" base_StructuralFeature="_546akX2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3osCvQEeWNKd-GIYRskA" base_StructuralFeature="_64irkH2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3osSvQEeWNKd-GIYRskA" base_StructuralFeature="_74KVgX2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3osivQEeWNKd-GIYRskA" base_StructuralFeature="_84r-YX2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3osyvQEeWNKd-GIYRskA" base_StructuralFeature="_LC1I4X2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3otCvQEeWNKd-GIYRskA" base_StructuralFeature="_L18A0X2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3otSvQEeWNKd-GIYRskA" base_StructuralFeature="_MoKH8X2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3otivQEeWNKd-GIYRskA" base_StructuralFeature="_NdWqkX2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mb3otyvQEeWNKd-GIYRskA" base_Class="_phqnwHzBEd2S7rQMqMRYLA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb3ouCvQEeWNKd-GIYRskA" base_StructuralFeature="_63mC0H2zEd2CEuIB5xoW6g" valueRange="NA" partOfObjectKey="1" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vQCvQEeWNKd-GIYRskA" base_StructuralFeature="_9dJv0H2zEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vQSvQEeWNKd-GIYRskA" base_StructuralFeature="_AJG_wH20Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vQivQEeWNKd-GIYRskA" base_StructuralFeature="_8sc2MX20Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vQyvQEeWNKd-GIYRskA" base_StructuralFeature="_97k7wH20Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vRCvQEeWNKd-GIYRskA" base_StructuralFeature="_-wxeYX20Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vRSvQEeWNKd-GIYRskA" base_StructuralFeature="_BDZoUX21Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vRivQEeWNKd-GIYRskA" base_StructuralFeature="_CaunoX21Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mb9vRyvQEeWNKd-GIYRskA" base_Class="_0LgBQH2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vSCvQEeWNKd-GIYRskA" base_StructuralFeature="_0LgBQ32SEd23zLSjbYwcFw" valueRange="NA" partOfObjectKey="1" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vSSvQEeWNKd-GIYRskA" base_StructuralFeature="_0LgBRH2SEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vSivQEeWNKd-GIYRskA" base_StructuralFeature="_HLiWIH2zEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vSyvQEeWNKd-GIYRskA" base_StructuralFeature="_DOq38H2zEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vTCvQEeWNKd-GIYRskA" base_StructuralFeature="_3lF90H2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vTSvQEeWNKd-GIYRskA" base_StructuralFeature="_55DkgH2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vTivQEeWNKd-GIYRskA" base_StructuralFeature="_64irk32TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vTyvQEeWNKd-GIYRskA" base_StructuralFeature="_74UGgH2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vUCvQEeWNKd-GIYRskA" base_StructuralFeature="_84r-ZH2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vUSvQEeWNKd-GIYRskA" base_StructuralFeature="_LC-S0n2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vUivQEeWNKd-GIYRskA" base_StructuralFeature="_L18A1H2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vUyvQEeWNKd-GIYRskA" base_StructuralFeature="_MoKH9H2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vVCvQEeWNKd-GIYRskA" base_StructuralFeature="_NdWqlH2UEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vVSvQEeWNKd-GIYRskA" base_StructuralFeature="_8smnMX20Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vVivQEeWNKd-GIYRskA" base_StructuralFeature="_97k7w320Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mb9vVyvQEeWNKd-GIYRskA" base_StructuralFeature="_-wxeZH20Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mcD14CvQEeWNKd-GIYRskA" base_StructuralFeature="_BDZoVH21Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mcD14SvQEeWNKd-GIYRskA" base_StructuralFeature="_Ca3xkH21Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mcD14ivQEeWNKd-GIYRskA" base_Class="_cJgTgLFpEd2MOdzuQUV2bQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mcD14yvQEeWNKd-GIYRskA" base_StructuralFeature="_cJgTh7FpEd2MOdzuQUV2bQ" valueRange="NA" partOfObjectKey="1" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mdfZVivQEeWNKd-GIYRskA" base_StructuralFeature="_egYId2ruEd6ERPrpHLFGMw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mdfZWCvQEeWNKd-GIYRskA" base_StructuralFeature="_egYIdGruEd6ERPrpHLFGMw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mdlf4CvQEeWNKd-GIYRskA" base_StructuralFeature="_egYIeWruEd6ERPrpHLFGMw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mdxtOivQEeWNKd-GIYRskA" base_Class="_uvYUEJK0EdybINoKQq_hfQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mdxtOyvQEeWNKd-GIYRskA" base_StructuralFeature="_x0fZ8JKrEdybINoKQq_hfQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zwCvQEeWNKd-GIYRskA" base_Class="_ECin4H2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zwSvQEeWNKd-GIYRskA" base_StructuralFeature="_X9EAIH2TEd23zLSjbYwcFw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zwivQEeWNKd-GIYRskA" base_Class="_O3vP0H2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zwyvQEeWNKd-GIYRskA" base_StructuralFeature="_9ei-UH2wEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zxCvQEeWNKd-GIYRskA" base_Class="_PMKAoH2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zxSvQEeWNKd-GIYRskA" base_StructuralFeature="_t5gjIH2wEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zxivQEeWNKd-GIYRskA" base_Class="_PeVVwH2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zxyvQEeWNKd-GIYRskA" base_StructuralFeature="_FrXOwH2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zyCvQEeWNKd-GIYRskA" base_Class="_P9U-4H2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zySvQEeWNKd-GIYRskA" base_StructuralFeature="_MNffAH2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zyivQEeWNKd-GIYRskA" base_Class="_cyYlwH2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zyyvQEeWNKd-GIYRskA" base_StructuralFeature="_RL7u8H2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zzCvQEeWNKd-GIYRskA" base_StructuralFeature="_WnuCMH2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3zzSvQEeWNKd-GIYRskA" base_Class="_dEaJ4H2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zzivQEeWNKd-GIYRskA" base_StructuralFeature="_dhZPwH2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3zzyvQEeWNKd-GIYRskA" base_StructuralFeature="_n2Qx0H2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3z0CvQEeWNKd-GIYRskA" base_StructuralFeature="_ruqmwH2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3z0SvQEeWNKd-GIYRskA" base_Class="_dX7i0H2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3z0ivQEeWNKd-GIYRskA" base_StructuralFeature="_27tG8H2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3z0yvQEeWNKd-GIYRskA" base_StructuralFeature="_7KA6cH2xEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3z1CvQEeWNKd-GIYRskA" base_StructuralFeature="_AZ44oH2yEd2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3z1SvQEeWNKd-GIYRskA" base_Class="_m4DOMH2SEd23zLSjbYwcFw" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3z1ivQEeWNKd-GIYRskA" base_Class="_bR1gkH20Ed2CEuIB5xoW6g" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3z1yvQEeWNKd-GIYRskA" base_StructuralFeature="_bR1gk320Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3z2CvQEeWNKd-GIYRskA" base_Class="_bofGAH20Ed2CEuIB5xoW6g" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md3z2SvQEeWNKd-GIYRskA" base_StructuralFeature="_bofGA320Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md3z2ivQEeWNKd-GIYRskA" base_Class="_cLqEgH20Ed2CEuIB5xoW6g" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md96YCvQEeWNKd-GIYRskA" base_StructuralFeature="_cLqEg320Ed2CEuIB5xoW6g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md96ZSvQEeWNKd-GIYRskA" base_Class="_T7Mj8JQ1EdyEFKh3Yw3Zsg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md96ZivQEeWNKd-GIYRskA" base_StructuralFeature="_W42LYJQ2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md96ZyvQEeWNKd-GIYRskA" base_Class="_11A-EJQ1EdyEFKh3Yw3Zsg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md96aCvQEeWNKd-GIYRskA" base_StructuralFeature="_VHSuMJQ2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md96aSvQEeWNKd-GIYRskA" base_Class="_8GaqsJQ1EdyEFKh3Yw3Zsg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md96aivQEeWNKd-GIYRskA" base_StructuralFeature="_WGIVAJQ2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_md96ayvQEeWNKd-GIYRskA" base_Class="_IBadEJQ2EdyEFKh3Yw3Zsg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_md96bCvQEeWNKd-GIYRskA" base_StructuralFeature="_T-ONUZQ2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meEBACvQEeWNKd-GIYRskA" base_Class="_hd7eQJQ3EdyEFKh3Yw3Zsg" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meEBASvQEeWNKd-GIYRskA" base_Class="_kcp5MJQ3EdyEFKh3Yw3Zsg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBAivQEeWNKd-GIYRskA" base_StructuralFeature="_T-UT8JQ2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBAyvQEeWNKd-GIYRskA" base_StructuralFeature="_VHSuM5Q2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBBCvQEeWNKd-GIYRskA" base_StructuralFeature="_WGIVA5Q2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBBSvQEeWNKd-GIYRskA" base_StructuralFeature="_W42LY5Q2EdyEFKh3Yw3Zsg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meEBBivQEeWNKd-GIYRskA" base_Class="_s_aKIHnFEd2GobjTM4neEA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBByvQEeWNKd-GIYRskA" base_StructuralFeature="_u_UhgHnHEd2GobjTM4neEA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meEBCCvQEeWNKd-GIYRskA" base_Class="_q7yL4HnNEd2GobjTM4neEA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBCSvQEeWNKd-GIYRskA" base_StructuralFeature="_upySMHnOEd2GobjTM4neEA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBCivQEeWNKd-GIYRskA" base_StructuralFeature="_zDHp8HnOEd2GobjTM4neEA" valueRange="0..4095" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBCyvQEeWNKd-GIYRskA" base_StructuralFeature="_q7yL8nnNEd2GobjTM4neEA" valueRange="see Enumeration" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBDCvQEeWNKd-GIYRskA" base_StructuralFeature="_vOIbgHp1Ed2F76X026nNcA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBDSvQEeWNKd-GIYRskA" base_StructuralFeature="_0_GOcHnOEd2GobjTM4neEA" valueRange="see Enumeration" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meEBDivQEeWNKd-GIYRskA" base_StructuralFeature="__KuU8HnOEd2GobjTM4neEA" valueRange="MacAddress: &#xD;&#xA;01-80-C2-00-00-10, &#xD;&#xA;01-80-C2-00-00-00 to &#xD;&#xA;01-80-C2-00-00-0F, and &#xD;&#xA;01-80-C2-00-00-20 to &#xD;&#xA;01-80-C2-00-00-2F;&#xD;&#xA;&#xD;&#xA;ActionEnum:&#xD;&#xA;PASS, BLOCK" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meEBDyvQEeWNKd-GIYRskA" base_Class="_iuOGkHzYEd2S7rQMqMRYLA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meEBECvQEeWNKd-GIYRskA" base_Parameter="_ljG98FEcEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meEBESvQEeWNKd-GIYRskA" base_Parameter="_1cUSUFEcEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meEBEivQEeWNKd-GIYRskA" base_Parameter="_34qY8FEcEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meEBEyvQEeWNKd-GIYRskA" base_Parameter="_81PAoFEcEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meEBFCvQEeWNKd-GIYRskA" base_Parameter="_81PAo1EcEd6VSrclB-Ybig" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meEBFSvQEeWNKd-GIYRskA" base_Parameter="_81PAolEcEd6VSrclB-Ybig" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHoCvQEeWNKd-GIYRskA" base_Parameter="_K2nQsFEdEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHoSvQEeWNKd-GIYRskA" base_Parameter="_81PAplEcEd6VSrclB-Ybig" valueRange="0, 1, 2, 3, 4, 5, 6, 7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHoivQEeWNKd-GIYRskA" base_Parameter="_81PAp1EcEd6VSrclB-Ybig" valueRange="Depends on the allowed MTU size." support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHoyvQEeWNKd-GIYRskA" base_Parameter="_81PAoVEcEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHpCvQEeWNKd-GIYRskA" base_Parameter="_odyw8FEdEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHpSvQEeWNKd-GIYRskA" base_Parameter="_s0u8AFEdEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHpivQEeWNKd-GIYRskA" base_Parameter="_Xr2L0FEfEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHpyvQEeWNKd-GIYRskA" base_Parameter="_ZvHEEFEfEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHqCvQEeWNKd-GIYRskA" base_Parameter="_m9tE8FEiEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHqSvQEeWNKd-GIYRskA" base_Parameter="_zrC6QFEiEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHqivQEeWNKd-GIYRskA" base_Parameter="_mFSZz1EjEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHqyvQEeWNKd-GIYRskA" base_Parameter="_mFSZ0VEjEd6VSrclB-Ybig" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHrCvQEeWNKd-GIYRskA" base_Parameter="_mFSZ0lEjEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meKHrSvQEeWNKd-GIYRskA" base_Parameter="_mFSZ1VEjEd6VSrclB-Ybig" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meKHsivQEeWNKd-GIYRskA" base_StructuralFeature="_-KAYcHLMEd6R-oxtU8C0HQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meKHsyvQEeWNKd-GIYRskA" base_StructuralFeature="_AL5XsHLNEd6R-oxtU8C0HQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meKHtCvQEeWNKd-GIYRskA" base_StructuralFeature="_Dz-4sHLNEd6R-oxtU8C0HQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meKHtSvQEeWNKd-GIYRskA" base_StructuralFeature="_KoJ7MHLNEd6R-oxtU8C0HQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOQCvQEeWNKd-GIYRskA" base_StructuralFeature="_tDygUKHdEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOQSvQEeWNKd-GIYRskA" base_StructuralFeature="_UFokNKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOQivQEeWNKd-GIYRskA" base_StructuralFeature="_Ugc39KHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOQyvQEeWNKd-GIYRskA" base_StructuralFeature="_UyoNFKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQORCvQEeWNKd-GIYRskA" base_StructuralFeature="_VED7VKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQORSvQEeWNKd-GIYRskA" base_StructuralFeature="_VYLxNKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQORivQEeWNKd-GIYRskA" base_StructuralFeature="_Vsl69KHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQORyvQEeWNKd-GIYRskA" base_StructuralFeature="_V9bzVKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOSCvQEeWNKd-GIYRskA" base_StructuralFeature="_WQqRVKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOSSvQEeWNKd-GIYRskA" base_StructuralFeature="_WpPwdKHeEd6Wos2BGooEOQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOSivQEeWNKd-GIYRskA" base_StructuralFeature="_nqlzgKKMEd6HZZ41m6oXAg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meQOSyvQEeWNKd-GIYRskA" base_Class="_C8IyYK5wEd6cFIpdu8eLhA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meQOTCvQEeWNKd-GIYRskA" base_Class="_XWZTQK50Ed6cFIpdu8eLhA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOTSvQEeWNKd-GIYRskA" base_StructuralFeature="_gtXpsa50Ed6cFIpdu8eLhA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOTivQEeWNKd-GIYRskA" base_StructuralFeature="_gtXpta50Ed6cFIpdu8eLhA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meQOTyvQEeWNKd-GIYRskA" base_Operation="_80JuMK50Ed6cFIpdu8eLhA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meQOUCvQEeWNKd-GIYRskA" base_Operation="_BiJuYK51Ed6cFIpdu8eLhA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meQOUSvQEeWNKd-GIYRskA" base_Class="_1c3s4K6bEd6cFIpdu8eLhA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOUivQEeWNKd-GIYRskA" base_StructuralFeature="_7xo2kK6bEd6cFIpdu8eLhA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOUyvQEeWNKd-GIYRskA" base_StructuralFeature="_7xo2lK6bEd6cFIpdu8eLhA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meQOVCvQEeWNKd-GIYRskA" base_Operation="_UemfkK6cEd6cFIpdu8eLhA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meQOVSvQEeWNKd-GIYRskA" base_Operation="_aO_w4K6cEd6cFIpdu8eLhA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meQOVivQEeWNKd-GIYRskA" base_StructuralFeature="_dZBFUK8qEd6PiOh_CmtkmA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU4CvQEeWNKd-GIYRskA" base_StructuralFeature="_dZBFVK8qEd6PiOh_CmtkmA" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU4SvQEeWNKd-GIYRskA" base_StructuralFeature="_eszVgK83Ed6PiOh_CmtkmA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU4ivQEeWNKd-GIYRskA" base_StructuralFeature="_nfNmUa83Ed6PiOh_CmtkmA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meWU4yvQEeWNKd-GIYRskA" base_Parameter="_pJKKMK84Ed6PiOh_CmtkmA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meWU5CvQEeWNKd-GIYRskA" base_Operation="_Nx7L8K87Ed6PiOh_CmtkmA" isOperationIdempotent="true" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meWU5SvQEeWNKd-GIYRskA" base_Operation="_STboQK87Ed6PiOh_CmtkmA" isOperationIdempotent="true" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU5ivQEeWNKd-GIYRskA" base_StructuralFeature="_ZfbU4K87Ed6PiOh_CmtkmA" attributeValueChangeNotification="YES" valueRange="0, 10 – 1 000 000" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU5yvQEeWNKd-GIYRskA" base_StructuralFeature="_jetogK87Ed6PiOh_CmtkmA" valueRange="10–1 000 000 s" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU6CvQEeWNKd-GIYRskA" base_StructuralFeature="_swANsK87Ed6PiOh_CmtkmA" attributeValueChangeNotification="YES" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU6SvQEeWNKd-GIYRskA" base_StructuralFeature="_5fHkoK87Ed6PiOh_CmtkmA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU6ivQEeWNKd-GIYRskA" base_StructuralFeature="_-zuGcK9qEd6PiOh_CmtkmA" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU6yvQEeWNKd-GIYRskA" base_StructuralFeature="_7Cr9cK9tEd6PiOh_CmtkmA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meWU7CvQEeWNKd-GIYRskA" base_Class="_euub0MI1Ed6E-_NkXJHasg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU7SvQEeWNKd-GIYRskA" base_StructuralFeature="_oFFuQMI1Ed6E-_NkXJHasg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU7ivQEeWNKd-GIYRskA" base_StructuralFeature="_oFPfQsI1Ed6E-_NkXJHasg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU7yvQEeWNKd-GIYRskA" base_StructuralFeature="_4pVHMcI2Ed6E-_NkXJHasg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU8CvQEeWNKd-GIYRskA" base_StructuralFeature="_4pVHNcI2Ed6E-_NkXJHasg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meWU8SvQEeWNKd-GIYRskA" base_Operation="_sUCwEMI3Ed6E-_NkXJHasg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU8ivQEeWNKd-GIYRskA" base_StructuralFeature="_6nWywMI5Ed6E-_NkXJHasg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU9CvQEeWNKd-GIYRskA" base_StructuralFeature="_coxJwMLWEd6YQenVf3pcTg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU9SvQEeWNKd-GIYRskA" base_StructuralFeature="_co66wMLWEd6YQenVf3pcTg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meWU9ivQEeWNKd-GIYRskA" base_StructuralFeature="_huabo8LbEd6YQenVf3pcTg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meWU9yvQEeWNKd-GIYRskA" base_Parameter="_ULvEUMLcEd6YQenVf3pcTg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meWU-CvQEeWNKd-GIYRskA" base_Class="_zUI_oNg5Ed6jmbGvnR96rQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbgCvQEeWNKd-GIYRskA" base_StructuralFeature="_BFgoUdg7Ed6jmbGvnR96rQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbgSvQEeWNKd-GIYRskA" base_StructuralFeature="_BFgoVdg7Ed6jmbGvnR96rQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbgivQEeWNKd-GIYRskA" base_StructuralFeature="_gRDeUdg7Ed6jmbGvnR96rQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbgyvQEeWNKd-GIYRskA" base_StructuralFeature="_gRDeVdg7Ed6jmbGvnR96rQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbhCvQEeWNKd-GIYRskA" base_StructuralFeature="_k8HfQdg7Ed6jmbGvnR96rQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbhSvQEeWNKd-GIYRskA" base_StructuralFeature="_k8HfRdg7Ed6jmbGvnR96rQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbhivQEeWNKd-GIYRskA" base_StructuralFeature="_iysCsNg9Ed6jmbGvnR96rQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbhyvQEeWNKd-GIYRskA" base_StructuralFeature="_6A51wNg9Ed6jmbGvnR96rQ" attributeValueChangeNotification="YES" valueRange="0 .. 10.000 ms" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mecbiCvQEeWNKd-GIYRskA" base_Operation="_rOp3gNg_Ed6jmbGvnR96rQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mecbiSvQEeWNKd-GIYRskA" base_Operation="_u2N0ENg_Ed6jmbGvnR96rQ" isOperationIdempotent="true" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mecbiivQEeWNKd-GIYRskA" base_Operation="_0RQgcNg_Ed6jmbGvnR96rQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mecbiyvQEeWNKd-GIYRskA" base_Operation="_JZ9_kNhAEd6jmbGvnR96rQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mecbjCvQEeWNKd-GIYRskA" base_Operation="_VHfWoNhAEd6jmbGvnR96rQ" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mecbjSvQEeWNKd-GIYRskA" base_Parameter="_m9Mz8NhAEd6jmbGvnR96rQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbjivQEeWNKd-GIYRskA" base_StructuralFeature="_oU3SUOM0Ed6bKNI_ISUo3g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbjyvQEeWNKd-GIYRskA" base_StructuralFeature="_p7dAMeM1Ed6bKNI_ISUo3g" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mecbkCvQEeWNKd-GIYRskA" base_StructuralFeature="_p7mxMeM1Ed6bKNI_ISUo3g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meiiICvQEeWNKd-GIYRskA" base_Operation="_OyDa4OM-Ed6bKNI_ISUo3g" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meiiISvQEeWNKd-GIYRskA" base_Operation="_UEx4wOM-Ed6bKNI_ISUo3g" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meiiIivQEeWNKd-GIYRskA" base_Class="_e9IQcONAEd6bKNI_ISUo3g" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiIyvQEeWNKd-GIYRskA" base_StructuralFeature="_vwnaYOVyEd6DFLLQeSx-cQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiJCvQEeWNKd-GIYRskA" base_StructuralFeature="_24SAoOVyEd6DFLLQeSx-cQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiJSvQEeWNKd-GIYRskA" base_StructuralFeature="_7dIr4OVyEd6DFLLQeSx-cQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meiiJivQEeWNKd-GIYRskA" base_Operation="_BVkSAO4-Ed6_S_YQ08vnYw" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meiiJyvQEeWNKd-GIYRskA" base_Operation="_BVkSBu4-Ed6_S_YQ08vnYw" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_meiiKCvQEeWNKd-GIYRskA" base_Parameter="_BVkSCO4-Ed6_S_YQ08vnYw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meiiKSvQEeWNKd-GIYRskA" base_Operation="_McN2UO4-Ed6_S_YQ08vnYw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiKivQEeWNKd-GIYRskA" base_StructuralFeature="_IJXPIO5AEd6_S_YQ08vnYw" attributeValueChangeNotification="YES" valueRange="10..2000 ms" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiKyvQEeWNKd-GIYRskA" base_StructuralFeature="_30W6IO5AEd6_S_YQ08vnYw" valueRange="0..10.000 ms" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiLCvQEeWNKd-GIYRskA" base_StructuralFeature="_h14B7HsuEd2PiqoIrXuTbA" valueRange="Lock, Normal" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiLSvQEeWNKd-GIYRskA" base_StructuralFeature="_JJfGYCbKEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiLivQEeWNKd-GIYRskA" base_StructuralFeature="_3BAMICbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiLyvQEeWNKd-GIYRskA" base_StructuralFeature="_3ey7YCbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiMCvQEeWNKd-GIYRskA" base_StructuralFeature="_3-PQcCbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiMSvQEeWNKd-GIYRskA" base_StructuralFeature="_4T_eACbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiMivQEeWNKd-GIYRskA" base_StructuralFeature="_4mnfECbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiMyvQEeWNKd-GIYRskA" base_StructuralFeature="_46SB8CbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiNCvQEeWNKd-GIYRskA" base_StructuralFeature="_5ND0ACbLEd-tK43JMxNtYw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiNSvQEeWNKd-GIYRskA" base_StructuralFeature="_h14B9nsuEd2PiqoIrXuTbA" valueRange="Lock, Normal" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meiiNivQEeWNKd-GIYRskA" base_StructuralFeature="_5HJIAG7yEd-KS-RjpPlIeg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoowCvQEeWNKd-GIYRskA" base_StructuralFeature="_5HJIAm7yEd-KS-RjpPlIeg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meoowSvQEeWNKd-GIYRskA" base_Class="_EL9m8LBHEd-cb_q0FhXb-g" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoowivQEeWNKd-GIYRskA" base_StructuralFeature="_m5dgwbBHEd-cb_q0FhXb-g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoowyvQEeWNKd-GIYRskA" base_StructuralFeature="_m5mqsrBHEd-cb_q0FhXb-g" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meooxCvQEeWNKd-GIYRskA" base_StructuralFeature="_BHJ8sLBIEd-cb_q0FhXb-g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meooxSvQEeWNKd-GIYRskA" base_Class="_SpyQECrVEeCLmY2bQg3hqQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meooxivQEeWNKd-GIYRskA" base_StructuralFeature="_djuYoCrWEeCLmY2bQg3hqQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="positive integer" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meooxyvQEeWNKd-GIYRskA" base_Operation="_gv3kgCrWEeCLmY2bQg3hqQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meooyCvQEeWNKd-GIYRskA" base_Operation="_jkBHICrWEeCLmY2bQg3hqQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meooySvQEeWNKd-GIYRskA" base_Operation="_lhVvcCrWEeCLmY2bQg3hqQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_meooyivQEeWNKd-GIYRskA" base_Operation="_m9uN4CrWEeCLmY2bQg3hqQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meooyyvQEeWNKd-GIYRskA" base_StructuralFeature="_FgxeIC0UEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoozCvQEeWNKd-GIYRskA" base_StructuralFeature="_Fg6oEi0UEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoozSvQEeWNKd-GIYRskA" base_StructuralFeature="_Njjo0S0UEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoozivQEeWNKd-GIYRskA" base_StructuralFeature="_NjtZ0C0UEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoozyvQEeWNKd-GIYRskA" base_StructuralFeature="_MvP5MS0jEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoo0CvQEeWNKd-GIYRskA" base_StructuralFeature="_MvZqMC0jEeC5VOR5P4wONQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoo0SvQEeWNKd-GIYRskA" base_StructuralFeature="_tMsb8S0jEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoo0ivQEeWNKd-GIYRskA" base_StructuralFeature="_tM1l4C0jEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meoo0yvQEeWNKd-GIYRskA" base_Class="_N_4lMC0kEeC5VOR5P4wONQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoo1CvQEeWNKd-GIYRskA" base_StructuralFeature="_ibtJIC0kEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meoo1SvQEeWNKd-GIYRskA" base_StructuralFeature="_2OgTUC0mEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meuvYCvQEeWNKd-GIYRskA" base_Class="_9rb-8C0mEeC5VOR5P4wONQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvYSvQEeWNKd-GIYRskA" base_StructuralFeature="_T9OmAS0nEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvYivQEeWNKd-GIYRskA" base_StructuralFeature="_T9YXAC0nEeC5VOR5P4wONQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvYyvQEeWNKd-GIYRskA" base_StructuralFeature="_tIO14S0nEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvZCvQEeWNKd-GIYRskA" base_StructuralFeature="_tIO15S0nEeC5VOR5P4wONQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meuvZSvQEeWNKd-GIYRskA" base_Class="_EJ3lgC0oEeC5VOR5P4wONQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_meuvZivQEeWNKd-GIYRskA" base_Class="_HAZtwC0oEeC5VOR5P4wONQ" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvZyvQEeWNKd-GIYRskA" base_StructuralFeature="_NJBR0S0oEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvaCvQEeWNKd-GIYRskA" base_StructuralFeature="_NJBR1S0oEeC5VOR5P4wONQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvaSvQEeWNKd-GIYRskA" base_StructuralFeature="_WLmsoS0oEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvaivQEeWNKd-GIYRskA" base_StructuralFeature="_WLmspS0oEeC5VOR5P4wONQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvayvQEeWNKd-GIYRskA" base_StructuralFeature="_B1fZAC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="SIZE(1..8)" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvbCvQEeWNKd-GIYRskA" base_StructuralFeature="_Ny8pgC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvbSvQEeWNKd-GIYRskA" base_StructuralFeature="_QsAhUC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="2-octet" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvbivQEeWNKd-GIYRskA" base_StructuralFeature="_Styy4C0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="16 bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvbyvQEeWNKd-GIYRskA" base_StructuralFeature="_VVbjgC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvcCvQEeWNKd-GIYRskA" base_StructuralFeature="_Xkn-8C0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="2-octet" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvcSvQEeWNKd-GIYRskA" base_StructuralFeature="_Zg5eYC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="16-bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvcivQEeWNKd-GIYRskA" base_StructuralFeature="_bXqLsC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvcyvQEeWNKd-GIYRskA" base_StructuralFeature="_dOaR8C0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="16-bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvdCvQEeWNKd-GIYRskA" base_StructuralFeature="_gysRAC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvdSvQEeWNKd-GIYRskA" base_StructuralFeature="_jnIukC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="Size(1..16)" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvdivQEeWNKd-GIYRskA" base_StructuralFeature="_lbEKUC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_meuvdyvQEeWNKd-GIYRskA" base_StructuralFeature="_nUNdQC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="16 bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02ACvQEeWNKd-GIYRskA" base_StructuralFeature="_pjQHsC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02ASvQEeWNKd-GIYRskA" base_StructuralFeature="_rJUtoC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="16 bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02AivQEeWNKd-GIYRskA" base_StructuralFeature="_sv_JcC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="16 bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02AyvQEeWNKd-GIYRskA" base_StructuralFeature="_uZon0C0xEeC5VOR5P4wONQ" attributeValueChangeNotification="NO" valueRange="16 bit" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02BCvQEeWNKd-GIYRskA" base_StructuralFeature="_w0TTcC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="Size(1..8)" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02BSvQEeWNKd-GIYRskA" base_StructuralFeature="_yc6QAC0xEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="Size(1..8)" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02BivQEeWNKd-GIYRskA" base_StructuralFeature="_pU1bwC0yEeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="0..number of ports" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02ByvQEeWNKd-GIYRskA" base_StructuralFeature="_0_3YIC01EeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02CCvQEeWNKd-GIYRskA" base_StructuralFeature="__7TK8C01EeC5VOR5P4wONQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02CSvQEeWNKd-GIYRskA" base_StructuralFeature="_WY4P8TqXEeCu35lketJ8Yg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02CivQEeWNKd-GIYRskA" base_StructuralFeature="_WZLK4DqXEeCu35lketJ8Yg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02CyvQEeWNKd-GIYRskA" base_StructuralFeature="_lKwTYDqYEeCu35lketJ8Yg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02DCvQEeWNKd-GIYRskA" base_StructuralFeature="_lKwTZDqYEeCu35lketJ8Yg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_me02DSvQEeWNKd-GIYRskA" base_Class="_kfrrMDqaEeCu35lketJ8Yg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02DivQEeWNKd-GIYRskA" base_StructuralFeature="_ukk3kDqaEeCu35lketJ8Yg" valueRange="true, false" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02DyvQEeWNKd-GIYRskA" base_StructuralFeature="_clWxkJKBEeC-CLEnZ54sHQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me02ECvQEeWNKd-GIYRskA" base_StructuralFeature="_wjcQoJKBEeC-CLEnZ54sHQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68oCvQEeWNKd-GIYRskA" base_StructuralFeature="_JBRRcJKCEeC-CLEnZ54sHQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68oSvQEeWNKd-GIYRskA" base_StructuralFeature="_aF-voJKCEeC-CLEnZ54sHQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_me68oivQEeWNKd-GIYRskA" base_Operation="_ekJSIJKEEeC-CLEnZ54sHQ" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_me68oyvQEeWNKd-GIYRskA" base_Operation="_gMS7sJKEEeC-CLEnZ54sHQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68pCvQEeWNKd-GIYRskA" base_StructuralFeature="_P8k6EJKrEeCbGfKiQZfIJg" valueRange="see Enumeration" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_me68pSvQEeWNKd-GIYRskA" base_Class="_-A0TIJMuEeCKK9uc7Khnmg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68pivQEeWNKd-GIYRskA" base_StructuralFeature="_-A0TI5MuEeCKK9uc7Khnmg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_me68pyvQEeWNKd-GIYRskA" base_Class="_hBZhAJMvEeCKK9uc7Khnmg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68qCvQEeWNKd-GIYRskA" base_StructuralFeature="_hBZhA5MvEeCKK9uc7Khnmg" valueRange="true, false" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68qSvQEeWNKd-GIYRskA" base_StructuralFeature="_i-TdIZMwEeCKK9uc7Khnmg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68qivQEeWNKd-GIYRskA" base_StructuralFeature="_i-dOIZMwEeCKK9uc7Khnmg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68qyvQEeWNKd-GIYRskA" base_StructuralFeature="_R8wyQZMxEeCKK9uc7Khnmg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68rCvQEeWNKd-GIYRskA" base_StructuralFeature="_R858MJMxEeCKK9uc7Khnmg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68rSvQEeWNKd-GIYRskA" base_StructuralFeature="_dMn88ZMxEeCKK9uc7Khnmg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68rivQEeWNKd-GIYRskA" base_StructuralFeature="_dMxt8JMxEeCKK9uc7Khnmg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68ryvQEeWNKd-GIYRskA" base_StructuralFeature="_mp2qULFXEeC6XaWwVljZZQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68sCvQEeWNKd-GIYRskA" base_StructuralFeature="_AP_XALFYEeC6XaWwVljZZQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68sSvQEeWNKd-GIYRskA" base_StructuralFeature="_WSBq0LFYEeC6XaWwVljZZQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_me68sivQEeWNKd-GIYRskA" base_Operation="_aSOuELGeEeCEz6U6aBks4w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_me68syvQEeWNKd-GIYRskA" base_StructuralFeature="_v2Z2ALHyEeCfvvdYcIeVoQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_me68tCvQEeWNKd-GIYRskA" base_Parameter="_vNwFILHzEeCfvvdYcIeVoQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_me68tSvQEeWNKd-GIYRskA" base_Parameter="_LwJuoLH0EeCfvvdYcIeVoQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_me68tivQEeWNKd-GIYRskA" base_Parameter="_u3IfcLH0EeCfvvdYcIeVoQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_me68tyvQEeWNKd-GIYRskA" base_Parameter="_5HFsULH0EeCfvvdYcIeVoQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_me68uCvQEeWNKd-GIYRskA" base_Parameter="_B43D8LH1EeCfvvdYcIeVoQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfBDQCvQEeWNKd-GIYRskA" base_Parameter="_YYddgLH1EeCfvvdYcIeVoQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfBDQSvQEeWNKd-GIYRskA" base_Parameter="_n2pCwLH1EeCfvvdYcIeVoQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfBDQivQEeWNKd-GIYRskA" base_Parameter="_2cCl4LH1EeCfvvdYcIeVoQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfBDQyvQEeWNKd-GIYRskA" base_Parameter="_2cCl5rH1EeCfvvdYcIeVoQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfBDRCvQEeWNKd-GIYRskA" base_Parameter="_33FyILH2EeCfvvdYcIeVoQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfBDRSvQEeWNKd-GIYRskA" base_Class="_Vdj6YDiDEeGKKvtWtO2aIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDRivQEeWNKd-GIYRskA" base_StructuralFeature="_mT9PwDiDEeGKKvtWtO2aIg" valueRange="-1, 0, 1..4094" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDRyvQEeWNKd-GIYRskA" base_StructuralFeature="_wETvgDiDEeGKKvtWtO2aIg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDSCvQEeWNKd-GIYRskA" base_StructuralFeature="_wEdggDiDEeGKKvtWtO2aIg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfBDSSvQEeWNKd-GIYRskA" base_Class="_VAOosDiEEeGKKvtWtO2aIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDSivQEeWNKd-GIYRskA" base_StructuralFeature="_VAOosziEEeGKKvtWtO2aIg" valueRange="-1, 0, 1..4094" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDSyvQEeWNKd-GIYRskA" base_StructuralFeature="_Z0-xIDiEEeGKKvtWtO2aIg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDTCvQEeWNKd-GIYRskA" base_StructuralFeature="_Z0-xJDiEEeGKKvtWtO2aIg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mfBDTSvQEeWNKd-GIYRskA" base_Operation="_wOAB8EKSEeGOU_Aog4a34g" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDTivQEeWNKd-GIYRskA" base_StructuralFeature="_VRWTkFEEEd6VSrclB-Ybig" attributeValueChangeNotification="YES" valueRange="1s, 1min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDTyvQEeWNKd-GIYRskA" base_StructuralFeature="_VRWTkVEEEd6VSrclB-Ybig" attributeValueChangeNotification="YES" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDUCvQEeWNKd-GIYRskA" base_StructuralFeature="_RFsbQkKUEeGOU_Aog4a34g" attributeValueChangeNotification="YES" valueRange="1s, 1min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDUSvQEeWNKd-GIYRskA" base_StructuralFeature="_RFsbREKUEeGOU_Aog4a34g" attributeValueChangeNotification="YES" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDUivQEeWNKd-GIYRskA" base_StructuralFeature="_ljgjQEKUEeGOU_Aog4a34g" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDUyvQEeWNKd-GIYRskA" base_StructuralFeature="_ORBewEKVEeGOU_Aog4a34g" attributeValueChangeNotification="YES" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfBDVCvQEeWNKd-GIYRskA" base_Class="_SXjBcENUEeGRwI_G1r0rnw" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDVSvQEeWNKd-GIYRskA" base_StructuralFeature="_SXjBd0NUEeGRwI_G1r0rnw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See corresponding Enum." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfBDVivQEeWNKd-GIYRskA" base_StructuralFeature="_SXjBfUNUEeGRwI_G1r0rnw" attributeValueChangeNotification="YES" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mfBDVyvQEeWNKd-GIYRskA" base_Operation="_SXjBfkNUEeGRwI_G1r0rnw" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfHJ4CvQEeWNKd-GIYRskA" base_Class="_0P-7gENUEeGRwI_G1r0rnw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ4SvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7hUNUEeGRwI_G1r0rnw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ4ivQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7iUNUEeGRwI_G1r0rnw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ4yvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7jkNUEeGRwI_G1r0rnw" valueRange="2..10" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ5CvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7k0NUEeGRwI_G1r0rnw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ5SvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7lkNUEeGRwI_G1r0rnw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ5ivQEeWNKd-GIYRskA" base_StructuralFeature="_lzciAUNrEeGRwI_G1r0rnw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ5yvQEeWNKd-GIYRskA" base_StructuralFeature="_lzmTAkNrEeGRwI_G1r0rnw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ6CvQEeWNKd-GIYRskA" base_StructuralFeature="_nkddkUN0EeGRwI_G1r0rnw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ6SvQEeWNKd-GIYRskA" base_StructuralFeature="_nkddlUN0EeGRwI_G1r0rnw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ6ivQEeWNKd-GIYRskA" base_StructuralFeature="_vk1BYEwPEeGk0vxVMJiPiA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ6yvQEeWNKd-GIYRskA" base_StructuralFeature="__0StUFycEeG9K6GVnuYc0w" attributeValueChangeNotification="YES" valueRange="Non-negative" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ7CvQEeWNKd-GIYRskA" base_StructuralFeature="_IsxNEFyhEeG9K6GVnuYc0w" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ7SvQEeWNKd-GIYRskA" base_StructuralFeature="_2fZvcF7qEeGyKcjKnV9Bqg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ7ivQEeWNKd-GIYRskA" base_StructuralFeature="_BRGWcF72EeGyKcjKnV9Bqg" attributeValueChangeNotification="NO" valueRange="cLOC[i], cUNL, cMMG, cUNM, cDEG, cUNP, cUNPr, cRDI, cSSF, cLCK" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ7yvQEeWNKd-GIYRskA" base_StructuralFeature="_A9Y3QGEaEeG_P5asDyU-5Q" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ8CvQEeWNKd-GIYRskA" base_StructuralFeature="_4KxgMGEbEeG_P5asDyU-5Q" attributeValueChangeNotification="NO" isInvariant="true" valueRange="1..239" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfHJ8SvQEeWNKd-GIYRskA" base_Class="_7us8IGEqEeG_P5asDyU-5Q" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ8ivQEeWNKd-GIYRskA" base_StructuralFeature="_Ca6jMWEwEeG_P5asDyU-5Q" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ8yvQEeWNKd-GIYRskA" base_StructuralFeature="_CbEUMmEwEeG_P5asDyU-5Q" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfHJ9CvQEeWNKd-GIYRskA" base_Class="_0SmDII4dEeGi1ZUWXLd2-A" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ9SvQEeWNKd-GIYRskA" base_StructuralFeature="_BGdXMI4eEeGi1ZUWXLd2-A" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfHJ9ivQEeWNKd-GIYRskA" base_StructuralFeature="_BGnIMo4eEeGi1ZUWXLd2-A" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mfHJ9yvQEeWNKd-GIYRskA" base_Operation="_xU8JwI4eEeGi1ZUWXLd2-A" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mfNQgCvQEeWNKd-GIYRskA" base_Operation="_zJw9YI4eEeGi1ZUWXLd2-A" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfNQgivQEeWNKd-GIYRskA" base_Class="_8QIrYK4wEeGjbtFXtCFKWg" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQgyvQEeWNKd-GIYRskA" base_StructuralFeature="_8QIrYq4wEeGjbtFXtCFKWg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQhCvQEeWNKd-GIYRskA" base_StructuralFeature="_8QIrY64wEeGjbtFXtCFKWg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfNQhSvQEeWNKd-GIYRskA" base_Class="_8QR1UK4wEeGjbtFXtCFKWg" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQhivQEeWNKd-GIYRskA" base_StructuralFeature="_8QR1U64wEeGjbtFXtCFKWg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQhyvQEeWNKd-GIYRskA" base_StructuralFeature="_dOlpcK4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQiCvQEeWNKd-GIYRskA" base_StructuralFeature="_dPCVYa4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQiSvQEeWNKd-GIYRskA" base_StructuralFeature="_ooJisK4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQiivQEeWNKd-GIYRskA" base_StructuralFeature="_ooJitK4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQiyvQEeWNKd-GIYRskA" base_StructuralFeature="_xpau4a4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQjCvQEeWNKd-GIYRskA" base_StructuralFeature="_xpkf4q4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQjSvQEeWNKd-GIYRskA" base_StructuralFeature="_z6tcEa4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQjivQEeWNKd-GIYRskA" base_StructuralFeature="_z63NEK4xEeGjbtFXtCFKWg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQjyvQEeWNKd-GIYRskA" base_StructuralFeature="_ru2d0K5FEeGvr_m5yJYoog" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQkCvQEeWNKd-GIYRskA" base_StructuralFeature="_DFS_0K5GEeGvr_m5yJYoog" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQkSvQEeWNKd-GIYRskA" base_StructuralFeature="_Dc1WEK5GEeGvr_m5yJYoog" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQkivQEeWNKd-GIYRskA" base_StructuralFeature="_Dw9L8K5GEeGvr_m5yJYoog" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQkyvQEeWNKd-GIYRskA" base_StructuralFeature="_KSMrYK5GEeGvr_m5yJYoog" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQlCvQEeWNKd-GIYRskA" base_StructuralFeature="_KnNSEK5GEeGvr_m5yJYoog" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQlSvQEeWNKd-GIYRskA" base_StructuralFeature="_lUUGgK5JEeGXRumldg-1oA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQlivQEeWNKd-GIYRskA" base_StructuralFeature="_u9XrcK5JEeGXRumldg-1oA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQlyvQEeWNKd-GIYRskA" base_StructuralFeature="_vWtYgK5JEeGXRumldg-1oA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQmCvQEeWNKd-GIYRskA" base_StructuralFeature="_inWUga5KEeGXRumldg-1oA" valueRange="1..8" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQmSvQEeWNKd-GIYRskA" base_StructuralFeature="_inWUgq5KEeGXRumldg-1oA" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfNQmivQEeWNKd-GIYRskA" base_StructuralFeature="_PHrv4LoIEeGh2ojTLz6Azw" attributeValueChangeNotification="YES" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfTXICvQEeWNKd-GIYRskA" base_StructuralFeature="_UtUisLoIEeGh2ojTLz6Azw" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mfTXISvQEeWNKd-GIYRskA" base_Association="_gtXpsK50Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfTXIivQEeWNKd-GIYRskA" base_StructuralFeature="_Tg7zoOhhEeG35t-G7oiZlg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZdySvQEeWNKd-GIYRskA" base_StructuralFeature="_2QoroOt8EeGPOswgCwFOKw" attributeValueChangeNotification="YES" valueRange="SSF, PLL, TLL" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfZdyivQEeWNKd-GIYRskA" base_Class="_7ySKwOuGEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZdyyvQEeWNKd-GIYRskA" base_StructuralFeature="_Osz7EOuHEeGZr5p9Vdkojw" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:Choice xmi:id="_mfZdzCvQEeWNKd-GIYRskA" base_DataType="_v3pIQOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZdzSvQEeWNKd-GIYRskA" base_StructuralFeature="_4sRKIOuIEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZdzivQEeWNKd-GIYRskA" base_StructuralFeature="_4saUEuuIEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfZdzyvQEeWNKd-GIYRskA" base_Class="_W8ZgwOuJEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZd0CvQEeWNKd-GIYRskA" base_StructuralFeature="_loYNAeuJEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZd0SvQEeWNKd-GIYRskA" base_StructuralFeature="_loYNBeuJEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZd0ivQEeWNKd-GIYRskA" base_StructuralFeature="_6xacQeuJEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZd0yvQEeWNKd-GIYRskA" base_StructuralFeature="_6xacReuJEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZd1CvQEeWNKd-GIYRskA" base_StructuralFeature="_BZXAoeuKEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfZd1SvQEeWNKd-GIYRskA" base_StructuralFeature="_BZgKkOuKEeGZr5p9Vdkojw" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfZd1ivQEeWNKd-GIYRskA" base_StructuralFeature="_4pVHMcI2Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfZd1yvQEeWNKd-GIYRskA" base_StructuralFeature="_gRDeUdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mffkYCvQEeWNKd-GIYRskA" base_StructuralFeature="_k8HfQdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mffkYSvQEeWNKd-GIYRskA" base_StructuralFeature="_p7dAMeM1Ed6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkYivQEeWNKd-GIYRskA" base_StructuralFeature="_nQw7kOuTEeGZr5p9Vdkojw" valueRange="1..8" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkYyvQEeWNKd-GIYRskA" base_StructuralFeature="_u4pyoOuWEeGZr5p9Vdkojw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mffkZCvQEeWNKd-GIYRskA" base_Class="_IopFAOw-EeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkZSvQEeWNKd-GIYRskA" base_StructuralFeature="_rHBn8OxCEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkZivQEeWNKd-GIYRskA" base_StructuralFeature="_rHBn9OxCEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkZyvQEeWNKd-GIYRskA" base_StructuralFeature="_3HoTEexCEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkaCvQEeWNKd-GIYRskA" base_StructuralFeature="_3HyEEuxCEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkaSvQEeWNKd-GIYRskA" base_StructuralFeature="_DiUSIexDEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkaivQEeWNKd-GIYRskA" base_StructuralFeature="_DidcEuxDEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mffkayvQEeWNKd-GIYRskA" base_Class="_ACUEMOxFEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkbCvQEeWNKd-GIYRskA" base_StructuralFeature="_DndekOxIEeGzwM2Uvwf5Xw" attributeValueChangeNotification="NO" valueRange="SSF, LCK, LOC[i], MMG, UNM, UNP, UNPri, UNL, DEG, RDI" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mffkbSvQEeWNKd-GIYRskA" base_Class="_fzLz0OxQEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkbivQEeWNKd-GIYRskA" base_StructuralFeature="_LpAAEJMvEeCKK9uc7Khnmg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkbyvQEeWNKd-GIYRskA" base_StructuralFeature="_Xo3rYJMvEeCKK9uc7Khnmg" valueRange="1518, 1522, 2000" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkcCvQEeWNKd-GIYRskA" base_StructuralFeature="_rz0BMOxdEeGzwM2Uvwf5Xw" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mffkcSvQEeWNKd-GIYRskA" base_StructuralFeature="_FgxeIC0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mffkcivQEeWNKd-GIYRskA" base_StructuralFeature="_tMsb8S0jEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mffkcyvQEeWNKd-GIYRskA" base_StructuralFeature="_MvP5MS0jEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mffkdCvQEeWNKd-GIYRskA" base_StructuralFeature="_Njjo0S0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:Names xmi:id="_mffkdSvQEeWNKd-GIYRskA" base_Association="_NrCLUHtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:Names xmi:id="_mffkdivQEeWNKd-GIYRskA" base_Association="_g6DIcHtSEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkdyvQEeWNKd-GIYRskA" base_StructuralFeature="_ABD1QexsEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mffkeCvQEeWNKd-GIYRskA" base_StructuralFeature="_ABM_MOxsEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mflrACvQEeWNKd-GIYRskA" base_Association="_ABD1QOxsEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mflrASvQEeWNKd-GIYRskA" base_StructuralFeature="_Q_qEYexsEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mflrAivQEeWNKd-GIYRskA" base_StructuralFeature="_Q_qEZexsEeGzwM2Uvwf5Xw" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mflrAyvQEeWNKd-GIYRskA" base_Operation="_g-C4ALoJEeGh2ojTLz6Azw" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mflrBCvQEeWNKd-GIYRskA" base_Operation="_982q8OzxEeGAeLnLFLO9_g" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mflrBSvQEeWNKd-GIYRskA" base_Operation="_FG7E8OzyEeGAeLnLFLO9_g" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mflrBivQEeWNKd-GIYRskA" base_Operation="_KQGlQOzyEeGAeLnLFLO9_g" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mflrByvQEeWNKd-GIYRskA" base_Operation="_hdn0wOzyEeGAeLnLFLO9_g" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mflrCCvQEeWNKd-GIYRskA" base_Operation="_hdn0w-zyEeGAeLnLFLO9_g" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrCSvQEeWNKd-GIYRskA" base_Parameter="_7OvFkOz2EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrCivQEeWNKd-GIYRskA" base_Parameter="_aTn58Oz3EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrCyvQEeWNKd-GIYRskA" base_Parameter="_xid_IOz3EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrDCvQEeWNKd-GIYRskA" base_Parameter="_ECYQAOz4EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrDSvQEeWNKd-GIYRskA" base_Parameter="_iUeqoOz6EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrDivQEeWNKd-GIYRskA" base_Parameter="_iUoboOz6EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrDyvQEeWNKd-GIYRskA" base_Parameter="_iUobpOz6EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrECvQEeWNKd-GIYRskA" base_Parameter="_PzHy0Oz7EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrESvQEeWNKd-GIYRskA" base_Parameter="_PzHy1uz7EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrEivQEeWNKd-GIYRskA" base_Parameter="_PzHy2uz7EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrEyvQEeWNKd-GIYRskA" base_Parameter="_VkX_wOz7EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrFCvQEeWNKd-GIYRskA" base_Parameter="_gN-bsOz7EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrFSvQEeWNKd-GIYRskA" base_Parameter="_ZUm6sOz8EeGAeLnLFLO9_g" valueRange="see data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrFivQEeWNKd-GIYRskA" base_Parameter="_ZUm6tuz8EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mflrFyvQEeWNKd-GIYRskA" base_Parameter="_ZUm6vOz8EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfrxoCvQEeWNKd-GIYRskA" base_Parameter="_ZUm6xOz8EeGAeLnLFLO9_g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mfrxoSvQEeWNKd-GIYRskA" base_Association="_juKW4FEOEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:Names xmi:id="_mfrxoivQEeWNKd-GIYRskA" base_Association="_biD4IFEOEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:Names xmi:id="_mfrxoyvQEeWNKd-GIYRskA" base_Association="_nkddkEN0EeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:Names xmi:id="_mfrxpCvQEeWNKd-GIYRskA" base_Association="_lzciAENrEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:Names xmi:id="_mfrxpSvQEeWNKd-GIYRskA" base_Association="_7xfsoK6bEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfrxpivQEeWNKd-GIYRskA" base_StructuralFeature="_dZBFVK8qEd6PiOh_CmtkmA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfrxpyvQEeWNKd-GIYRskA" base_StructuralFeature="_dZBFUK8qEd6PiOh_CmtkmA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfrxqCvQEeWNKd-GIYRskA" base_Parameter="_2cCl5rH1EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfrxqSvQEeWNKd-GIYRskA" base_Parameter="_vNwFILHzEeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfrxqivQEeWNKd-GIYRskA" base_Parameter="_33FyILH2EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mfrxqyvQEeWNKd-GIYRskA" base_Parameter="_u3IfcLH0EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfrxrCvQEeWNKd-GIYRskA" base_Parameter="__CmsQELLEeKtRKTHZgJhIg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxrSvQEeWNKd-GIYRskA" base_StructuralFeature="_in3IsEN1EeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxrivQEeWNKd-GIYRskA" base_StructuralFeature="_in3Is0N1EeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxryvQEeWNKd-GIYRskA" base_StructuralFeature="_ABzeMEN2EeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxsCvQEeWNKd-GIYRskA" base_StructuralFeature="_BikMsEN-EeKtRKTHZgJhIg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="non-negative" condition="none"/>
+  <OpenModel_Profile:Choice xmi:id="_mfrxsSvQEeWNKd-GIYRskA" base_DataType="_Qp12YEOVEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxsivQEeWNKd-GIYRskA" base_StructuralFeature="_Qp12cEOVEeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxsyvQEeWNKd-GIYRskA" base_StructuralFeature="_Qp_neUOVEeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mfrxtCvQEeWNKd-GIYRskA" base_Parameter="_6mI8YUOZEeKtRKTHZgJhIg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxtSvQEeWNKd-GIYRskA" base_StructuralFeature="_o7GL0UQ6EeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxtivQEeWNKd-GIYRskA" base_StructuralFeature="_o7GL1UQ6EeKtRKTHZgJhIg" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxtyvQEeWNKd-GIYRskA" base_StructuralFeature="_Bk0rUFEUEd6VSrclB-Ybig" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxuCvQEeWNKd-GIYRskA" base_StructuralFeature="_EkEDoFEUEd6VSrclB-Ybig" valueRange="100ms, 1s, 10s" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfrxuSvQEeWNKd-GIYRskA" base_StructuralFeature="_GzuZIFEUEd6VSrclB-Ybig" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4QCvQEeWNKd-GIYRskA" base_StructuralFeature="_CxiCsURZEeKtRKTHZgJhIg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4QSvQEeWNKd-GIYRskA" base_StructuralFeature="_CxiCtERZEeKtRKTHZgJhIg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4QivQEeWNKd-GIYRskA" base_StructuralFeature="_GFPJMVEZEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..900 for 15min interval or 0..86400 for 24 hr interval." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4QyvQEeWNKd-GIYRskA" base_StructuralFeature="_GFPJNFEZEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..900 for 15min interval or 0..86400 for 24 hr interval." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4RCvQEeWNKd-GIYRskA" base_StructuralFeature="_GFPJNlEZEd6VSrclB-Ybig" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..900 for 15min interval or 0..86400 for 24 hr interval." condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfx4RSvQEeWNKd-GIYRskA" base_Class="_6gIJAERfEeKsbYfVW3kmQQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4RivQEeWNKd-GIYRskA" base_StructuralFeature="_6gIJBERfEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4RyvQEeWNKd-GIYRskA" base_StructuralFeature="_6gIJB0RfEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4SCvQEeWNKd-GIYRskA" base_StructuralFeature="_VF54UkRhEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mfx4SSvQEeWNKd-GIYRskA" base_Class="_3ZT3IERhEeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4SivQEeWNKd-GIYRskA" base_StructuralFeature="_3ZT3I0RhEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4SyvQEeWNKd-GIYRskA" base_StructuralFeature="_3ZT3JkRhEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4TCvQEeWNKd-GIYRskA" base_StructuralFeature="_LvFdcERiEeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4TSvQEeWNKd-GIYRskA" base_StructuralFeature="_LvOnYkRiEeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4TivQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVAURsEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4TyvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVA0RsEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4UCvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVBURsEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4USvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVE0RsEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4UivQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVFURsEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4UyvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVF0RsEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mfx4VCvQEeWNKd-GIYRskA" base_StructuralFeature="_ecldYkRtEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-4CvQEeWNKd-GIYRskA" base_StructuralFeature="_ecldZERtEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-4SvQEeWNKd-GIYRskA" base_StructuralFeature="_HZhU8ERuEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mf3-4ivQEeWNKd-GIYRskA" base_Class="_1D9goERyEeKsbYfVW3kmQQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-4yvQEeWNKd-GIYRskA" base_StructuralFeature="_1D9gpERyEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-5CvQEeWNKd-GIYRskA" base_StructuralFeature="_1D9gpkRyEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-5SvQEeWNKd-GIYRskA" base_StructuralFeature="_JV3TkURzEeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-5ivQEeWNKd-GIYRskA" base_StructuralFeature="_JWAdgERzEeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-5yvQEeWNKd-GIYRskA" base_StructuralFeature="_eZFOskRzEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mf3-6CvQEeWNKd-GIYRskA" base_Class="_Kfrl4ER0EeKsbYfVW3kmQQ" objectCreationNotification="NO" objectDeletionNotification="NO" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-6SvQEeWNKd-GIYRskA" base_StructuralFeature="_Kfrl5ER0EeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-6ivQEeWNKd-GIYRskA" base_StructuralFeature="_Kfrl5kR0EeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-6yvQEeWNKd-GIYRskA" base_StructuralFeature="_o32eMUR0EeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-7CvQEeWNKd-GIYRskA" base_StructuralFeature="_o32eNUR0EeKsbYfVW3kmQQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-7SvQEeWNKd-GIYRskA" base_StructuralFeature="_vHYAcEUBEeKsbYfVW3kmQQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-7ivQEeWNKd-GIYRskA" base_StructuralFeature="_vHYAc0UBEeKsbYfVW3kmQQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-7yvQEeWNKd-GIYRskA" base_StructuralFeature="_v1aLIEUBEeKsbYfVW3kmQQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-8CvQEeWNKd-GIYRskA" base_StructuralFeature="_v1aLI0UBEeKsbYfVW3kmQQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-8SvQEeWNKd-GIYRskA" base_StructuralFeature="_ZitIoEUCEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="24hr, 15min, 1 - 14 min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-8ivQEeWNKd-GIYRskA" base_StructuralFeature="_HPZvYUUNEeKsbYfVW3kmQQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="24hr, 15min, 1 - 14 min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-8yvQEeWNKd-GIYRskA" base_StructuralFeature="_HPZvY0UNEeKsbYfVW3kmQQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-9CvQEeWNKd-GIYRskA" base_StructuralFeature="_HPZvZUUNEeKsbYfVW3kmQQ" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-9SvQEeWNKd-GIYRskA" base_StructuralFeature="_OsYW8EUQEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf3-9ivQEeWNKd-GIYRskA" base_StructuralFeature="_PJcGYEUQEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FgCvQEeWNKd-GIYRskA" base_StructuralFeature="_PjOfYEUQEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FgSvQEeWNKd-GIYRskA" base_StructuralFeature="_ZVrbcEUREeKyK7rRd9C5sg" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FgivQEeWNKd-GIYRskA" base_StructuralFeature="_ZV1MckUREeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mf-FgyvQEeWNKd-GIYRskA" base_Class="_FnT98EUSEeKyK7rRd9C5sg" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mf-FhCvQEeWNKd-GIYRskA" base_StructuralFeature="_ZVrbcEUREeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mf-FhSvQEeWNKd-GIYRskA" base_StructuralFeature="_ZV1MckUREeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FhivQEeWNKd-GIYRskA" base_StructuralFeature="_unxiQUUgEeKyK7rRd9C5sg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="24hr, 15min, 1 - 14 min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FhyvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiQ0UgEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FiCvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiRUUgEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FiSvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiR0UgEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FiivQEeWNKd-GIYRskA" base_StructuralFeature="_unxiSUUgEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FiyvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiS0UgEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FjCvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiTUUgEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FjSvQEeWNKd-GIYRskA" base_StructuralFeature="_fHOWwkUmEeKyK7rRd9C5sg" attributeValueChangeNotification="NO" isInvariant="true" valueRange="24hr, 15min, 1 - 14 min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FjivQEeWNKd-GIYRskA" base_StructuralFeature="_fHOWxEUmEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mf-FjyvQEeWNKd-GIYRskA" base_StructuralFeature="_fHOWxkUmEeKyK7rRd9C5sg" attributeValueChangeNotification="YES" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mf-FkCvQEeWNKd-GIYRskA" base_Parameter="_tpMV8EUnEeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mf-FkSvQEeWNKd-GIYRskA" base_Parameter="_0Qc90EUnEeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mf-FkivQEeWNKd-GIYRskA" base_Parameter="_JraqkEUoEeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mf-FkyvQEeWNKd-GIYRskA" base_Parameter="_PCWTAEUoEeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mf-FlCvQEeWNKd-GIYRskA" base_Parameter="_iIePUEUoEeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mf-FlSvQEeWNKd-GIYRskA" base_Parameter="_rtGAMEUoEeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgEMICvQEeWNKd-GIYRskA" base_Operation="_3HdUQEU0EeKyK7rRd9C5sg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMISvQEeWNKd-GIYRskA" base_Parameter="_3HdUQkU0EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMIivQEeWNKd-GIYRskA" base_Parameter="_3HdUREU0EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMIyvQEeWNKd-GIYRskA" base_Parameter="_3HdUSEU0EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMJCvQEeWNKd-GIYRskA" base_Parameter="_3HdUTEU0EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMJSvQEeWNKd-GIYRskA" base_Parameter="_3HdUUEU0EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMJivQEeWNKd-GIYRskA" base_Parameter="_3HdUVEU0EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgEMJyvQEeWNKd-GIYRskA" base_Parameter="_3HdUQkU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgEMKCvQEeWNKd-GIYRskA" base_Parameter="_iIePUEUoEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgEMKSvQEeWNKd-GIYRskA" base_Operation="_OnV0MEU3EeKyK7rRd9C5sg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMKivQEeWNKd-GIYRskA" base_Parameter="_OnV0MkU3EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgEMKyvQEeWNKd-GIYRskA" base_Parameter="_OnV0MkU3EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMLCvQEeWNKd-GIYRskA" base_Parameter="_hNrnwEU4EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgEMLSvQEeWNKd-GIYRskA" base_Parameter="_hNrnwEU4EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgEMLivQEeWNKd-GIYRskA" base_Operation="_GDMW8EU5EeKyK7rRd9C5sg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMLyvQEeWNKd-GIYRskA" base_Parameter="_GDMW8kU5EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgEMMCvQEeWNKd-GIYRskA" base_Parameter="_Sp8cEEU5EeKyK7rRd9C5sg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgEMMSvQEeWNKd-GIYRskA" base_Parameter="_Sp8cEEU5EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:Names xmi:id="_mgEMMivQEeWNKd-GIYRskA" base_Association="_W4OToHtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:Names xmi:id="_mgEMMyvQEeWNKd-GIYRskA" base_Association="_dCSosLJFEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgEMNCvQEeWNKd-GIYRskA" base_StructuralFeature="_O9QFcGCkEeKJHOJsrnUaqw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgEMNSvQEeWNKd-GIYRskA" base_StructuralFeature="_O9ZPYmCkEeKJHOJsrnUaqw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgEMNivQEeWNKd-GIYRskA" base_StructuralFeature="_Rhm4kWCkEeKJHOJsrnUaqw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKSwCvQEeWNKd-GIYRskA" base_StructuralFeature="_Rhm4lWCkEeKJHOJsrnUaqw" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mgKSwSvQEeWNKd-GIYRskA" base_Association="_O9GUcGCkEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:Names xmi:id="_mgKSwivQEeWNKd-GIYRskA" base_Association="_Rhm4kGCkEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgKSwyvQEeWNKd-GIYRskA" base_Parameter="__ck-IGCpEeKJHOJsrnUaqw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgKSxCvQEeWNKd-GIYRskA" base_Parameter="_kF85UGCrEeKJHOJsrnUaqw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgKSxSvQEeWNKd-GIYRskA" base_Parameter="__U9oUWCrEeKJHOJsrnUaqw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgKSxivQEeWNKd-GIYRskA" base_Parameter="__U9oVmCrEeKJHOJsrnUaqw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgKSxyvQEeWNKd-GIYRskA" base_Parameter="_fKFxYGCtEeKJHOJsrnUaqw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKSyCvQEeWNKd-GIYRskA" base_StructuralFeature="_TU7JkIAPEeK2Wa4B6ppTIw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKSySvQEeWNKd-GIYRskA" base_StructuralFeature="_TVE6koAPEeK2Wa4B6ppTIw" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mgKSyivQEeWNKd-GIYRskA" base_Association="_TO9rgIAPEeK2Wa4B6ppTIw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgKSyyvQEeWNKd-GIYRskA" base_Parameter="_qAZUkIASEeK2Wa4B6ppTIw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mgKSzCvQEeWNKd-GIYRskA" base_Class="_GoQsYIsVEeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mgKSzSvQEeWNKd-GIYRskA" base_Class="_hJ3Q4IsXEeK2NvDLt60gDw" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKSzivQEeWNKd-GIYRskA" base_StructuralFeature="_OJcCAIsZEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See corresponding Enum." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKSzyvQEeWNKd-GIYRskA" base_StructuralFeature="_ttIDgIsfEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="Depends on the allowed MTU size." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS0CvQEeWNKd-GIYRskA" base_StructuralFeature="_ttIDg4sfEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS0SvQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFIIstEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS0ivQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFJIstEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS0yvQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFKIstEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS1CvQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFLIstEeK2NvDLt60gDw" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS1SvQEeWNKd-GIYRskA" base_StructuralFeature="_VIVkcosyEeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS1ivQEeWNKd-GIYRskA" base_StructuralFeature="_1k454IszEeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgKS1yvQEeWNKd-GIYRskA" base_StructuralFeature="_1k455IszEeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:Choice xmi:id="_mgQZYCvQEeWNKd-GIYRskA" base_DataType="_LD4i4Iu0EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZYSvQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i44u0EeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZYivQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i5ou0EeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZYyvQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i7ou0EeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZZCvQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i84u0EeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZZSvQEeWNKd-GIYRskA" base_StructuralFeature="_c0CVUou1EeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZZivQEeWNKd-GIYRskA" base_StructuralFeature="_pjlxIIu1EeK2NvDLt60gDw" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZZyvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP4IvDEeK2NvDLt60gDw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZaCvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP5IvDEeK2NvDLt60gDw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZaSvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP6IvDEeK2NvDLt60gDw" valueRange="See associated Enum." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZaivQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP7IvDEeK2NvDLt60gDw" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZayvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP8IvDEeK2NvDLt60gDw" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgQZbCvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP9IvDEeK2NvDLt60gDw" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgQZbSvQEeWNKd-GIYRskA" base_Operation="_9diacIveEeKIPqQgvzcmyg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZbivQEeWNKd-GIYRskA" base_Parameter="_9diacoveEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZbyvQEeWNKd-GIYRskA" base_Parameter="_9diadYveEeKIPqQgvzcmyg" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZcCvQEeWNKd-GIYRskA" base_Parameter="_9diaeIveEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZcSvQEeWNKd-GIYRskA" base_Parameter="_9diae4veEeKIPqQgvzcmyg" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZcivQEeWNKd-GIYRskA" base_Parameter="_9diafoveEeKIPqQgvzcmyg" valueRange="0, 1, 2, 3, 4, 5, 6, 7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZcyvQEeWNKd-GIYRskA" base_Parameter="_9diagYveEeKIPqQgvzcmyg" valueRange="Depends on the allowed MTU size." condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZdCvQEeWNKd-GIYRskA" base_Parameter="_9diahIveEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgQZdSvQEeWNKd-GIYRskA" base_Operation="_4pws8IvfEeKIPqQgvzcmyg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZdivQEeWNKd-GIYRskA" base_Parameter="_4pws8ovfEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZdyvQEeWNKd-GIYRskA" base_Parameter="_4pws9YvfEeKIPqQgvzcmyg" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZeCvQEeWNKd-GIYRskA" base_Parameter="_4pws-4vfEeKIPqQgvzcmyg" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgQZeSvQEeWNKd-GIYRskA" base_Parameter="_4pwtBIvfEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgWgACvQEeWNKd-GIYRskA" base_Parameter="_l471wIvgEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgWgASvQEeWNKd-GIYRskA" base_Parameter="_l471xIvgEeKIPqQgvzcmyg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mgWgAivQEeWNKd-GIYRskA" base_Class="_2sFHoJVIEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgAyvQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHopVIEeKd8oT75MgdlA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgBCvQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHqZVIEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgBSvQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHrJVIEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="100ms, 1s, 10s" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgBivQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHr5VIEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgByvQEeWNKd-GIYRskA" base_StructuralFeature="_PvwAcJVJEeKd8oT75MgdlA" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgCCvQEeWNKd-GIYRskA" base_StructuralFeature="_PvwAdJVJEeKd8oT75MgdlA" isInvariant="true" valueRange="Depends on the allowed MTU size." condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mgWgCSvQEeWNKd-GIYRskA" base_Class="_xCFuYJVKEeKd8oT75MgdlA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgCivQEeWNKd-GIYRskA" base_StructuralFeature="_xCFuZJVKEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mgWgCyvQEeWNKd-GIYRskA" base_Class="_xCFugZVKEeKd8oT75MgdlA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgDCvQEeWNKd-GIYRskA" base_StructuralFeature="_xCFug5VKEeKd8oT75MgdlA" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgDSvQEeWNKd-GIYRskA" base_StructuralFeature="_xCFuhZVKEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgDivQEeWNKd-GIYRskA" base_StructuralFeature="_xCFuh5VKEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgDyvQEeWNKd-GIYRskA" base_StructuralFeature="_xCPfcJVKEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mgWgECvQEeWNKd-GIYRskA" base_Class="_12GP8JVKEeKd8oT75MgdlA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgESvQEeWNKd-GIYRskA" base_StructuralFeature="_12GP9JVKEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgEivQEeWNKd-GIYRskA" base_StructuralFeature="_1vAUAJVLEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgEyvQEeWNKd-GIYRskA" base_StructuralFeature="_1vAUBJVLEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="Depends on the allowed MTU size." condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgFCvQEeWNKd-GIYRskA" base_StructuralFeature="_3VZNkJVMEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgWgFSvQEeWNKd-GIYRskA" base_StructuralFeature="_3Vi-kpVMEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mgcmoCvQEeWNKd-GIYRskA" base_Association="_3UpmsJVMEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgcmoSvQEeWNKd-GIYRskA" base_StructuralFeature="_-Dby4ZVMEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgcmoivQEeWNKd-GIYRskA" base_StructuralFeature="_-Dby5ZVMEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mgcmoyvQEeWNKd-GIYRskA" base_Association="_-Dby4JVMEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgcmpCvQEeWNKd-GIYRskA" base_StructuralFeature="_EkDnQZVNEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgcmpSvQEeWNKd-GIYRskA" base_StructuralFeature="_EkDnRZVNEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mgcmpivQEeWNKd-GIYRskA" base_Association="_EkDnQJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgcmpyvQEeWNKd-GIYRskA" base_Operation="_SKavQJVNEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmqCvQEeWNKd-GIYRskA" base_Parameter="_SKavQpVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmqSvQEeWNKd-GIYRskA" base_Parameter="_SKavRZVNEeKd8oT75MgdlA" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmqivQEeWNKd-GIYRskA" base_Parameter="_SKavSJVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmqyvQEeWNKd-GIYRskA" base_Parameter="_SKavS5VNEeKd8oT75MgdlA" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmrCvQEeWNKd-GIYRskA" base_Parameter="_SKavTpVNEeKd8oT75MgdlA" valueRange="0, 1, 2, 3, 4, 5, 6, 7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmrSvQEeWNKd-GIYRskA" base_Parameter="_SKavUZVNEeKd8oT75MgdlA" valueRange="Depends on the allowed MTU size." condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmrivQEeWNKd-GIYRskA" base_Parameter="_SKavVJVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgcmryvQEeWNKd-GIYRskA" base_Operation="_YcS9AJVNEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmsCvQEeWNKd-GIYRskA" base_Parameter="_YcS9ApVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmsSvQEeWNKd-GIYRskA" base_Parameter="_YcS9BZVNEeKd8oT75MgdlA" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmsivQEeWNKd-GIYRskA" base_Parameter="_YcS9CJVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmsyvQEeWNKd-GIYRskA" base_Parameter="_YcS9C5VNEeKd8oT75MgdlA" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmtCvQEeWNKd-GIYRskA" base_Parameter="_YcS9DpVNEeKd8oT75MgdlA" valueRange="0, 1, 2, 3, 4, 5, 6, 7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmtSvQEeWNKd-GIYRskA" base_Parameter="_YcS9EZVNEeKd8oT75MgdlA" valueRange="Depends on the allowed MTU size." support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgcmtivQEeWNKd-GIYRskA" base_Parameter="_YcS9FJVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mgcmtyvQEeWNKd-GIYRskA" base_Operation="_dtqI8JVNEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgitQCvQEeWNKd-GIYRskA" base_Parameter="_dtqI8pVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgitQSvQEeWNKd-GIYRskA" base_Parameter="_dtqI9ZVNEeKd8oT75MgdlA" valueRange="See corresponding Enum" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgitQivQEeWNKd-GIYRskA" base_Parameter="_dtqI-JVNEeKd8oT75MgdlA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgitQyvQEeWNKd-GIYRskA" base_Parameter="_dtqI_pVNEeKd8oT75MgdlA" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgitRCvQEeWNKd-GIYRskA" base_Parameter="_dtqJAZVNEeKd8oT75MgdlA" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitRSvQEeWNKd-GIYRskA" base_StructuralFeature="_4qTVkJVNEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitRivQEeWNKd-GIYRskA" base_StructuralFeature="_A5XBsJVOEeKd8oT75MgdlA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..(2^32) - 1" support="OPTIONAL" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitRyvQEeWNKd-GIYRskA" base_StructuralFeature="_2Lx18ZVTEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitSCvQEeWNKd-GIYRskA" base_StructuralFeature="_2Lx19ZVTEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitSSvQEeWNKd-GIYRskA" base_StructuralFeature="_GXkIEZVUEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitSivQEeWNKd-GIYRskA" base_StructuralFeature="_GXkIFZVUEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitSyvQEeWNKd-GIYRskA" base_StructuralFeature="_7ByGIZVUEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitTCvQEeWNKd-GIYRskA" base_StructuralFeature="_7ByGJZVUEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitTSvQEeWNKd-GIYRskA" base_StructuralFeature="_GpphIZVVEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitTivQEeWNKd-GIYRskA" base_StructuralFeature="_GpphJZVVEeKd8oT75MgdlA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitTyvQEeWNKd-GIYRskA" base_StructuralFeature="_QNEkEKHKEeKRNLblqYhoTg" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitUCvQEeWNKd-GIYRskA" base_StructuralFeature="_QNEkFKHKEeKRNLblqYhoTg" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgitUSvQEeWNKd-GIYRskA" base_StructuralFeature="_QNEkEKHKEeKRNLblqYhoTg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgitUivQEeWNKd-GIYRskA" base_Parameter="_BVkSCO4-Ed6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgitUyvQEeWNKd-GIYRskA" base_Parameter="_lNjuwKHfEeKb96dZOhIJOg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgitVCvQEeWNKd-GIYRskA" base_Parameter="_lNjuwKHfEeKb96dZOhIJOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitVSvQEeWNKd-GIYRskA" base_StructuralFeature="_03LH9KHfEeKb96dZOhIJOg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgitVivQEeWNKd-GIYRskA" base_StructuralFeature="_a0hMdKHhEeKb96dZOhIJOg" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mgoz4ivQEeWNKd-GIYRskA" base_Association="_BFgoUNg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz4yvQEeWNKd-GIYRskA" base_StructuralFeature="_7DoIQaKREeKZoeGA12VHIQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz5CvQEeWNKd-GIYRskA" base_StructuralFeature="_7DoIRaKREeKZoeGA12VHIQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz5SvQEeWNKd-GIYRskA" base_StructuralFeature="_6nCA8aKTEeKZoeGA12VHIQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz5ivQEeWNKd-GIYRskA" base_StructuralFeature="_6nCA9aKTEeKZoeGA12VHIQ" attributeValueChangeNotification="NO" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgoz5yvQEeWNKd-GIYRskA" base_StructuralFeature="_7DoIQaKREeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgoz6CvQEeWNKd-GIYRskA" base_StructuralFeature="_7DoIRaKREeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgoz6SvQEeWNKd-GIYRskA" base_StructuralFeature="_6nCA8aKTEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgoz6ivQEeWNKd-GIYRskA" base_StructuralFeature="_6nCA9aKTEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgoz6yvQEeWNKd-GIYRskA" base_StructuralFeature="_Osz7EOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgoz7CvQEeWNKd-GIYRskA" base_Parameter="_sLKD4KKsEeKZoeGA12VHIQ" valueRange="1..14" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgoz7SvQEeWNKd-GIYRskA" base_Parameter="_nqxzgKKtEeKZoeGA12VHIQ" valueRange="1..14" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgoz7ivQEeWNKd-GIYRskA" base_Parameter="_1p1vYKKtEeKZoeGA12VHIQ" valueRange="1..14" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mgoz7yvQEeWNKd-GIYRskA" base_Parameter="_2ur3kKKtEeKZoeGA12VHIQ" valueRange="1..14" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz8yvQEeWNKd-GIYRskA" base_StructuralFeature="_u99zIKtGEeKnAKpr1sW3qQ" valueRange="" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz9CvQEeWNKd-GIYRskA" base_StructuralFeature="_3jh6wKtGEeKnAKpr1sW3qQ" valueRange="" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgoz9SvQEeWNKd-GIYRskA" base_StructuralFeature="_3jh6wKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz9ivQEeWNKd-GIYRskA" base_StructuralFeature="_nSzPgKtMEeKnAKpr1sW3qQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgoz9yvQEeWNKd-GIYRskA" base_StructuralFeature="_nTGKcqtMEeKnAKpr1sW3qQ" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mgu6gCvQEeWNKd-GIYRskA" base_StructuralFeature="_nSzPgKtMEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6gSvQEeWNKd-GIYRskA" base_StructuralFeature="_qHWqkKzoEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6givQEeWNKd-GIYRskA" base_StructuralFeature="_qHWqlKzoEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6gyvQEeWNKd-GIYRskA" base_StructuralFeature="_1e2uUazoEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6hCvQEeWNKd-GIYRskA" base_StructuralFeature="_1e2uVazoEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6hSvQEeWNKd-GIYRskA" base_StructuralFeature="_7rYiAazoEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6hivQEeWNKd-GIYRskA" base_StructuralFeature="_7rYiBazoEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6hyvQEeWNKd-GIYRskA" base_StructuralFeature="_34lwYazpEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6iCvQEeWNKd-GIYRskA" base_StructuralFeature="_34lwZazpEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6iSvQEeWNKd-GIYRskA" base_StructuralFeature="_4obR4azpEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6iivQEeWNKd-GIYRskA" base_StructuralFeature="_4obR5azpEeK4UJp6At-puA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6iyvQEeWNKd-GIYRskA" base_StructuralFeature="_rIRxQK2GEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6jCvQEeWNKd-GIYRskA" base_StructuralFeature="_G-8WIK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6jSvQEeWNKd-GIYRskA" base_StructuralFeature="_lUPgoK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6jivQEeWNKd-GIYRskA" base_StructuralFeature="_lz-woK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6jyvQEeWNKd-GIYRskA" base_StructuralFeature="_mKelEK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6kCvQEeWNKd-GIYRskA" base_StructuralFeature="_mczrMK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6kSvQEeWNKd-GIYRskA" base_StructuralFeature="_musscK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6kivQEeWNKd-GIYRskA" base_StructuralFeature="_nAuQkK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6kyvQEeWNKd-GIYRskA" base_StructuralFeature="_naW4kK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6lCvQEeWNKd-GIYRskA" base_StructuralFeature="_ntlWkK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6lSvQEeWNKd-GIYRskA" base_StructuralFeature="_n_6csK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6livQEeWNKd-GIYRskA" base_StructuralFeature="_oRWK8K2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6lyvQEeWNKd-GIYRskA" base_StructuralFeature="_ol6FsK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6mCvQEeWNKd-GIYRskA" base_StructuralFeature="_o4PL0K2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mgu6mSvQEeWNKd-GIYRskA" base_StructuralFeature="_pM83kK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BICvQEeWNKd-GIYRskA" base_StructuralFeature="_phOecK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BISvQEeWNKd-GIYRskA" base_StructuralFeature="_p1yZMK2HEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BIivQEeWNKd-GIYRskA" base_StructuralFeature="_bebnMK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BIyvQEeWNKd-GIYRskA" base_StructuralFeature="_frjH4K2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BJCvQEeWNKd-GIYRskA" base_StructuralFeature="_gN0ugK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BJSvQEeWNKd-GIYRskA" base_StructuralFeature="_gkeT8K2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BJivQEeWNKd-GIYRskA" base_StructuralFeature="_g5VJoK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BJyvQEeWNKd-GIYRskA" base_StructuralFeature="_hOVwUK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BKCvQEeWNKd-GIYRskA" base_StructuralFeature="_hjWXAK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BKSvQEeWNKd-GIYRskA" base_StructuralFeature="_h3Ub4K2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BKivQEeWNKd-GIYRskA" base_StructuralFeature="_iNrGYK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BKyvQEeWNKd-GIYRskA" base_StructuralFeature="_igTHcK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BLCvQEeWNKd-GIYRskA" base_StructuralFeature="_i1AzMK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BLSvQEeWNKd-GIYRskA" base_StructuralFeature="_jJbkAK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BLivQEeWNKd-GIYRskA" base_StructuralFeature="_jf7YcK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BLyvQEeWNKd-GIYRskA" base_StructuralFeature="_jzJ2cK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BMCvQEeWNKd-GIYRskA" base_StructuralFeature="_kIwTAK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BMSvQEeWNKd-GIYRskA" base_StructuralFeature="_lBOzIK2JEeKoWKjPsL4xyQ" valueRange="NA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mg1BMivQEeWNKd-GIYRskA" base_Parameter="_oWZDMK2sEeKoWKjPsL4xyQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BMyvQEeWNKd-GIYRskA" base_StructuralFeature="_N48CEK2uEeKoWKjPsL4xyQ" valueRange="0..number of ports" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BNCvQEeWNKd-GIYRskA" base_StructuralFeature="_N48CFa2uEeKoWKjPsL4xyQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BNSvQEeWNKd-GIYRskA" base_StructuralFeature="_N48CGa2uEeKoWKjPsL4xyQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BNivQEeWNKd-GIYRskA" base_StructuralFeature="_DTkJYq2vEeKoWKjPsL4xyQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mg1BNyvQEeWNKd-GIYRskA" base_StructuralFeature="_DTkJYq2vEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BOCvQEeWNKd-GIYRskA" base_StructuralFeature="_spRGQK2vEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg1BOSvQEeWNKd-GIYRskA" base_StructuralFeature="_spa3Qq2vEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HwCvQEeWNKd-GIYRskA" base_StructuralFeature="_6A5Osa2vEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HwSvQEeWNKd-GIYRskA" base_StructuralFeature="_6A5Ota2vEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HwivQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy0q2wEeKoWKjPsL4xyQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mg7HwyvQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy0q2wEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HxCvQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy1q2wEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HxSvQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy2a2wEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HxivQEeWNKd-GIYRskA" base_StructuralFeature="_C18j0a2wEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HxyvQEeWNKd-GIYRskA" base_StructuralFeature="_C18j1q2wEeKoWKjPsL4xyQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7HyCvQEeWNKd-GIYRskA" base_StructuralFeature="_X8wwEK2xEeKoWKjPsL4xyQ" valueRange="SIZE(1..8)" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mg7HySvQEeWNKd-GIYRskA" base_Parameter="_4UXjkK5AEeKXNfjfbIxfYg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mg7HyivQEeWNKd-GIYRskA" base_Class="_EhoxsK5BEeKXNfjfbIxfYg" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mg7HyyvQEeWNKd-GIYRskA" base_Class="_djhh0K5BEeKXNfjfbIxfYg" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mg7HzCvQEeWNKd-GIYRskA" base_Parameter="_gPgtUK5JEeKXNfjfbIxfYg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mg7HzSvQEeWNKd-GIYRskA" base_Parameter="_gPgtVa5JEeKXNfjfbIxfYg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mg7HzivQEeWNKd-GIYRskA" base_Parameter="_RAVigK5LEeKXNfjfbIxfYg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mg7HzyvQEeWNKd-GIYRskA" base_Parameter="_RAVigK5LEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mg7H0CvQEeWNKd-GIYRskA" base_Parameter="_1ZB9YK5MEeKXNfjfbIxfYg" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mg7H0SvQEeWNKd-GIYRskA" base_Parameter="_1ZB9YK5MEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7H0ivQEeWNKd-GIYRskA" base_StructuralFeature="_CvRXAK5TEeKbRfTRicRZzQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7H0yvQEeWNKd-GIYRskA" base_StructuralFeature="_CwwkwK5TEeKbRfTRicRZzQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7H1CvQEeWNKd-GIYRskA" base_StructuralFeature="_Cwwkw65TEeKbRfTRicRZzQ" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7H1SvQEeWNKd-GIYRskA" base_StructuralFeature="_Cwwkxa5TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mg7H1ivQEeWNKd-GIYRskA" base_StructuralFeature="_Cwwkx65TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOYCvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5usa5TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOYSvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5us65TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOYivQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5ut65TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOYyvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5uua5TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="1s, 1min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOZCvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5uva5TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mhBOZSvQEeWNKd-GIYRskA" base_Association="_BVe5AHtTEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:Names xmi:id="_mhBOZivQEeWNKd-GIYRskA" base_Association="_zsbCUHtSEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOZyvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5uwa5TEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOaCvQEeWNKd-GIYRskA" base_StructuralFeature="_zRwE0K5tEeKbRfTRicRZzQ" attributeValueChangeNotification="YES" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhBOaSvQEeWNKd-GIYRskA" base_Parameter="_I1YokK5yEeKbRfTRicRZzQ" valueRange="75 octet" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOaivQEeWNKd-GIYRskA" base_StructuralFeature="_Ades0LC_EeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOayvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades27C_EeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBObCvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades47C_EeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBObSvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades57C_EeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBObivQEeWNKd-GIYRskA" base_StructuralFeature="_Adn2wLC_EeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBObyvQEeWNKd-GIYRskA" base_StructuralFeature="_Adn2xLC_EeK3DNmPdBk7Xw" valueRange="1s, 1min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOcCvQEeWNKd-GIYRskA" base_StructuralFeature="_Adn2yrC_EeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOcSvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades1LC_EeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOcivQEeWNKd-GIYRskA" base_StructuralFeature="_Ades17C_EeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOcyvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades4LC_EeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOdCvQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLsLDAEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOdSvQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLs7DAEeK3DNmPdBk7Xw" valueRange="1s, 1min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOdivQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLt7DAEeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhBOdyvQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLu7DAEeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVACvQEeWNKd-GIYRskA" base_StructuralFeature="_K7egQLDAEeK3DNmPdBk7Xw" valueRange="0..8191" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVASvQEeWNKd-GIYRskA" base_StructuralFeature="_Q10XwLDAEeK3DNmPdBk7Xw" valueRange="0..8191" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVAivQEeWNKd-GIYRskA" base_StructuralFeature="_Q10XxrDAEeK3DNmPdBk7Xw" valueRange="1s, 1min" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVAyvQEeWNKd-GIYRskA" base_StructuralFeature="_Q10XzLDAEeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVBCvQEeWNKd-GIYRskA" base_StructuralFeature="_Q10X0rDAEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVBSvQEeWNKd-GIYRskA" base_StructuralFeature="_Q1-IwLDAEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVBivQEeWNKd-GIYRskA" base_StructuralFeature="_Q1-IxLDAEeK3DNmPdBk7Xw" valueRange="cLOC[i], cUNL, cMMG, cUNM, cDEG, cUNP, cUNPr, cRDI, cSSF, cLCK" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVByvQEeWNKd-GIYRskA" base_Parameter="_ky5X8LDFEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhHVCCvQEeWNKd-GIYRskA" base_Parameter="_ky5X8LDFEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVCSvQEeWNKd-GIYRskA" base_Parameter="_y3-cQLDFEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhHVCivQEeWNKd-GIYRskA" base_Parameter="_y3-cQLDFEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVCyvQEeWNKd-GIYRskA" base_Parameter="_RvSHoLDGEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVDCvQEeWNKd-GIYRskA" base_Parameter="_RvSHprDGEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVDSvQEeWNKd-GIYRskA" base_Parameter="_RvSHq7DGEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVDivQEeWNKd-GIYRskA" base_Parameter="_CkIhMLDIEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhHVDyvQEeWNKd-GIYRskA" base_Parameter="_OuJDILDMEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVECvQEeWNKd-GIYRskA" base_StructuralFeature="_5tSPwLDcEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVESvQEeWNKd-GIYRskA" base_StructuralFeature="_TMX5QLDdEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVEivQEeWNKd-GIYRskA" base_StructuralFeature="_kRFXcLDdEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mhHVEyvQEeWNKd-GIYRskA" base_Class="_qa8-oLFfEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhHVFCvQEeWNKd-GIYRskA" base_StructuralFeature="_msRQ8LFgEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNboCvQEeWNKd-GIYRskA" base_StructuralFeature="_msbB8rFgEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNboSvQEeWNKd-GIYRskA" base_StructuralFeature="_nn39kbFgEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNboivQEeWNKd-GIYRskA" base_StructuralFeature="_nn39lbFgEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNboyvQEeWNKd-GIYRskA" base_StructuralFeature="_oar6kbFgEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbpCvQEeWNKd-GIYRskA" base_StructuralFeature="_oar6lbFgEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhNbpSvQEeWNKd-GIYRskA" base_Parameter="_ljG98FEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhNbpivQEeWNKd-GIYRskA" base_Parameter="_1cUSUFEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mhNbpyvQEeWNKd-GIYRskA" base_Class="_2NtBsLFkEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbqCvQEeWNKd-GIYRskA" base_StructuralFeature="_Cxy0YbFlEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbqSvQEeWNKd-GIYRskA" base_StructuralFeature="_Cxy0ZbFlEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbqivQEeWNKd-GIYRskA" base_StructuralFeature="_DOQG4bFlEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbqyvQEeWNKd-GIYRskA" base_StructuralFeature="_DOQG5bFlEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbrCvQEeWNKd-GIYRskA" base_StructuralFeature="_D7aH0bFlEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbrSvQEeWNKd-GIYRskA" base_StructuralFeature="_D7aH1bFlEeKY9r1KmoVLlQ" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhNbrivQEeWNKd-GIYRskA" base_Parameter="_NqhcALFmEeKY9r1KmoVLlQ" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhNbryvQEeWNKd-GIYRskA" base_StructuralFeature="_m5dgwbBHEd-cb_q0FhXb-g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhNbsCvQEeWNKd-GIYRskA" base_Operation="_OUb0orF-Ed2MOdzuQUV2bQ" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mhNbsSvQEeWNKd-GIYRskA" base_Association="_WLmsoC0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:Names xmi:id="_mhNbsivQEeWNKd-GIYRskA" base_Association="_NJBR0C0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:Names xmi:id="_mhNbsyvQEeWNKd-GIYRskA" base_Association="_tIO14C0nEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:Names xmi:id="_mhNbtCvQEeWNKd-GIYRskA" base_Association="_T9OmAC0nEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:Names xmi:id="_mhNbtSvQEeWNKd-GIYRskA" base_Association="_FW39oHzOEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:Names xmi:id="_mhNbtivQEeWNKd-GIYRskA" base_Association="_TBR4IHzOEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhNbtyvQEeWNKd-GIYRskA" base_StructuralFeature="_-NTsQL07EeK60ZII6Bg2Kg" valueRange="true, false" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhNbuCvQEeWNKd-GIYRskA" base_Operation="_GDP5YHs3Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiQCvQEeWNKd-GIYRskA" base_Parameter="_2qCI4LDWEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiQSvQEeWNKd-GIYRskA" base_Parameter="_2qCI5LDWEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiQivQEeWNKd-GIYRskA" base_Parameter="_2qCI6LDWEeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiQyvQEeWNKd-GIYRskA" base_Parameter="_2qCI7LDWEeK3DNmPdBk7Xw" valueRange="Depends on the allowed MTU size" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiRCvQEeWNKd-GIYRskA" base_Parameter="_2qCI8LDWEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiRSvQEeWNKd-GIYRskA" base_Parameter="_e-10ALDYEeK3DNmPdBk7Xw" valueRange="0..3" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhTiRivQEeWNKd-GIYRskA" base_Operation="_HnsHoHs3Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiRyvQEeWNKd-GIYRskA" base_Parameter="_I40GYHs5Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiSCvQEeWNKd-GIYRskA" base_Parameter="_es3dwLDZEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiSSvQEeWNKd-GIYRskA" base_Parameter="_es3dw7DZEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiSivQEeWNKd-GIYRskA" base_Parameter="_es3dxrDZEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiSyvQEeWNKd-GIYRskA" base_Parameter="_es3dybDZEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhTiTCvQEeWNKd-GIYRskA" base_Operation="_EPUdoHs3Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiTSvQEeWNKd-GIYRskA" base_Parameter="_rfsQQHs4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiTivQEeWNKd-GIYRskA" base_Parameter="_rfsQQXs4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiTyvQEeWNKd-GIYRskA" base_Parameter="_rfsQQns4Ed2PiqoIrXuTbA" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiUCvQEeWNKd-GIYRskA" base_Parameter="_wMsK4Hs4Ed2PiqoIrXuTbA" valueRange="Depends on the allowed MTU size" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiUSvQEeWNKd-GIYRskA" base_Parameter="_wMsK4Xs4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiUivQEeWNKd-GIYRskA" base_Parameter="_wMsK4ns4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiUyvQEeWNKd-GIYRskA" base_Parameter="_rfsQQ3s4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiVCvQEeWNKd-GIYRskA" base_Parameter="_4VL8AHs4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhTiVSvQEeWNKd-GIYRskA" base_Operation="_BwecoHs3Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiVivQEeWNKd-GIYRskA" base_Parameter="_etUJ8Xs4Ed2PiqoIrXuTbA" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhTiVyvQEeWNKd-GIYRskA" base_Parameter="_k77BQHs4Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhZo4CvQEeWNKd-GIYRskA" base_Operation="_3JKqQHs3Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo4SvQEeWNKd-GIYRskA" base_Parameter="_rmgXwLDbEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo4ivQEeWNKd-GIYRskA" base_Parameter="_rmgXxLDbEeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo4yvQEeWNKd-GIYRskA" base_Parameter="_LVG3gLDcEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo5CvQEeWNKd-GIYRskA" base_Parameter="_I3NHYHs6Ed2PiqoIrXuTbA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhZo5SvQEeWNKd-GIYRskA" base_Operation="_lhru0Hs6Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo5ivQEeWNKd-GIYRskA" base_Parameter="_iQlp4LDeEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo5yvQEeWNKd-GIYRskA" base_Parameter="_iQlp5LDeEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo6CvQEeWNKd-GIYRskA" base_Parameter="_iQlp6LDeEeK3DNmPdBk7Xw" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo6SvQEeWNKd-GIYRskA" base_Parameter="_iQlp7LDeEeK3DNmPdBk7Xw" valueRange="Depends on the allowed MTU size" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo6ivQEeWNKd-GIYRskA" base_Parameter="_iQlp8LDeEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo6yvQEeWNKd-GIYRskA" base_Parameter="_iQlp87DeEeK3DNmPdBk7Xw" valueRange="0..3" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhZo7CvQEeWNKd-GIYRskA" base_Operation="_lhru1Hs6Ed2PiqoIrXuTbA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo7SvQEeWNKd-GIYRskA" base_Parameter="_--uXYLDgEeK3DNmPdBk7Xw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhZo7ivQEeWNKd-GIYRskA" base_Operation="_fEeWgEHDEeGE1M-45R8x1g" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo7yvQEeWNKd-GIYRskA" base_Parameter="_fEeWgUHDEeGE1M-45R8x1g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo8CvQEeWNKd-GIYRskA" base_Parameter="_fEeWgkHDEeGE1M-45R8x1g" valueRange="0..3" condition="none"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhZo8SvQEeWNKd-GIYRskA" base_Operation="_fEeWg0HDEeGE1M-45R8x1g" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo8ivQEeWNKd-GIYRskA" base_Parameter="_fEeWhEHDEeGE1M-45R8x1g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo8yvQEeWNKd-GIYRskA" base_Parameter="_fEeWhUHDEeGE1M-45R8x1g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo9CvQEeWNKd-GIYRskA" base_Parameter="_fEeWhkHDEeGE1M-45R8x1g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo9SvQEeWNKd-GIYRskA" base_Parameter="_fEeWh0HDEeGE1M-45R8x1g" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhZo9ivQEeWNKd-GIYRskA" base_Parameter="_34qY8FEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:Names xmi:id="_mhZo9yvQEeWNKd-GIYRskA" base_Association="_Q_qEYOxsEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhZo-CvQEeWNKd-GIYRskA" base_Parameter="_s-8-cNG2EeKzI4N0oSjmcw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhfvgCvQEeWNKd-GIYRskA" base_Parameter="_s-8-cNG2EeKzI4N0oSjmcw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhfvgSvQEeWNKd-GIYRskA" base_Parameter="_CdZAgNG4EeKzI4N0oSjmcw" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhfvgivQEeWNKd-GIYRskA" base_Parameter="_CdZAgNG4EeKzI4N0oSjmcw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhfvgyvQEeWNKd-GIYRskA" base_StructuralFeature="_Fg6oEi0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhfvhCvQEeWNKd-GIYRskA" base_StructuralFeature="_NjtZ0C0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfvhSvQEeWNKd-GIYRskA" base_StructuralFeature="_rzoicOcNEeK4F9SZ1tiVAA" attributeValueChangeNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfvhivQEeWNKd-GIYRskA" base_StructuralFeature="_GidVgOcOEeK4F9SZ1tiVAA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_mhfvhyvQEeWNKd-GIYRskA" base_StructuralFeature="_GidVgOcOEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfviCvQEeWNKd-GIYRskA" base_StructuralFeature="_HZ1XgOcQEeK4F9SZ1tiVAA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mhfviSvQEeWNKd-GIYRskA" base_Class="_Q-E7oOcVEeK4F9SZ1tiVAA" objectCreationNotification="YES" objectDeletionNotification="YES" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfviivQEeWNKd-GIYRskA" base_StructuralFeature="_Q-E7o-cVEeK4F9SZ1tiVAA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfviyvQEeWNKd-GIYRskA" base_StructuralFeature="_Q-E7pucVEeK4F9SZ1tiVAA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfvjCvQEeWNKd-GIYRskA" base_StructuralFeature="_Q-E7qecVEeK4F9SZ1tiVAA" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfvjSvQEeWNKd-GIYRskA" base_StructuralFeature="_Zp3nEOcVEeK4F9SZ1tiVAA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mhfvjivQEeWNKd-GIYRskA" base_StructuralFeature="_Zp3nFOcVEeK4F9SZ1tiVAA" condition="none"/>
+  <OpenModel_Profile:Names xmi:id="_mhfvjyvQEeWNKd-GIYRskA" base_Association="_ZpksIOcVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mhfvkCvQEeWNKd-GIYRskA" base_Operation="_jKr5MOcZEeK4F9SZ1tiVAA" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhfvkSvQEeWNKd-GIYRskA" base_Parameter="_jKr5NucZEeK4F9SZ1tiVAA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhfvkivQEeWNKd-GIYRskA" base_Parameter="_jKr5OecZEeK4F9SZ1tiVAA" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhfvkyvQEeWNKd-GIYRskA" base_Parameter="_jKr5POcZEeK4F9SZ1tiVAA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mhl2ICvQEeWNKd-GIYRskA" base_Parameter="_Ny94QOcaEeK4F9SZ1tiVAA" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mh4KBCvQEeWNKd-GIYRskA" base_Parameter="_9wY70DcCEeOsEPY42g0uLA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mh4KBSvQEeWNKd-GIYRskA" base_Parameter="_HwK-sDcDEeOsEPY42g0uLA" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh4KBivQEeWNKd-GIYRskA" base_Class="_MhpnUGD2EeSYfK4iPcXSGA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KByvQEeWNKd-GIYRskA" base_StructuralFeature="_FYTwoGD3EeSYfK4iPcXSGA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KCCvQEeWNKd-GIYRskA" base_StructuralFeature="_LaVIAGD4EeSYfK4iPcXSGA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KCSvQEeWNKd-GIYRskA" base_StructuralFeature="_LadD0GD4EeSYfK4iPcXSGA" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KDivQEeWNKd-GIYRskA" base_StructuralFeature="_RGPHcHu-EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KDyvQEeWNKd-GIYRskA" base_StructuralFeature="_Vt2y0Hu-EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KECvQEeWNKd-GIYRskA" base_StructuralFeature="_aARqQHu-EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KESvQEeWNKd-GIYRskA" base_StructuralFeature="_gbmu8Hu-EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KEivQEeWNKd-GIYRskA" base_StructuralFeature="_Lx5DgHu_EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh4KEyvQEeWNKd-GIYRskA" base_Class="_a2d18Hu_EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh4KFCvQEeWNKd-GIYRskA" base_Class="_rsq-EHu_EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh4KFSvQEeWNKd-GIYRskA" base_Class="_upetcHu_EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh4KFivQEeWNKd-GIYRskA" base_Class="_xV_XAHu_EeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KFyvQEeWNKd-GIYRskA" base_StructuralFeature="_9hOvYHvAEeSSGKd_EdTB1w" attributeValueChangeNotification="NO" isInvariant="true" valueRange="See data type" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KGCvQEeWNKd-GIYRskA" base_StructuralFeature="_9hOvY3vAEeSSGKd_EdTB1w" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KGSvQEeWNKd-GIYRskA" base_StructuralFeature="_YYqE0HvBEeSSGKd_EdTB1w" valueRange="0..7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh4KGivQEeWNKd-GIYRskA" base_StructuralFeature="_29LXEHvBEeSSGKd_EdTB1w" valueRange="0..8191" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QoCvQEeWNKd-GIYRskA" base_StructuralFeature="_BBcRUHvCEeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QoSvQEeWNKd-GIYRskA" base_StructuralFeature="_OKX2cHvCEeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QoivQEeWNKd-GIYRskA" base_StructuralFeature="_ScwRoHvCEeSSGKd_EdTB1w" valueRange="Non negative (in seconds)" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QoyvQEeWNKd-GIYRskA" base_StructuralFeature="_ealVkHvCEeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QpCvQEeWNKd-GIYRskA" base_StructuralFeature="_lqgf8HvCEeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QpSvQEeWNKd-GIYRskA" base_StructuralFeature="_tIq6oHvCEeSSGKd_EdTB1w" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QpivQEeWNKd-GIYRskA" base_StructuralFeature="_8PbXAHvFEeSSGKd_EdTB1w" attributeValueChangeNotification="NO" isInvariant="true" valueRange="0, 1, 2, 3, 4, 5, 6, 7" condition="none"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QpyvQEeWNKd-GIYRskA" base_StructuralFeature="_iWO58CFREeWxnoblgNdj6g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mh-QqCvQEeWNKd-GIYRskA" base_Parameter="_aPE6sCFTEeWxnoblgNdj6g" valueRange="1..7"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh-QqSvQEeWNKd-GIYRskA" base_Class="_8QR1UK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QqivQEeWNKd-GIYRskA" base_StructuralFeature="_Tg7zoOhhEeG35t-G7oiZlg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QqyvQEeWNKd-GIYRskA" base_StructuralFeature="_8QR1U64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QrCvQEeWNKd-GIYRskA" base_StructuralFeature="_PHrv4LoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh-QrSvQEeWNKd-GIYRskA" base_Class="_8QIrYK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QrivQEeWNKd-GIYRskA" base_StructuralFeature="_8QIrYq4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QryvQEeWNKd-GIYRskA" base_StructuralFeature="_8QIrY64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QsCvQEeWNKd-GIYRskA" base_StructuralFeature="_UtUisLoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QsSvQEeWNKd-GIYRskA" base_StructuralFeature="_u4pyoOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh-QsivQEeWNKd-GIYRskA" base_Class="_N_4lMC0kEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mh-QsyvQEeWNKd-GIYRskA" base_Class="_9rb-8C0mEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QtCvQEeWNKd-GIYRskA" base_StructuralFeature="_B1fZAC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QtSvQEeWNKd-GIYRskA" base_StructuralFeature="_gysRAC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mh-QtivQEeWNKd-GIYRskA" base_StructuralFeature="_jnIukC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXQCvQEeWNKd-GIYRskA" base_StructuralFeature="_lbEKUC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXQSvQEeWNKd-GIYRskA" base_StructuralFeature="_nUNdQC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXQivQEeWNKd-GIYRskA" base_StructuralFeature="_pjQHsC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXQyvQEeWNKd-GIYRskA" base_StructuralFeature="_rJUtoC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXRCvQEeWNKd-GIYRskA" base_StructuralFeature="_sv_JcC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXRSvQEeWNKd-GIYRskA" base_StructuralFeature="_uZon0C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXRivQEeWNKd-GIYRskA" base_StructuralFeature="_w0TTcC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXRyvQEeWNKd-GIYRskA" base_StructuralFeature="_yc6QAC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miEXSCvQEeWNKd-GIYRskA" base_Class="_HAZtwC0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXSSvQEeWNKd-GIYRskA" base_StructuralFeature="_pU1bwC0yEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXSivQEeWNKd-GIYRskA" base_StructuralFeature="_0_3YIC01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXSyvQEeWNKd-GIYRskA" base_StructuralFeature="__7TK8C01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXTCvQEeWNKd-GIYRskA" base_StructuralFeature="_2QoroOt8EeGPOswgCwFOKw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miEXTSvQEeWNKd-GIYRskA" base_Class="_EJ3lgC0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXTivQEeWNKd-GIYRskA" base_StructuralFeature="_Ny8pgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXTyvQEeWNKd-GIYRskA" base_StructuralFeature="_QsAhUC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXUCvQEeWNKd-GIYRskA" base_StructuralFeature="_Styy4C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXUSvQEeWNKd-GIYRskA" base_StructuralFeature="_VVbjgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXUivQEeWNKd-GIYRskA" base_StructuralFeature="_Xkn-8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXUyvQEeWNKd-GIYRskA" base_StructuralFeature="_Zg5eYC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXVCvQEeWNKd-GIYRskA" base_StructuralFeature="_bXqLsC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXVSvQEeWNKd-GIYRskA" base_StructuralFeature="_dOaR8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miEXVivQEeWNKd-GIYRskA" base_Class="_LH3dQJNdEdyK0-bKI_zx1A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miEXVyvQEeWNKd-GIYRskA" base_StructuralFeature="_yvHlUXnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd4CvQEeWNKd-GIYRskA" base_StructuralFeature="_DndekOxIEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miKd4SvQEeWNKd-GIYRskA" base_Class="_jIOd8JNoEdyK0-bKI_zx1A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd4ivQEeWNKd-GIYRskA" base_StructuralFeature="_G3-DkHnGEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miKd4yvQEeWNKd-GIYRskA" base_Class="_9YdbEJNpEdyK0-bKI_zx1A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miKd5CvQEeWNKd-GIYRskA" base_Class="_KlqYAJNxEdyK0-bKI_zx1A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd5SvQEeWNKd-GIYRskA" base_StructuralFeature="_dORgkJQvEdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd5ivQEeWNKd-GIYRskA" base_StructuralFeature="_dOFTUJQvEdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd5yvQEeWNKd-GIYRskA" base_StructuralFeature="_G3-Dk3nGEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd6CvQEeWNKd-GIYRskA" base_StructuralFeature="_yvRWUHnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miKd6SvQEeWNKd-GIYRskA" base_Class="_2bNC8Hs1Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd6ivQEeWNKd-GIYRskA" base_StructuralFeature="_PzqLAHmsEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd6yvQEeWNKd-GIYRskA" base_StructuralFeature="_zRwE0K5tEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd7CvQEeWNKd-GIYRskA" base_StructuralFeature="_RFsbQkKUEeGOU_Aog4a34g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd7SvQEeWNKd-GIYRskA" base_StructuralFeature="_RFsbREKUEeGOU_Aog4a34g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miKd7ivQEeWNKd-GIYRskA" base_StructuralFeature="_ORBewEKVEeGOU_Aog4a34g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miKd7yvQEeWNKd-GIYRskA" base_Operation="_9diacIveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd8CvQEeWNKd-GIYRskA" base_Parameter="_9diacoveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd8SvQEeWNKd-GIYRskA" base_Parameter="_9diadYveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd8ivQEeWNKd-GIYRskA" base_Parameter="_9diaeIveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd8yvQEeWNKd-GIYRskA" base_Parameter="_9diae4veEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd9CvQEeWNKd-GIYRskA" base_Parameter="_9diafoveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd9SvQEeWNKd-GIYRskA" base_Parameter="_9diagYveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd9ivQEeWNKd-GIYRskA" base_Parameter="_9diahIveEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miKd9yvQEeWNKd-GIYRskA" base_Operation="_SKavQJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd-CvQEeWNKd-GIYRskA" base_Parameter="_SKavQpVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd-SvQEeWNKd-GIYRskA" base_Parameter="_SKavRZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miKd-ivQEeWNKd-GIYRskA" base_Parameter="_SKavSJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkgCvQEeWNKd-GIYRskA" base_Parameter="_SKavS5VNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkgSvQEeWNKd-GIYRskA" base_Parameter="_SKavTpVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkgivQEeWNKd-GIYRskA" base_Parameter="_SKavUZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkgyvQEeWNKd-GIYRskA" base_Parameter="_9wY70DcCEeOsEPY42g0uLA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkhCvQEeWNKd-GIYRskA" base_Parameter="_SKavVJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miQkhSvQEeWNKd-GIYRskA" base_Operation="_GDP5YHs3Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkhivQEeWNKd-GIYRskA" base_Parameter="_2qCI4LDWEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkhyvQEeWNKd-GIYRskA" base_Parameter="_2qCI5LDWEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkiCvQEeWNKd-GIYRskA" base_Parameter="_2qCI6LDWEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkiSvQEeWNKd-GIYRskA" base_Parameter="_2qCI7LDWEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkiivQEeWNKd-GIYRskA" base_Parameter="_2qCI8LDWEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkiyvQEeWNKd-GIYRskA" base_Parameter="_e-10ALDYEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miQkjCvQEeWNKd-GIYRskA" base_Operation="_HnsHoHs3Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkjSvQEeWNKd-GIYRskA" base_Parameter="_I40GYHs5Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkjivQEeWNKd-GIYRskA" base_Parameter="_es3dwLDZEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkjyvQEeWNKd-GIYRskA" base_Parameter="_es3dw7DZEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkkCvQEeWNKd-GIYRskA" base_Parameter="_es3dxrDZEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkkSvQEeWNKd-GIYRskA" base_Parameter="_es3dybDZEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miQkkivQEeWNKd-GIYRskA" base_Operation="_EPUdoHs3Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQkkyvQEeWNKd-GIYRskA" base_Parameter="_rfsQQHs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQklCvQEeWNKd-GIYRskA" base_Parameter="_rfsQQXs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQklSvQEeWNKd-GIYRskA" base_Parameter="_rfsQQns4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miQklivQEeWNKd-GIYRskA" base_Parameter="_wMsK4Hs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrICvQEeWNKd-GIYRskA" base_Parameter="_wMsK4Xs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrISvQEeWNKd-GIYRskA" base_Parameter="_wMsK4ns4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrIivQEeWNKd-GIYRskA" base_Parameter="_rfsQQ3s4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrIyvQEeWNKd-GIYRskA" base_Parameter="_4VL8AHs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miWrJCvQEeWNKd-GIYRskA" base_Operation="_BwecoHs3Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrJSvQEeWNKd-GIYRskA" base_Parameter="_etUJ8Xs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrJivQEeWNKd-GIYRskA" base_Parameter="_k77BQHs4Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miWrJyvQEeWNKd-GIYRskA" base_Operation="_3JKqQHs3Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrKCvQEeWNKd-GIYRskA" base_Parameter="_rmgXwLDbEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrKSvQEeWNKd-GIYRskA" base_Parameter="_rmgXxLDbEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrKivQEeWNKd-GIYRskA" base_Parameter="_LVG3gLDcEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrKyvQEeWNKd-GIYRskA" base_Parameter="_I3NHYHs6Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miWrLCvQEeWNKd-GIYRskA" base_Operation="_lhru0Hs6Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrLSvQEeWNKd-GIYRskA" base_Parameter="_iQlp4LDeEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrLivQEeWNKd-GIYRskA" base_Parameter="_iQlp5LDeEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrLyvQEeWNKd-GIYRskA" base_Parameter="_iQlp6LDeEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrMCvQEeWNKd-GIYRskA" base_Parameter="_iQlp7LDeEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrMSvQEeWNKd-GIYRskA" base_Parameter="_iQlp8LDeEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrMivQEeWNKd-GIYRskA" base_Parameter="_iQlp87DeEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_miWrMyvQEeWNKd-GIYRskA" base_Operation="_lhru1Hs6Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_miWrNCvQEeWNKd-GIYRskA" base_Parameter="_--uXYLDgEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_miWrNSvQEeWNKd-GIYRskA" base_Class="_5tTs4Hs1Ed2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miWrNivQEeWNKd-GIYRskA" base_StructuralFeature="_w3AmUJNhEdyK0-bKI_zx1A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miWrNyvQEeWNKd-GIYRskA" base_StructuralFeature="_VRWTkFEEEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miWrOCvQEeWNKd-GIYRskA" base_StructuralFeature="_VRWTkVEEEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miWrOSvQEeWNKd-GIYRskA" base_StructuralFeature="_ljgjQEKUEeGOU_Aog4a34g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miWrOivQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5uwa5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_miWrOyvQEeWNKd-GIYRskA" base_StructuralFeature="_BRGWcF72EeGyKcjKnV9Bqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_micxwCvQEeWNKd-GIYRskA" base_StructuralFeature="_Lx5DgHu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_micxwSvQEeWNKd-GIYRskA" base_StructuralFeature="_iWO58CFREeWxnoblgNdj6g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_micxwivQEeWNKd-GIYRskA" base_Operation="_4pws8IvfEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxwyvQEeWNKd-GIYRskA" base_Parameter="_4pws8ovfEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxxCvQEeWNKd-GIYRskA" base_Parameter="_aPE6sCFTEeWxnoblgNdj6g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxxSvQEeWNKd-GIYRskA" base_Parameter="_4pws9YvfEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxxivQEeWNKd-GIYRskA" base_Parameter="_l471wIvgEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxxyvQEeWNKd-GIYRskA" base_Parameter="_l471xIvgEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxyCvQEeWNKd-GIYRskA" base_Parameter="_4pws-4vfEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxySvQEeWNKd-GIYRskA" base_Parameter="_4pwtBIvfEeKIPqQgvzcmyg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_micxyivQEeWNKd-GIYRskA" base_Operation="_dtqI8JVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxyyvQEeWNKd-GIYRskA" base_Parameter="_dtqI8pVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxzCvQEeWNKd-GIYRskA" base_Parameter="_dtqI9ZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxzSvQEeWNKd-GIYRskA" base_Parameter="_dtqI-JVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxzivQEeWNKd-GIYRskA" base_Parameter="_dtqI_pVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micxzyvQEeWNKd-GIYRskA" base_Parameter="_CdZAgNG4EeKzI4N0oSjmcw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx0CvQEeWNKd-GIYRskA" base_Parameter="_dtqJAZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_micx0SvQEeWNKd-GIYRskA" base_Operation="_wOAB8EKSEeGOU_Aog4a34g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx0ivQEeWNKd-GIYRskA" base_Parameter="_I1YokK5yEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_micx0yvQEeWNKd-GIYRskA" base_Operation="_fEeWgEHDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx1CvQEeWNKd-GIYRskA" base_Parameter="_fEeWgUHDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx1SvQEeWNKd-GIYRskA" base_Parameter="_fEeWgkHDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_micx1ivQEeWNKd-GIYRskA" base_Operation="_fEeWg0HDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx1yvQEeWNKd-GIYRskA" base_Parameter="_fEeWhEHDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx2CvQEeWNKd-GIYRskA" base_Parameter="_fEeWhUHDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx2SvQEeWNKd-GIYRskA" base_Parameter="_fEeWhkHDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_micx2ivQEeWNKd-GIYRskA" base_Parameter="_fEeWh0HDEeGE1M-45R8x1g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_micx2yvQEeWNKd-GIYRskA" base_StructuralFeature="_NrL8UHtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4YCvQEeWNKd-GIYRskA" base_StructuralFeature="_NrCLUXtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4YSvQEeWNKd-GIYRskA" base_StructuralFeature="_W4OTpHtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4YivQEeWNKd-GIYRskA" base_StructuralFeature="_W4OToXtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mii4YyvQEeWNKd-GIYRskA" base_Class="_hTWOsHtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4ZCvQEeWNKd-GIYRskA" base_StructuralFeature="_MvZqMC0jEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4ZSvQEeWNKd-GIYRskA" base_StructuralFeature="_NJBR0S0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4ZivQEeWNKd-GIYRskA" base_StructuralFeature="_i-TdIZMwEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4ZyvQEeWNKd-GIYRskA" base_StructuralFeature="_wETvgDiDEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4aCvQEeWNKd-GIYRskA" base_StructuralFeature="_LaVIAGD4EeSYfK4iPcXSGA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mii4aSvQEeWNKd-GIYRskA" base_Class="_7tJM8HtREd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4aivQEeWNKd-GIYRskA" base_StructuralFeature="_tM1l4C0jEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4ayvQEeWNKd-GIYRskA" base_StructuralFeature="_WLmsoS0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4bCvQEeWNKd-GIYRskA" base_StructuralFeature="_R8wyQZMxEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4bSvQEeWNKd-GIYRskA" base_StructuralFeature="_dMn88ZMxEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4bivQEeWNKd-GIYRskA" base_StructuralFeature="_Z0-xIDiEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4byvQEeWNKd-GIYRskA" base_StructuralFeature="_s0Va8XzYEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4cCvQEeWNKd-GIYRskA" base_StructuralFeature="_g6M5cHtSEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4cSvQEeWNKd-GIYRskA" base_StructuralFeature="_g6DIcXtSEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4civQEeWNKd-GIYRskA" base_StructuralFeature="_zsbCVHtSEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4cyvQEeWNKd-GIYRskA" base_StructuralFeature="_zsbCUXtSEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4dCvQEeWNKd-GIYRskA" base_StructuralFeature="_BVoqAntTEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mii4dSvQEeWNKd-GIYRskA" base_StructuralFeature="_BVe5AXtTEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mii4divQEeWNKd-GIYRskA" base_Class="_q3kNQHzNEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mii4dyvQEeWNKd-GIYRskA" base_Operation="_PwxOYFGdEd6JXKS-hDEWDw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mii4eCvQEeWNKd-GIYRskA" base_Parameter="_iIePUEUoEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mii4eSvQEeWNKd-GIYRskA" base_Parameter="_tpMV8EUnEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mii4eivQEeWNKd-GIYRskA" base_Parameter="_0Qc90EUnEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mii4eyvQEeWNKd-GIYRskA" base_Parameter="_JraqkEUoEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_ACvQEeWNKd-GIYRskA" base_Parameter="_PCWTAEUoEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_ASvQEeWNKd-GIYRskA" base_Parameter="_rtGAMEUoEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mio_AivQEeWNKd-GIYRskA" base_Operation="_3HdUQEU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_AyvQEeWNKd-GIYRskA" base_Parameter="_3HdUQkU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_BCvQEeWNKd-GIYRskA" base_Parameter="_3HdUREU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_BSvQEeWNKd-GIYRskA" base_Parameter="_3HdUSEU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_BivQEeWNKd-GIYRskA" base_Parameter="_3HdUTEU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_ByvQEeWNKd-GIYRskA" base_Parameter="_3HdUUEU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_CCvQEeWNKd-GIYRskA" base_Parameter="_3HdUVEU0EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mio_CSvQEeWNKd-GIYRskA" base_Operation="_OnV0MEU3EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_CivQEeWNKd-GIYRskA" base_Parameter="_OnV0MkU3EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mio_CyvQEeWNKd-GIYRskA" base_Operation="_U3G2EFGdEd6JXKS-hDEWDw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_DCvQEeWNKd-GIYRskA" base_Parameter="_hNrnwEU4EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mio_DSvQEeWNKd-GIYRskA" base_Operation="_GDMW8EU5EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_DivQEeWNKd-GIYRskA" base_Parameter="_GDMW8kU5EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mio_DyvQEeWNKd-GIYRskA" base_Parameter="_Sp8cEEU5EeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_ECvQEeWNKd-GIYRskA" base_StructuralFeature="_17X49HzNEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_ESvQEeWNKd-GIYRskA" base_StructuralFeature="_17X48XzNEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_EivQEeWNKd-GIYRskA" base_StructuralFeature="_4Hl45HzNEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_EyvQEeWNKd-GIYRskA" base_StructuralFeature="_4Hl44XzNEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_FCvQEeWNKd-GIYRskA" base_StructuralFeature="_FXBuonzOEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_FSvQEeWNKd-GIYRskA" base_StructuralFeature="_FW39oXzOEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_FivQEeWNKd-GIYRskA" base_StructuralFeature="_TBbCE3zOEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_FyvQEeWNKd-GIYRskA" base_StructuralFeature="_TBbCEHzOEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mio_GCvQEeWNKd-GIYRskA" base_Class="_y-K5QHzTEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_GSvQEeWNKd-GIYRskA" base_StructuralFeature="_J3_wsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_GivQEeWNKd-GIYRskA" base_StructuralFeature="_PFLnQHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_GyvQEeWNKd-GIYRskA" base_StructuralFeature="_QoRxsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_HCvQEeWNKd-GIYRskA" base_StructuralFeature="_NjtZ0C0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mio_HSvQEeWNKd-GIYRskA" base_StructuralFeature="_ibtJIC0kEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFoCvQEeWNKd-GIYRskA" base_StructuralFeature="_tIO14S0nEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFoSvQEeWNKd-GIYRskA" base_Class="_eo4lsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFoivQEeWNKd-GIYRskA" base_StructuralFeature="_Fg6oEi0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFoyvQEeWNKd-GIYRskA" base_StructuralFeature="_T9OmAS0nEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFpCvQEeWNKd-GIYRskA" base_StructuralFeature="_rz0BMOxdEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFpSvQEeWNKd-GIYRskA" base_Class="_PuDIoHzVEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFpivQEeWNKd-GIYRskA" base_StructuralFeature="_PuMSoXzVEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFpyvQEeWNKd-GIYRskA" base_StructuralFeature="_PuMSknzVEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFqCvQEeWNKd-GIYRskA" base_StructuralFeature="_s0Va9HzYEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFqSvQEeWNKd-GIYRskA" base_Class="_n4NGYLFVEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFqivQEeWNKd-GIYRskA" base_StructuralFeature="_WztYsLFXEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFqyvQEeWNKd-GIYRskA" base_StructuralFeature="_jBTYULGWEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFrCvQEeWNKd-GIYRskA" base_Class="_hq-gYLFbEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFrSvQEeWNKd-GIYRskA" base_StructuralFeature="_9PcskLFcEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFrivQEeWNKd-GIYRskA" base_StructuralFeature="_1dFfMFGcEd6JXKS-hDEWDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFryvQEeWNKd-GIYRskA" base_StructuralFeature="_O9UTJLF2Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFsCvQEeWNKd-GIYRskA" base_StructuralFeature="_O9UTIbF2Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFsSvQEeWNKd-GIYRskA" base_StructuralFeature="_qbzBgLF2Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFsivQEeWNKd-GIYRskA" base_StructuralFeature="_qbp3kbF2Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFsyvQEeWNKd-GIYRskA" base_Class="_OUb0kLF-Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFtCvQEeWNKd-GIYRskA" base_StructuralFeature="_OUb0lLF-Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFtSvQEeWNKd-GIYRskA" base_StructuralFeature="_ETNv0LGVEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFtivQEeWNKd-GIYRskA" base_Class="_AwH-MLGCEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFtyvQEeWNKd-GIYRskA" base_StructuralFeature="_G4s2QLGTEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFuCvQEeWNKd-GIYRskA" base_StructuralFeature="_37XpYLGUEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mivFuSvQEeWNKd-GIYRskA" base_Class="_pSB6ELGXEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFuivQEeWNKd-GIYRskA" base_StructuralFeature="_pSB6FLGXEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mivFuyvQEeWNKd-GIYRskA" base_StructuralFeature="_OsYW8EUQEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MQCvQEeWNKd-GIYRskA" base_StructuralFeature="_PJcGYEUQEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MQSvQEeWNKd-GIYRskA" base_StructuralFeature="_PjOfYEUQEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MQivQEeWNKd-GIYRskA" base_StructuralFeature="_ZVrbcEUREeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MQyvQEeWNKd-GIYRskA" base_StructuralFeature="_9l4sNLJEEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MRCvQEeWNKd-GIYRskA" base_StructuralFeature="_9l4sMbJEEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MRSvQEeWNKd-GIYRskA" base_StructuralFeature="_Mhyq0LJFEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MRivQEeWNKd-GIYRskA" base_StructuralFeature="_Mhpg4bJFEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MRyvQEeWNKd-GIYRskA" base_StructuralFeature="_dCbyoLJFEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MSCvQEeWNKd-GIYRskA" base_StructuralFeature="_dCSosbJFEd2akMdVSPw5LA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mi1MSSvQEeWNKd-GIYRskA" base_Class="_aoUckMa9Ed2dpqWvHBkVSw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MSivQEeWNKd-GIYRskA" base_StructuralFeature="_7DoIRaKREeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi1MSyvQEeWNKd-GIYRskA" base_StructuralFeature="_6nCA9aKTEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi1MTCvQEeWNKd-GIYRskA" base_Operation="_hGuCRlEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MTSvQEeWNKd-GIYRskA" base_Parameter="_81PAoFEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MTivQEeWNKd-GIYRskA" base_Parameter="_81PAo1EcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MTyvQEeWNKd-GIYRskA" base_Parameter="_K2nQsFEdEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MUCvQEeWNKd-GIYRskA" base_Parameter="_81PAolEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MUSvQEeWNKd-GIYRskA" base_Parameter="_81PAplEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MUivQEeWNKd-GIYRskA" base_Parameter="_81PAp1EcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MUyvQEeWNKd-GIYRskA" base_Parameter="_81PAoVEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi1MVCvQEeWNKd-GIYRskA" base_Operation="_YcS9AJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MVSvQEeWNKd-GIYRskA" base_Parameter="_YcS9ApVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MVivQEeWNKd-GIYRskA" base_Parameter="_YcS9BZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MVyvQEeWNKd-GIYRskA" base_Parameter="_YcS9CJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MWCvQEeWNKd-GIYRskA" base_Parameter="_YcS9C5VNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MWSvQEeWNKd-GIYRskA" base_Parameter="_YcS9DpVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MWivQEeWNKd-GIYRskA" base_Parameter="_YcS9EZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi1MWyvQEeWNKd-GIYRskA" base_Parameter="_s-8-cNG2EeKzI4N0oSjmcw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S4CvQEeWNKd-GIYRskA" base_Parameter="_HwK-sDcDEeOsEPY42g0uLA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S4SvQEeWNKd-GIYRskA" base_Parameter="_YcS9FJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mi7S4ivQEeWNKd-GIYRskA" base_Class="_udkZQEVwEd6WrOYSXNJbnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi7S4yvQEeWNKd-GIYRskA" base_StructuralFeature="_5HJIAm7yEd-KS-RjpPlIeg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi7S5CvQEeWNKd-GIYRskA" base_StructuralFeature="_5HJIAG7yEd-KS-RjpPlIeg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi7S5SvQEeWNKd-GIYRskA" base_StructuralFeature="_vk1BYEwPEeGk0vxVMJiPiA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mi7S5ivQEeWNKd-GIYRskA" base_Class="_hGuCQFEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S5yvQEeWNKd-GIYRskA" base_Operation="_hGuCQ1EIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S6CvQEeWNKd-GIYRskA" base_Parameter="_ljG98FEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S6SvQEeWNKd-GIYRskA" base_Operation="_hGuCRFEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S6ivQEeWNKd-GIYRskA" base_Parameter="_1cUSUFEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S6yvQEeWNKd-GIYRskA" base_Operation="_hGuCRVEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S7CvQEeWNKd-GIYRskA" base_Parameter="_34qY8FEcEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S7SvQEeWNKd-GIYRskA" base_Operation="_hGuCSlEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S7ivQEeWNKd-GIYRskA" base_Parameter="__ck-IGCpEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S7yvQEeWNKd-GIYRskA" base_Parameter="_kF85UGCrEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S8CvQEeWNKd-GIYRskA" base_Operation="_hGuCS1EIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S8SvQEeWNKd-GIYRskA" base_Parameter="__U9oUWCrEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S8ivQEeWNKd-GIYRskA" base_Parameter="_fKFxYGCtEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S8yvQEeWNKd-GIYRskA" base_Parameter="_qAZUkIASEeK2Wa4B6ppTIw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S9CvQEeWNKd-GIYRskA" base_Parameter="__U9oVmCrEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S9SvQEeWNKd-GIYRskA" base_Operation="_hGuCSFEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S9ivQEeWNKd-GIYRskA" base_Parameter="_odyw8FEdEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mi7S9yvQEeWNKd-GIYRskA" base_Operation="_hGuCSVEIEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S-CvQEeWNKd-GIYRskA" base_Parameter="_s0u8AFEdEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mi7S-SvQEeWNKd-GIYRskA" base_Parameter="_NqhcALFmEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mi7S-ivQEeWNKd-GIYRskA" base_Class="_ShisIFEJEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi7S-yvQEeWNKd-GIYRskA" base_StructuralFeature="_OJcCAIsZEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mi7S_CvQEeWNKd-GIYRskA" base_StructuralFeature="_ShisIVEJEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjBZgCvQEeWNKd-GIYRskA" base_Operation="_ShisIlEJEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZgSvQEeWNKd-GIYRskA" base_Parameter="__CmsQELLEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjBZgivQEeWNKd-GIYRskA" base_Class="_ShisI1EJEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZgyvQEeWNKd-GIYRskA" base_StructuralFeature="_DCDeUFEUEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZhCvQEeWNKd-GIYRskA" base_StructuralFeature="_IqBMYFEUEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZhSvQEeWNKd-GIYRskA" base_StructuralFeature="_Bk0rUFEUEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZhivQEeWNKd-GIYRskA" base_StructuralFeature="_EkEDoFEUEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZhyvQEeWNKd-GIYRskA" base_StructuralFeature="_GzuZIFEUEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZiCvQEeWNKd-GIYRskA" base_StructuralFeature="_PvwAcJVJEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZiSvQEeWNKd-GIYRskA" base_StructuralFeature="_PvwAdJVJEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZiivQEeWNKd-GIYRskA" base_StructuralFeature="_biD4JFEOEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZiyvQEeWNKd-GIYRskA" base_StructuralFeature="_biD4IVEOEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZjCvQEeWNKd-GIYRskA" base_StructuralFeature="_juKW5FEOEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjBZjSvQEeWNKd-GIYRskA" base_StructuralFeature="_juKW4VEOEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjBZjivQEeWNKd-GIYRskA" base_Class="_pH_vEFEeEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjBZjyvQEeWNKd-GIYRskA" base_Operation="_3vbxAVEHEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZkCvQEeWNKd-GIYRskA" base_Parameter="_Xr2L0FEfEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZkSvQEeWNKd-GIYRskA" base_Parameter="_ZvHEEFEfEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZkivQEeWNKd-GIYRskA" base_Parameter="_m9tE8FEiEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZkyvQEeWNKd-GIYRskA" base_Parameter="_zrC6QFEiEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjBZlCvQEeWNKd-GIYRskA" base_Operation="_3vbxAlEHEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZlSvQEeWNKd-GIYRskA" base_Parameter="_ky5X8LDFEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZlivQEeWNKd-GIYRskA" base_Parameter="_RvSHoLDGEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZlyvQEeWNKd-GIYRskA" base_Parameter="_RvSHprDGEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZmCvQEeWNKd-GIYRskA" base_Parameter="_RvSHq7DGEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjBZmSvQEeWNKd-GIYRskA" base_Operation="_3vbxAFEHEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZmivQEeWNKd-GIYRskA" base_Parameter="_y3-cQLDFEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjBZmyvQEeWNKd-GIYRskA" base_Operation="__u--VFEDEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjBZnCvQEeWNKd-GIYRskA" base_Parameter="_CkIhMLDIEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjHgICvQEeWNKd-GIYRskA" base_Class="_mFSZwFEjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgISvQEeWNKd-GIYRskA" base_Operation="_mFSZzlEjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgIivQEeWNKd-GIYRskA" base_Parameter="_mFSZz1EjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgIyvQEeWNKd-GIYRskA" base_Parameter="_mFSZ0VEjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgJCvQEeWNKd-GIYRskA" base_Parameter="_mFSZ0lEjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgJSvQEeWNKd-GIYRskA" base_Operation="_jKr5MOcZEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgJivQEeWNKd-GIYRskA" base_Parameter="_jKr5NucZEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgJyvQEeWNKd-GIYRskA" base_Parameter="_jKr5OecZEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgKCvQEeWNKd-GIYRskA" base_Parameter="_Ny94QOcaEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgKSvQEeWNKd-GIYRskA" base_Parameter="_jKr5POcZEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgKivQEeWNKd-GIYRskA" base_Operation="_mFSZ1FEjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgKyvQEeWNKd-GIYRskA" base_Parameter="_mFSZ1VEjEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgLCvQEeWNKd-GIYRskA" base_Operation="__u--UlEDEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgLSvQEeWNKd-GIYRskA" base_Parameter="_OuJDILDMEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjHgLivQEeWNKd-GIYRskA" base_Class="_C8IyYK5wEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgLyvQEeWNKd-GIYRskA" base_Operation="_80JuMK50Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgMCvQEeWNKd-GIYRskA" base_Parameter="_pJKKMK84Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgMSvQEeWNKd-GIYRskA" base_Parameter="_ULvEUMLcEd6YQenVf3pcTg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgMivQEeWNKd-GIYRskA" base_Operation="_aO_w4K6cEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgMyvQEeWNKd-GIYRskA" base_Parameter="_u3IfcLH0EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgNCvQEeWNKd-GIYRskA" base_Parameter="_5HFsULH0EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgNSvQEeWNKd-GIYRskA" base_Parameter="_B43D8LH1EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjHgNivQEeWNKd-GIYRskA" base_Operation="_BiJuYK51Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjHgNyvQEeWNKd-GIYRskA" base_Parameter="_vNwFILHzEeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjHgOCvQEeWNKd-GIYRskA" base_Class="_XWZTQK50Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjHgOSvQEeWNKd-GIYRskA" base_StructuralFeature="_dZBFUK8qEd6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjHgOivQEeWNKd-GIYRskA" base_StructuralFeature="_swANsK87Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjHgOyvQEeWNKd-GIYRskA" base_StructuralFeature="_oFFuQMI1Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNmwCvQEeWNKd-GIYRskA" base_StructuralFeature="_6nWywMI5Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNmwSvQEeWNKd-GIYRskA" base_StructuralFeature="_coxJwMLWEd6YQenVf3pcTg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNmwivQEeWNKd-GIYRskA" base_StructuralFeature="_BFgoUdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNmxCvQEeWNKd-GIYRskA" base_Operation="_ekJSIJKEEeC-CLEnZ54sHQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjNmxSvQEeWNKd-GIYRskA" base_Parameter="_2cCl4LH1EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjNmxivQEeWNKd-GIYRskA" base_Parameter="_2cCl5rH1EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNmxyvQEeWNKd-GIYRskA" base_Operation="_sUCwEMI3Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjNmyCvQEeWNKd-GIYRskA" base_Parameter="_YYddgLH1EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjNmySvQEeWNKd-GIYRskA" base_Parameter="_n2pCwLH1EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNmyivQEeWNKd-GIYRskA" base_Operation="_gMS7sJKEEeC-CLEnZ54sHQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjNmyyvQEeWNKd-GIYRskA" base_Parameter="_33FyILH2EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNmzCvQEeWNKd-GIYRskA" base_Operation="_aSOuELGeEeCEz6U6aBks4w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNmzSvQEeWNKd-GIYRskA" base_StructuralFeature="_gtXpta50Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNmzivQEeWNKd-GIYRskA" base_StructuralFeature="_gtXpsa50Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjNmzyvQEeWNKd-GIYRskA" base_Class="_1c3s4K6bEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm0CvQEeWNKd-GIYRskA" base_StructuralFeature="_dZBFVK8qEd6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm0SvQEeWNKd-GIYRskA" base_StructuralFeature="_ZfbU4K87Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm0ivQEeWNKd-GIYRskA" base_StructuralFeature="_-zuGcK9qEd6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm0yvQEeWNKd-GIYRskA" base_StructuralFeature="_mp2qULFXEeC6XaWwVljZZQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm1CvQEeWNKd-GIYRskA" base_StructuralFeature="_AP_XALFYEeC6XaWwVljZZQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm1SvQEeWNKd-GIYRskA" base_StructuralFeature="_WSBq0LFYEeC6XaWwVljZZQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm1ivQEeWNKd-GIYRskA" base_StructuralFeature="_nSzPgKtMEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNm1yvQEeWNKd-GIYRskA" base_Operation="_UemfkK6cEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjNm2CvQEeWNKd-GIYRskA" base_Parameter="_LwJuoLH0EeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNm2SvQEeWNKd-GIYRskA" base_Operation="_Nx7L8K87Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjNm2ivQEeWNKd-GIYRskA" base_Operation="_STboQK87Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm2yvQEeWNKd-GIYRskA" base_StructuralFeature="_7xo2lK6bEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjNm3CvQEeWNKd-GIYRskA" base_StructuralFeature="_7xo2kK6bEd6cFIpdu8eLhA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjTtYCvQEeWNKd-GIYRskA" base_Class="_euub0MI1Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtYSvQEeWNKd-GIYRskA" base_StructuralFeature="_4pVHMcI2Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtYivQEeWNKd-GIYRskA" base_StructuralFeature="_oFPfQsI1Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtYyvQEeWNKd-GIYRskA" base_StructuralFeature="_4pVHNcI2Ed6E-_NkXJHasg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtZCvQEeWNKd-GIYRskA" base_StructuralFeature="_co66wMLWEd6YQenVf3pcTg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjTtZSvQEeWNKd-GIYRskA" base_Class="_zUI_oNg5Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtZivQEeWNKd-GIYRskA" base_StructuralFeature="_gRDeUdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtZyvQEeWNKd-GIYRskA" base_StructuralFeature="_k8HfQdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtaCvQEeWNKd-GIYRskA" base_StructuralFeature="_iysCsNg9Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtaSvQEeWNKd-GIYRskA" base_StructuralFeature="_6A51wNg9Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtaivQEeWNKd-GIYRskA" base_StructuralFeature="_oU3SUOM0Ed6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtayvQEeWNKd-GIYRskA" base_StructuralFeature="_p7dAMeM1Ed6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtbCvQEeWNKd-GIYRskA" base_StructuralFeature="_A9Y3QGEaEeG_P5asDyU-5Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtbSvQEeWNKd-GIYRskA" base_StructuralFeature="_6nCA8aKTEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtbivQEeWNKd-GIYRskA" base_Operation="_u2N0ENg_Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtbyvQEeWNKd-GIYRskA" base_Operation="_rOp3gNg_Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtcCvQEeWNKd-GIYRskA" base_Operation="_JZ9_kNhAEd6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtcSvQEeWNKd-GIYRskA" base_Operation="_0RQgcNg_Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjTtcivQEeWNKd-GIYRskA" base_Parameter="_m9Mz8NhAEd6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtcyvQEeWNKd-GIYRskA" base_Operation="_VHfWoNhAEd6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtdCvQEeWNKd-GIYRskA" base_Operation="_OyDa4OM-Ed6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjTtdSvQEeWNKd-GIYRskA" base_Operation="_UEx4wOM-Ed6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtdivQEeWNKd-GIYRskA" base_StructuralFeature="_BFgoVdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTtdyvQEeWNKd-GIYRskA" base_StructuralFeature="_gRDeVdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTteCvQEeWNKd-GIYRskA" base_StructuralFeature="_k8HfRdg7Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTteSvQEeWNKd-GIYRskA" base_StructuralFeature="_p7mxMeM1Ed6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjTteivQEeWNKd-GIYRskA" base_Class="_e9IQcONAEd6bKNI_ISUo3g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjTteyvQEeWNKd-GIYRskA" base_StructuralFeature="_vwnaYOVyEd6DFLLQeSx-cQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0ACvQEeWNKd-GIYRskA" base_StructuralFeature="_24SAoOVyEd6DFLLQeSx-cQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0ASvQEeWNKd-GIYRskA" base_StructuralFeature="_7dIr4OVyEd6DFLLQeSx-cQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0AivQEeWNKd-GIYRskA" base_StructuralFeature="_IJXPIO5AEd6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0AyvQEeWNKd-GIYRskA" base_StructuralFeature="_30W6IO5AEd6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0BCvQEeWNKd-GIYRskA" base_StructuralFeature="_4KxgMGEbEeG_P5asDyU-5Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0BSvQEeWNKd-GIYRskA" base_StructuralFeature="_7DoIQaKREeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0BivQEeWNKd-GIYRskA" base_StructuralFeature="_rzoicOcNEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjZ0ByvQEeWNKd-GIYRskA" base_Operation="_BVkSAO4-Ed6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjZ0CCvQEeWNKd-GIYRskA" base_Parameter="_lNjuwKHfEeKb96dZOhIJOg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjZ0CSvQEeWNKd-GIYRskA" base_Operation="_BVkSBu4-Ed6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjZ0CivQEeWNKd-GIYRskA" base_Parameter="_BVkSCO4-Ed6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjZ0CyvQEeWNKd-GIYRskA" base_Operation="_McN2UO4-Ed6_S_YQ08vnYw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjZ0DCvQEeWNKd-GIYRskA" base_Class="_EL9m8LBHEd-cb_q0FhXb-g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0DSvQEeWNKd-GIYRskA" base_StructuralFeature="_m5dgwbBHEd-cb_q0FhXb-g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0DivQEeWNKd-GIYRskA" base_StructuralFeature="_BHJ8sLBIEd-cb_q0FhXb-g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjZ0DyvQEeWNKd-GIYRskA" base_Class="_SpyQECrVEeCLmY2bQg3hqQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0ECvQEeWNKd-GIYRskA" base_StructuralFeature="_djuYoCrWEeCLmY2bQg3hqQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0ESvQEeWNKd-GIYRskA" base_StructuralFeature="_FgxeIC0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0EivQEeWNKd-GIYRskA" base_StructuralFeature="_Njjo0S0UEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0EyvQEeWNKd-GIYRskA" base_StructuralFeature="_MvP5MS0jEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0FCvQEeWNKd-GIYRskA" base_StructuralFeature="_tMsb8S0jEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjZ0FSvQEeWNKd-GIYRskA" base_StructuralFeature="_2OgTUC0mEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjZ0FivQEeWNKd-GIYRskA" base_Operation="_gv3kgCrWEeCLmY2bQg3hqQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjZ0FyvQEeWNKd-GIYRskA" base_Parameter="_gPgtUK5JEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjZ0GCvQEeWNKd-GIYRskA" base_Parameter="_gPgtVa5JEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjZ0GSvQEeWNKd-GIYRskA" base_Operation="_jkBHICrWEeCLmY2bQg3hqQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjZ0GivQEeWNKd-GIYRskA" base_Parameter="_1ZB9YK5MEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjZ0GyvQEeWNKd-GIYRskA" base_Operation="_lhVvcCrWEeCLmY2bQg3hqQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjZ0HCvQEeWNKd-GIYRskA" base_Parameter="_oWZDMK2sEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjf6oCvQEeWNKd-GIYRskA" base_Parameter="_4UXjkK5AEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjf6oSvQEeWNKd-GIYRskA" base_Operation="_m9uN4CrWEeCLmY2bQg3hqQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjf6oivQEeWNKd-GIYRskA" base_Parameter="_RAVigK5LEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6oyvQEeWNKd-GIYRskA" base_StructuralFeature="_T9YXAC0nEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6pCvQEeWNKd-GIYRskA" base_StructuralFeature="_tIO15S0nEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6pSvQEeWNKd-GIYRskA" base_StructuralFeature="_NJBR1S0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6pivQEeWNKd-GIYRskA" base_StructuralFeature="_WLmspS0oEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6pyvQEeWNKd-GIYRskA" base_StructuralFeature="_WZLK4DqXEeCu35lketJ8Yg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6qCvQEeWNKd-GIYRskA" base_StructuralFeature="_WY4P8TqXEeCu35lketJ8Yg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6qSvQEeWNKd-GIYRskA" base_StructuralFeature="_lKwTZDqYEeCu35lketJ8Yg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6qivQEeWNKd-GIYRskA" base_StructuralFeature="_lKwTYDqYEeCu35lketJ8Yg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6qyvQEeWNKd-GIYRskA" base_StructuralFeature="_i-dOIZMwEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6rCvQEeWNKd-GIYRskA" base_StructuralFeature="_R858MJMxEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6rSvQEeWNKd-GIYRskA" base_StructuralFeature="_dMxt8JMxEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6rivQEeWNKd-GIYRskA" base_StructuralFeature="_wEdggDiDEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6ryvQEeWNKd-GIYRskA" base_StructuralFeature="_Z0-xJDiEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjf6sCvQEeWNKd-GIYRskA" base_Class="_SXjBcENUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6sSvQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFIIstEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6sivQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFJIstEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6syvQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFKIstEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6tCvQEeWNKd-GIYRskA" base_StructuralFeature="_SXjBd0NUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6tSvQEeWNKd-GIYRskA" base_StructuralFeature="_jlPFLIstEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6tivQEeWNKd-GIYRskA" base_StructuralFeature="_SXjBfUNUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjf6tyvQEeWNKd-GIYRskA" base_StructuralFeature="_8PbXAHvFEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjf6uCvQEeWNKd-GIYRskA" base_Operation="_SXjBfkNUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjf6uSvQEeWNKd-GIYRskA" base_Parameter="_6mI8YUOZEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjf6uivQEeWNKd-GIYRskA" base_Class="_0P-7gENUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBQCvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7hUNUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBQSvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7iUNUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBQivQEeWNKd-GIYRskA" base_StructuralFeature="_Ca6jMWEwEeG_P5asDyU-5Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBQyvQEeWNKd-GIYRskA" base_StructuralFeature="_lzmTAkNrEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBRCvQEeWNKd-GIYRskA" base_StructuralFeature="_lzciAUNrEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBRSvQEeWNKd-GIYRskA" base_StructuralFeature="_nkddlUN0EeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBRivQEeWNKd-GIYRskA" base_StructuralFeature="_nkddkUN0EeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBRyvQEeWNKd-GIYRskA" base_StructuralFeature="_CbEUMmEwEeG_P5asDyU-5Q"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjmBSCvQEeWNKd-GIYRskA" base_Class="_0SmDII4dEeGi1ZUWXLd2-A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBSSvQEeWNKd-GIYRskA" base_StructuralFeature="_BGdXMI4eEeGi1ZUWXLd2-A"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjmBSivQEeWNKd-GIYRskA" base_Operation="_xU8JwI4eEeGi1ZUWXLd2-A"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjmBSyvQEeWNKd-GIYRskA" base_Operation="_zJw9YI4eEeGi1ZUWXLd2-A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBTCvQEeWNKd-GIYRskA" base_StructuralFeature="_BGnIMo4eEeGi1ZUWXLd2-A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBTSvQEeWNKd-GIYRskA" base_StructuralFeature="_dPCVYa4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBTivQEeWNKd-GIYRskA" base_StructuralFeature="_dOlpcK4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBTyvQEeWNKd-GIYRskA" base_StructuralFeature="_ooJitK4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBUCvQEeWNKd-GIYRskA" base_StructuralFeature="_ooJisK4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBUSvQEeWNKd-GIYRskA" base_StructuralFeature="_xpkf4q4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBUivQEeWNKd-GIYRskA" base_StructuralFeature="_xpau4a4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBUyvQEeWNKd-GIYRskA" base_StructuralFeature="_z63NEK4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBVCvQEeWNKd-GIYRskA" base_StructuralFeature="_z6tcEa4xEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjmBVSvQEeWNKd-GIYRskA" base_Class="_7ySKwOuGEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjmBVivQEeWNKd-GIYRskA" base_StructuralFeature="_Osz7EOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjmBVyvQEeWNKd-GIYRskA" base_Operation="_g-C4ALoJEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjmBWCvQEeWNKd-GIYRskA" base_Parameter="_7OvFkOz2EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjmBWSvQEeWNKd-GIYRskA" base_Parameter="_sLKD4KKsEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjmBWivQEeWNKd-GIYRskA" base_Parameter="_aTn58Oz3EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjmBWyvQEeWNKd-GIYRskA" base_Parameter="_xid_IOz3EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjmBXCvQEeWNKd-GIYRskA" base_Parameter="_ECYQAOz4EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjsH4CvQEeWNKd-GIYRskA" base_Operation="_982q8OzxEeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjsH4SvQEeWNKd-GIYRskA" base_Operation="_FG7E8OzyEeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH4ivQEeWNKd-GIYRskA" base_Parameter="_iUeqoOz6EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH4yvQEeWNKd-GIYRskA" base_Parameter="_1p1vYKKtEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH5CvQEeWNKd-GIYRskA" base_Parameter="_iUobpOz6EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH5SvQEeWNKd-GIYRskA" base_Parameter="_iUoboOz6EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjsH5ivQEeWNKd-GIYRskA" base_Operation="_KQGlQOzyEeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH5yvQEeWNKd-GIYRskA" base_Parameter="_PzHy0Oz7EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH6CvQEeWNKd-GIYRskA" base_Parameter="_nqxzgKKtEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH6SvQEeWNKd-GIYRskA" base_Parameter="_VkX_wOz7EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH6ivQEeWNKd-GIYRskA" base_Parameter="_gN-bsOz7EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH6yvQEeWNKd-GIYRskA" base_Parameter="_PzHy1uz7EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH7CvQEeWNKd-GIYRskA" base_Parameter="_PzHy2uz7EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjsH7SvQEeWNKd-GIYRskA" base_Operation="_hdn0wOzyEeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mjsH7ivQEeWNKd-GIYRskA" base_Operation="_hdn0w-zyEeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH7yvQEeWNKd-GIYRskA" base_Parameter="_ZUm6sOz8EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH8CvQEeWNKd-GIYRskA" base_Parameter="_2ur3kKKtEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH8SvQEeWNKd-GIYRskA" base_Parameter="_ZUm6tuz8EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH8ivQEeWNKd-GIYRskA" base_Parameter="_ZUm6vOz8EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mjsH8yvQEeWNKd-GIYRskA" base_Parameter="_ZUm6xOz8EeGAeLnLFLO9_g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjsH9CvQEeWNKd-GIYRskA" base_Class="_W8ZgwOuJEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH9SvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5ut65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH9ivQEeWNKd-GIYRskA" base_StructuralFeature="_CvRXAK5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH9yvQEeWNKd-GIYRskA" base_StructuralFeature="_CwwkwK5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH-CvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5us65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH-SvQEeWNKd-GIYRskA" base_StructuralFeature="_Cwwkw65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH-ivQEeWNKd-GIYRskA" base_StructuralFeature="_Cwwkxa5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH-yvQEeWNKd-GIYRskA" base_StructuralFeature="_Cwwkx65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjsH_CvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5usa5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOgCvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5uua5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOgSvQEeWNKd-GIYRskA" base_StructuralFeature="_Cw5uva5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjyOgivQEeWNKd-GIYRskA" base_Class="_ACUEMOxFEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjyOgyvQEeWNKd-GIYRskA" base_Class="_fzLz0OxQEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOhCvQEeWNKd-GIYRskA" base_StructuralFeature="_ABD1QexsEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOhSvQEeWNKd-GIYRskA" base_StructuralFeature="_ABM_MOxsEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOhivQEeWNKd-GIYRskA" base_StructuralFeature="_Q_qEZexsEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOhyvQEeWNKd-GIYRskA" base_StructuralFeature="_Q_qEYexsEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOiCvQEeWNKd-GIYRskA" base_StructuralFeature="_o7GL1UQ6EeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOiSvQEeWNKd-GIYRskA" base_StructuralFeature="_o7GL0UQ6EeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjyOiivQEeWNKd-GIYRskA" base_Class="_6gIJAERfEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOiyvQEeWNKd-GIYRskA" base_StructuralFeature="_6gIJBERfEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOjCvQEeWNKd-GIYRskA" base_StructuralFeature="_6gIJB0RfEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjyOjSvQEeWNKd-GIYRskA" base_Class="_3ZT3IERhEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOjivQEeWNKd-GIYRskA" base_StructuralFeature="_3ZT3I0RhEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOjyvQEeWNKd-GIYRskA" base_StructuralFeature="_3ZT3JkRhEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOkCvQEeWNKd-GIYRskA" base_StructuralFeature="_LvOnYkRiEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOkSvQEeWNKd-GIYRskA" base_StructuralFeature="_LvFdcERiEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjyOkivQEeWNKd-GIYRskA" base_Class="_1D9goERyEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOkyvQEeWNKd-GIYRskA" base_StructuralFeature="_1D9gpERyEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOlCvQEeWNKd-GIYRskA" base_StructuralFeature="_1D9gpkRyEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOlSvQEeWNKd-GIYRskA" base_StructuralFeature="_JWAdgERzEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOlivQEeWNKd-GIYRskA" base_StructuralFeature="_JV3TkURzEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mjyOlyvQEeWNKd-GIYRskA" base_Class="_Kfrl4ER0EeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOmCvQEeWNKd-GIYRskA" base_StructuralFeature="_Kfrl5ER0EeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOmSvQEeWNKd-GIYRskA" base_StructuralFeature="_Kfrl5kR0EeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOmivQEeWNKd-GIYRskA" base_StructuralFeature="_o32eNUR0EeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mjyOmyvQEeWNKd-GIYRskA" base_StructuralFeature="_o32eMUR0EeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj4VICvQEeWNKd-GIYRskA" base_Class="_FnT98EUSEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VISvQEeWNKd-GIYRskA" base_StructuralFeature="_ZV1MckUREeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_mj4VIivQEeWNKd-GIYRskA" base_Operation="_OUb0orF-Ed2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VIyvQEeWNKd-GIYRskA" base_StructuralFeature="_O9ZPYmCkEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VJCvQEeWNKd-GIYRskA" base_StructuralFeature="_O9QFcGCkEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VJSvQEeWNKd-GIYRskA" base_StructuralFeature="_Rhm4lWCkEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VJivQEeWNKd-GIYRskA" base_StructuralFeature="_Rhm4kWCkEeKJHOJsrnUaqw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VJyvQEeWNKd-GIYRskA" base_StructuralFeature="_TVE6koAPEeK2Wa4B6ppTIw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VKCvQEeWNKd-GIYRskA" base_StructuralFeature="_TU7JkIAPEeK2Wa4B6ppTIw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj4VKSvQEeWNKd-GIYRskA" base_Class="_GoQsYIsVEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VKivQEeWNKd-GIYRskA" base_StructuralFeature="_tsg8wFEWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VKyvQEeWNKd-GIYRskA" base_StructuralFeature="_vJKg8FEWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VLCvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEs1EWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VLSvQEeWNKd-GIYRskA" base_StructuralFeature="_IsxNEFyhEeG9K6GVnuYc0w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VLivQEeWNKd-GIYRskA" base_StructuralFeature="__0StUFycEeG9K6GVnuYc0w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VLyvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEtFEWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VMCvQEeWNKd-GIYRskA" base_StructuralFeature="_3vQ0EFEWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VMSvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEslEWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VMivQEeWNKd-GIYRskA" base_StructuralFeature="_ttIDg4sfEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VMyvQEeWNKd-GIYRskA" base_StructuralFeature="_ttIDgIsfEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj4VNCvQEeWNKd-GIYRskA" base_Class="_hJ3Q4IsXEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VNSvQEeWNKd-GIYRskA" base_StructuralFeature="_pfzEsFEWEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj4VNivQEeWNKd-GIYRskA" base_Class="_2sFHoJVIEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VNyvQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHopVIEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VOCvQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHqZVIEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VOSvQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHrJVIEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VOivQEeWNKd-GIYRskA" base_StructuralFeature="_2sFHr5VIEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VOyvQEeWNKd-GIYRskA" base_StructuralFeature="_1vAUAJVLEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj4VPCvQEeWNKd-GIYRskA" base_StructuralFeature="_1vAUBJVLEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj-bwCvQEeWNKd-GIYRskA" base_Class="_xCFuYJVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bwSvQEeWNKd-GIYRskA" base_StructuralFeature="_xCFuZJVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bwivQEeWNKd-GIYRskA" base_StructuralFeature="_xCFuh5VKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj-bwyvQEeWNKd-GIYRskA" base_Class="_xCFugZVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bxCvQEeWNKd-GIYRskA" base_StructuralFeature="_xCFug5VKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bxSvQEeWNKd-GIYRskA" base_StructuralFeature="_4qTVkJVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bxivQEeWNKd-GIYRskA" base_StructuralFeature="_A5XBsJVOEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bxyvQEeWNKd-GIYRskA" base_StructuralFeature="_xCFuhZVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj-byCvQEeWNKd-GIYRskA" base_Class="_12GP8JVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bySvQEeWNKd-GIYRskA" base_StructuralFeature="_12GP9JVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-byivQEeWNKd-GIYRskA" base_StructuralFeature="_3Vi-kpVMEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-byyvQEeWNKd-GIYRskA" base_StructuralFeature="_3VZNkJVMEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bzCvQEeWNKd-GIYRskA" base_StructuralFeature="_-Dby5ZVMEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bzSvQEeWNKd-GIYRskA" base_StructuralFeature="_-Dby4ZVMEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bzivQEeWNKd-GIYRskA" base_StructuralFeature="_EkDnRZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-bzyvQEeWNKd-GIYRskA" base_StructuralFeature="_EkDnQZVNEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b0CvQEeWNKd-GIYRskA" base_StructuralFeature="_2Lx19ZVTEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b0SvQEeWNKd-GIYRskA" base_StructuralFeature="_2Lx18ZVTEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b0ivQEeWNKd-GIYRskA" base_StructuralFeature="_GXkIFZVUEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b0yvQEeWNKd-GIYRskA" base_StructuralFeature="_GXkIEZVUEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b1CvQEeWNKd-GIYRskA" base_StructuralFeature="_7ByGJZVUEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b1SvQEeWNKd-GIYRskA" base_StructuralFeature="_7ByGIZVUEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b1ivQEeWNKd-GIYRskA" base_StructuralFeature="_GpphJZVVEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b1yvQEeWNKd-GIYRskA" base_StructuralFeature="_GpphIZVVEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b2CvQEeWNKd-GIYRskA" base_StructuralFeature="_QNEkFKHKEeKRNLblqYhoTg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b2SvQEeWNKd-GIYRskA" base_StructuralFeature="_QNEkEKHKEeKRNLblqYhoTg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mj-b2ivQEeWNKd-GIYRskA" base_StructuralFeature="_nTGKcqtMEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj-b2yvQEeWNKd-GIYRskA" base_Class="_EhoxsK5BEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mj-b3CvQEeWNKd-GIYRskA" base_Class="_djhh0K5BEeKXNfjfbIxfYg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkEiYCvQEeWNKd-GIYRskA" base_Class="_qa8-oLFfEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiYSvQEeWNKd-GIYRskA" base_StructuralFeature="_msRQ8LFgEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiYivQEeWNKd-GIYRskA" base_StructuralFeature="_nn39kbFgEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiYyvQEeWNKd-GIYRskA" base_StructuralFeature="_oar6kbFgEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiZCvQEeWNKd-GIYRskA" base_StructuralFeature="_msbB8rFgEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiZSvQEeWNKd-GIYRskA" base_StructuralFeature="_nn39lbFgEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiZivQEeWNKd-GIYRskA" base_StructuralFeature="_oar6lbFgEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkEiZyvQEeWNKd-GIYRskA" base_Class="_2NtBsLFkEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiaCvQEeWNKd-GIYRskA" base_StructuralFeature="_Cxy0YbFlEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiaSvQEeWNKd-GIYRskA" base_StructuralFeature="_DOQG4bFlEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiaivQEeWNKd-GIYRskA" base_StructuralFeature="_D7aH0bFlEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEiayvQEeWNKd-GIYRskA" base_StructuralFeature="_Cxy0ZbFlEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEibCvQEeWNKd-GIYRskA" base_StructuralFeature="_DOQG5bFlEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEibSvQEeWNKd-GIYRskA" base_StructuralFeature="_D7aH1bFlEeKY9r1KmoVLlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkEibivQEeWNKd-GIYRskA" base_Class="_Q-E7oOcVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEibyvQEeWNKd-GIYRskA" base_StructuralFeature="_Q-E7o-cVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEicCvQEeWNKd-GIYRskA" base_StructuralFeature="_Q-E7pucVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEicSvQEeWNKd-GIYRskA" base_StructuralFeature="_Q-E7qecVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEicivQEeWNKd-GIYRskA" base_StructuralFeature="_Zp3nFOcVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEicyvQEeWNKd-GIYRskA" base_StructuralFeature="_Zp3nEOcVEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEidCvQEeWNKd-GIYRskA" base_StructuralFeature="_LadD0GD4EeSYfK4iPcXSGA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkEidSvQEeWNKd-GIYRskA" base_Class="_a2d18Hu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEidivQEeWNKd-GIYRskA" base_StructuralFeature="_9hOvYHvAEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEidyvQEeWNKd-GIYRskA" base_StructuralFeature="_9hOvY3vAEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkEieCvQEeWNKd-GIYRskA" base_Class="_rsq-EHu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEieSvQEeWNKd-GIYRskA" base_StructuralFeature="_tIq6oHvCEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkEieivQEeWNKd-GIYRskA" base_Class="_upetcHu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkEieyvQEeWNKd-GIYRskA" base_StructuralFeature="_YYqE0HvBEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpACvQEeWNKd-GIYRskA" base_StructuralFeature="_29LXEHvBEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpASvQEeWNKd-GIYRskA" base_StructuralFeature="_BBcRUHvCEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpAivQEeWNKd-GIYRskA" base_StructuralFeature="_OKX2cHvCEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpAyvQEeWNKd-GIYRskA" base_StructuralFeature="_ScwRoHvCEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mkKpBCvQEeWNKd-GIYRskA" base_Class="_xV_XAHu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpBSvQEeWNKd-GIYRskA" base_StructuralFeature="_inWUgq5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpBivQEeWNKd-GIYRskA" base_StructuralFeature="_inWUga5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpByvQEeWNKd-GIYRskA" base_StructuralFeature="_lUUGgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpCCvQEeWNKd-GIYRskA" base_StructuralFeature="_u9XrcK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpCSvQEeWNKd-GIYRskA" base_StructuralFeature="_vWtYgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpCivQEeWNKd-GIYRskA" base_StructuralFeature="_ru2d0K5FEeGvr_m5yJYoog"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpCyvQEeWNKd-GIYRskA" base_StructuralFeature="_DFS_0K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpDCvQEeWNKd-GIYRskA" base_StructuralFeature="_Dc1WEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpDSvQEeWNKd-GIYRskA" base_StructuralFeature="_Dw9L8K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpDivQEeWNKd-GIYRskA" base_StructuralFeature="_KSMrYK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpDyvQEeWNKd-GIYRskA" base_StructuralFeature="_KnNSEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpECvQEeWNKd-GIYRskA" base_StructuralFeature="_nQw7kOuTEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpESvQEeWNKd-GIYRskA" base_StructuralFeature="_ZitIoEUCEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpEivQEeWNKd-GIYRskA" base_StructuralFeature="_gIj0LbGXEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpEyvQEeWNKd-GIYRskA" base_StructuralFeature="_gIj0L7GXEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpFCvQEeWNKd-GIYRskA" base_StructuralFeature="_vHYAcEUBEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpFSvQEeWNKd-GIYRskA" base_StructuralFeature="_vHYAc0UBEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpFivQEeWNKd-GIYRskA" base_StructuralFeature="_v1aLIEUBEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpFyvQEeWNKd-GIYRskA" base_StructuralFeature="_v1aLI0UBEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpGCvQEeWNKd-GIYRskA" base_StructuralFeature="_oF4ZgVEYEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpGSvQEeWNKd-GIYRskA" base_StructuralFeature="_oF4Zg1EYEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpGivQEeWNKd-GIYRskA" base_StructuralFeature="_oGBjcVEYEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkKpGyvQEeWNKd-GIYRskA" base_StructuralFeature="_GFPJMVEZEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvoCvQEeWNKd-GIYRskA" base_StructuralFeature="_GFPJNFEZEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvoSvQEeWNKd-GIYRskA" base_StructuralFeature="_CxiCsURZEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvoivQEeWNKd-GIYRskA" base_StructuralFeature="_CxiCtERZEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvoyvQEeWNKd-GIYRskA" base_StructuralFeature="_GFPJNlEZEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvpCvQEeWNKd-GIYRskA" base_StructuralFeature="_uyMrEVEZEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvpSvQEeWNKd-GIYRskA" base_StructuralFeature="_uyMrE1EZEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvpivQEeWNKd-GIYRskA" base_StructuralFeature="_uyMrFVEZEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvpyvQEeWNKd-GIYRskA" base_StructuralFeature="_BikMsEN-EeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvqCvQEeWNKd-GIYRskA" base_StructuralFeature="_zeuZsVEbEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvqSvQEeWNKd-GIYRskA" base_StructuralFeature="_zeuZt1EbEd6VSrclB-Ybig"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvqivQEeWNKd-GIYRskA" base_StructuralFeature="_qHWqkKzoEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvqyvQEeWNKd-GIYRskA" base_StructuralFeature="_1e2uUazoEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvrCvQEeWNKd-GIYRskA" base_StructuralFeature="_7rYiAazoEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvrSvQEeWNKd-GIYRskA" base_StructuralFeature="_jetogK87Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvrivQEeWNKd-GIYRskA" base_StructuralFeature="_5fHkoK87Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvryvQEeWNKd-GIYRskA" base_StructuralFeature="_7Cr9cK9tEd6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvsCvQEeWNKd-GIYRskA" base_StructuralFeature="_eszVgK83Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvsSvQEeWNKd-GIYRskA" base_StructuralFeature="_nfNmUa83Ed6PiOh_CmtkmA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvsivQEeWNKd-GIYRskA" base_StructuralFeature="_huabo8LbEd6YQenVf3pcTg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvsyvQEeWNKd-GIYRskA" base_StructuralFeature="_34lwYazpEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvtCvQEeWNKd-GIYRskA" base_StructuralFeature="_4obR4azpEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvtSvQEeWNKd-GIYRskA" base_StructuralFeature="_JJfGYCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvtivQEeWNKd-GIYRskA" base_StructuralFeature="_3BAMICbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvtyvQEeWNKd-GIYRskA" base_StructuralFeature="_3ey7YCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvuCvQEeWNKd-GIYRskA" base_StructuralFeature="_3-PQcCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvuSvQEeWNKd-GIYRskA" base_StructuralFeature="_4T_eACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkQvuivQEeWNKd-GIYRskA" base_StructuralFeature="_4mnfECbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2QCvQEeWNKd-GIYRskA" base_StructuralFeature="_46SB8CbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2QSvQEeWNKd-GIYRskA" base_StructuralFeature="_5ND0ACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2QivQEeWNKd-GIYRskA" base_StructuralFeature="_clWxkJKBEeC-CLEnZ54sHQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2QyvQEeWNKd-GIYRskA" base_StructuralFeature="_wjcQoJKBEeC-CLEnZ54sHQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2RCvQEeWNKd-GIYRskA" base_StructuralFeature="_JBRRcJKCEeC-CLEnZ54sHQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2RSvQEeWNKd-GIYRskA" base_StructuralFeature="_aF-voJKCEeC-CLEnZ54sHQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2RivQEeWNKd-GIYRskA" base_StructuralFeature="_v2Z2ALHyEeCfvvdYcIeVoQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2RyvQEeWNKd-GIYRskA" base_StructuralFeature="_u99zIKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2SCvQEeWNKd-GIYRskA" base_StructuralFeature="_3jh6wKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2SSvQEeWNKd-GIYRskA" base_StructuralFeature="_4sRKIOuIEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2SivQEeWNKd-GIYRskA" base_StructuralFeature="_loYNAeuJEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2SyvQEeWNKd-GIYRskA" base_StructuralFeature="_6xacQeuJEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2TCvQEeWNKd-GIYRskA" base_StructuralFeature="_BZXAoeuKEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2TSvQEeWNKd-GIYRskA" base_StructuralFeature="_4saUEuuIEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2TivQEeWNKd-GIYRskA" base_StructuralFeature="_loYNBeuJEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2TyvQEeWNKd-GIYRskA" base_StructuralFeature="_6xacReuJEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2UCvQEeWNKd-GIYRskA" base_StructuralFeature="_BZgKkOuKEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2USvQEeWNKd-GIYRskA" base_StructuralFeature="_ABzeMEN2EeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2UivQEeWNKd-GIYRskA" base_StructuralFeature="_in3IsEN1EeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2UyvQEeWNKd-GIYRskA" base_StructuralFeature="_in3Is0N1EeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2VCvQEeWNKd-GIYRskA" base_StructuralFeature="_Qp12cEOVEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2VSvQEeWNKd-GIYRskA" base_StructuralFeature="_1k454IszEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2VivQEeWNKd-GIYRskA" base_StructuralFeature="_Qp_neUOVEeKtRKTHZgJhIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2VyvQEeWNKd-GIYRskA" base_StructuralFeature="_VF54UkRhEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2WCvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVAURsEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2WSvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVA0RsEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2WivQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVBURsEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkW2WyvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVE0RsEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc84CvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVFURsEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc84SvQEeWNKd-GIYRskA" base_StructuralFeature="_3FTVF0RsEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc84ivQEeWNKd-GIYRskA" base_StructuralFeature="_ecldYkRtEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc84yvQEeWNKd-GIYRskA" base_StructuralFeature="_ecldZERtEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc85CvQEeWNKd-GIYRskA" base_StructuralFeature="_HZhU8ERuEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc85SvQEeWNKd-GIYRskA" base_StructuralFeature="_eZFOskRzEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc85ivQEeWNKd-GIYRskA" base_StructuralFeature="_HPZvYUUNEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc85yvQEeWNKd-GIYRskA" base_StructuralFeature="_HPZvY0UNEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc86CvQEeWNKd-GIYRskA" base_StructuralFeature="_HPZvZUUNEeKsbYfVW3kmQQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc86SvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiQUUgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc86ivQEeWNKd-GIYRskA" base_StructuralFeature="_unxiQ0UgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc86yvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiRUUgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc87CvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiR0UgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc87SvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiSUUgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc87ivQEeWNKd-GIYRskA" base_StructuralFeature="_unxiS0UgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc87yvQEeWNKd-GIYRskA" base_StructuralFeature="_unxiTUUgEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc88CvQEeWNKd-GIYRskA" base_StructuralFeature="_fHOWwkUmEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc88SvQEeWNKd-GIYRskA" base_StructuralFeature="_fHOWxEUmEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc88ivQEeWNKd-GIYRskA" base_StructuralFeature="_fHOWxkUmEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc88yvQEeWNKd-GIYRskA" base_StructuralFeature="_VIVkcosyEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc89CvQEeWNKd-GIYRskA" base_StructuralFeature="_1k455IszEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc89SvQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i44u0EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc89ivQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i5ou0EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc89yvQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i7ou0EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc8-CvQEeWNKd-GIYRskA" base_StructuralFeature="_LD4i84u0EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc8-SvQEeWNKd-GIYRskA" base_StructuralFeature="_c0CVUou1EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc8-ivQEeWNKd-GIYRskA" base_StructuralFeature="_pjlxIIu1EeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkc8-yvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP4IvDEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDgCvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP5IvDEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDgSvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP6IvDEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDgivQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP8IvDEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDgyvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP7IvDEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDhCvQEeWNKd-GIYRskA" base_StructuralFeature="_cEuP9IvDEeK2NvDLt60gDw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDhSvQEeWNKd-GIYRskA" base_StructuralFeature="_qHWqlKzoEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDhivQEeWNKd-GIYRskA" base_StructuralFeature="_1e2uVazoEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDhyvQEeWNKd-GIYRskA" base_StructuralFeature="_7rYiBazoEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDiCvQEeWNKd-GIYRskA" base_StructuralFeature="_34lwZazpEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDiSvQEeWNKd-GIYRskA" base_StructuralFeature="_4obR5azpEeK4UJp6At-puA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDiivQEeWNKd-GIYRskA" base_StructuralFeature="_rIRxQK2GEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDiyvQEeWNKd-GIYRskA" base_StructuralFeature="_G-8WIK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDjCvQEeWNKd-GIYRskA" base_StructuralFeature="_lUPgoK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDjSvQEeWNKd-GIYRskA" base_StructuralFeature="_lz-woK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDjivQEeWNKd-GIYRskA" base_StructuralFeature="_mKelEK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDjyvQEeWNKd-GIYRskA" base_StructuralFeature="_mczrMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDkCvQEeWNKd-GIYRskA" base_StructuralFeature="_musscK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDkSvQEeWNKd-GIYRskA" base_StructuralFeature="_nAuQkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDkivQEeWNKd-GIYRskA" base_StructuralFeature="_naW4kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDkyvQEeWNKd-GIYRskA" base_StructuralFeature="_ntlWkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDlCvQEeWNKd-GIYRskA" base_StructuralFeature="_n_6csK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDlSvQEeWNKd-GIYRskA" base_StructuralFeature="_oRWK8K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDlivQEeWNKd-GIYRskA" base_StructuralFeature="_ol6FsK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDlyvQEeWNKd-GIYRskA" base_StructuralFeature="_o4PL0K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDmCvQEeWNKd-GIYRskA" base_StructuralFeature="_pM83kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDmSvQEeWNKd-GIYRskA" base_StructuralFeature="_phOecK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDmivQEeWNKd-GIYRskA" base_StructuralFeature="_p1yZMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkjDmyvQEeWNKd-GIYRskA" base_StructuralFeature="_bebnMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKICvQEeWNKd-GIYRskA" base_StructuralFeature="_frjH4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKISvQEeWNKd-GIYRskA" base_StructuralFeature="_gN0ugK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKIivQEeWNKd-GIYRskA" base_StructuralFeature="_gkeT8K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKIyvQEeWNKd-GIYRskA" base_StructuralFeature="_g5VJoK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKJCvQEeWNKd-GIYRskA" base_StructuralFeature="_hOVwUK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKJSvQEeWNKd-GIYRskA" base_StructuralFeature="_hjWXAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKJivQEeWNKd-GIYRskA" base_StructuralFeature="_h3Ub4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKJyvQEeWNKd-GIYRskA" base_StructuralFeature="_iNrGYK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKKCvQEeWNKd-GIYRskA" base_StructuralFeature="_igTHcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKKSvQEeWNKd-GIYRskA" base_StructuralFeature="_i1AzMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKKivQEeWNKd-GIYRskA" base_StructuralFeature="_jJbkAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKKyvQEeWNKd-GIYRskA" base_StructuralFeature="_jf7YcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKLCvQEeWNKd-GIYRskA" base_StructuralFeature="_jzJ2cK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKLSvQEeWNKd-GIYRskA" base_StructuralFeature="_kIwTAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKLivQEeWNKd-GIYRskA" base_StructuralFeature="_lBOzIK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKLyvQEeWNKd-GIYRskA" base_StructuralFeature="_N48CEK2uEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKMCvQEeWNKd-GIYRskA" base_StructuralFeature="_N48CFa2uEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKMSvQEeWNKd-GIYRskA" base_StructuralFeature="_N48CGa2uEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKMivQEeWNKd-GIYRskA" base_StructuralFeature="_DTkJYq2vEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKMyvQEeWNKd-GIYRskA" base_StructuralFeature="_spRGQK2vEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKNCvQEeWNKd-GIYRskA" base_StructuralFeature="_6A5Osa2vEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKNSvQEeWNKd-GIYRskA" base_StructuralFeature="_spa3Qq2vEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKNivQEeWNKd-GIYRskA" base_StructuralFeature="_6A5Ota2vEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKNyvQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy0q2wEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkpKOCvQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy1q2wEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQwCvQEeWNKd-GIYRskA" base_StructuralFeature="_C1yy2a2wEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQwSvQEeWNKd-GIYRskA" base_StructuralFeature="_C18j0a2wEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQwivQEeWNKd-GIYRskA" base_StructuralFeature="_C18j1q2wEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQwyvQEeWNKd-GIYRskA" base_StructuralFeature="_X8wwEK2xEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQxCvQEeWNKd-GIYRskA" base_StructuralFeature="_-NTsQL07EeK60ZII6Bg2Kg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQxSvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades0LC_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQxivQEeWNKd-GIYRskA" base_StructuralFeature="_Ades27C_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQxyvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades47C_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQyCvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades57C_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQySvQEeWNKd-GIYRskA" base_StructuralFeature="_Adn2wLC_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQyivQEeWNKd-GIYRskA" base_StructuralFeature="_Adn2xLC_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQyyvQEeWNKd-GIYRskA" base_StructuralFeature="_Adn2yrC_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQzCvQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLsLDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQzSvQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLs7DAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQzivQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLt7DAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQzyvQEeWNKd-GIYRskA" base_StructuralFeature="_HtjLu7DAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ0CvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades1LC_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ0SvQEeWNKd-GIYRskA" base_StructuralFeature="_Ades17C_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ0ivQEeWNKd-GIYRskA" base_StructuralFeature="_Ades4LC_EeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ0yvQEeWNKd-GIYRskA" base_StructuralFeature="_Q10XwLDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ1CvQEeWNKd-GIYRskA" base_StructuralFeature="_Q10XxrDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ1SvQEeWNKd-GIYRskA" base_StructuralFeature="_Q10XzLDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ1ivQEeWNKd-GIYRskA" base_StructuralFeature="_Q10X0rDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ1yvQEeWNKd-GIYRskA" base_StructuralFeature="_Q1-IwLDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mkvQ2CvQEeWNKd-GIYRskA" base_StructuralFeature="_Q1-IxLDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XYCvQEeWNKd-GIYRskA" base_StructuralFeature="_K7egQLDAEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XYSvQEeWNKd-GIYRskA" base_StructuralFeature="_5tSPwLDcEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XYivQEeWNKd-GIYRskA" base_StructuralFeature="_TMX5QLDdEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XYyvQEeWNKd-GIYRskA" base_StructuralFeature="_kRFXcLDdEeK3DNmPdBk7Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XZCvQEeWNKd-GIYRskA" base_StructuralFeature="_GidVgOcOEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XZSvQEeWNKd-GIYRskA" base_StructuralFeature="_HZ1XgOcQEeK4F9SZ1tiVAA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XZivQEeWNKd-GIYRskA" base_StructuralFeature="_RGPHcHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XZyvQEeWNKd-GIYRskA" base_StructuralFeature="_Vt2y0Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XaCvQEeWNKd-GIYRskA" base_StructuralFeature="_aARqQHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XaSvQEeWNKd-GIYRskA" base_StructuralFeature="_gbmu8Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XaivQEeWNKd-GIYRskA" base_StructuralFeature="_ealVkHvCEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mk1XayvQEeWNKd-GIYRskA" base_StructuralFeature="_lqgf8HvCEeSSGKd_EdTB1w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mmdIBCvQEeWNKd-GIYRskA" base_StructuralFeature="_egYId2ruEd6ERPrpHLFGMw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mmdIBivQEeWNKd-GIYRskA" base_StructuralFeature="_egYIdGruEd6ERPrpHLFGMw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mmdIByvQEeWNKd-GIYRskA" base_StructuralFeature="_egYIeWruEd6ERPrpHLFGMw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mmdIDCvQEeWNKd-GIYRskA" base_StructuralFeature="_m5mqsrBHEd-cb_q0FhXb-g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mm7pKCvQEeWNKd-GIYRskA" base_Class="_YybDQHzBEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pKSvQEeWNKd-GIYRskA" base_StructuralFeature="_n-WkYH2REd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pKivQEeWNKd-GIYRskA" base_StructuralFeature="_uGZgsH2REd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pKyvQEeWNKd-GIYRskA" base_StructuralFeature="_3k8M0X2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pLCvQEeWNKd-GIYRskA" base_StructuralFeature="_546akX2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pLSvQEeWNKd-GIYRskA" base_StructuralFeature="_64irkH2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pLivQEeWNKd-GIYRskA" base_StructuralFeature="_74KVgX2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pLyvQEeWNKd-GIYRskA" base_StructuralFeature="_84r-YX2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pMCvQEeWNKd-GIYRskA" base_StructuralFeature="_LC1I4X2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pMSvQEeWNKd-GIYRskA" base_StructuralFeature="_L18A0X2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pMivQEeWNKd-GIYRskA" base_StructuralFeature="_MoKH8X2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pMyvQEeWNKd-GIYRskA" base_StructuralFeature="_NdWqkX2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mm7pNCvQEeWNKd-GIYRskA" base_Class="_phqnwHzBEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pNSvQEeWNKd-GIYRskA" base_StructuralFeature="_63mC0H2zEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pNivQEeWNKd-GIYRskA" base_StructuralFeature="_9dJv0H2zEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pNyvQEeWNKd-GIYRskA" base_StructuralFeature="_AJG_wH20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pOCvQEeWNKd-GIYRskA" base_StructuralFeature="_8sc2MX20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mm7pOSvQEeWNKd-GIYRskA" base_StructuralFeature="_97k7wH20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvwCvQEeWNKd-GIYRskA" base_StructuralFeature="_-wxeYX20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvwSvQEeWNKd-GIYRskA" base_StructuralFeature="_BDZoUX21Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvwivQEeWNKd-GIYRskA" base_StructuralFeature="_CaunoX21Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnBvwyvQEeWNKd-GIYRskA" base_Class="_cJgTgLFpEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvxCvQEeWNKd-GIYRskA" base_StructuralFeature="_cJgTh7FpEd2MOdzuQUV2bQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvxSvQEeWNKd-GIYRskA" base_StructuralFeature="_97k7w320Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvxivQEeWNKd-GIYRskA" base_StructuralFeature="_8smnMX20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvxyvQEeWNKd-GIYRskA" base_StructuralFeature="_Ca3xkH21Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvyCvQEeWNKd-GIYRskA" base_StructuralFeature="_BDZoVH21Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvySvQEeWNKd-GIYRskA" base_StructuralFeature="_-wxeZH20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvyivQEeWNKd-GIYRskA" base_StructuralFeature="_55DkgH2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvyyvQEeWNKd-GIYRskA" base_StructuralFeature="_MoKH9H2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvzCvQEeWNKd-GIYRskA" base_StructuralFeature="_L18A1H2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvzSvQEeWNKd-GIYRskA" base_StructuralFeature="_3lF90H2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvzivQEeWNKd-GIYRskA" base_StructuralFeature="_NdWqlH2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBvzyvQEeWNKd-GIYRskA" base_StructuralFeature="_64irk32TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv0CvQEeWNKd-GIYRskA" base_StructuralFeature="_LC-S0n2UEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv0SvQEeWNKd-GIYRskA" base_StructuralFeature="_84r-ZH2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv0ivQEeWNKd-GIYRskA" base_StructuralFeature="_74UGgH2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnBv0yvQEeWNKd-GIYRskA" base_Class="_ECin4H2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv1CvQEeWNKd-GIYRskA" base_StructuralFeature="_X9EAIH2TEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnBv1SvQEeWNKd-GIYRskA" base_Class="_bR1gkH20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv1ivQEeWNKd-GIYRskA" base_StructuralFeature="_bR1gk320Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnBv1yvQEeWNKd-GIYRskA" base_Class="_bofGAH20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv2CvQEeWNKd-GIYRskA" base_StructuralFeature="_bofGA320Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnBv2SvQEeWNKd-GIYRskA" base_Class="_O3vP0H2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnBv2ivQEeWNKd-GIYRskA" base_StructuralFeature="_9ei-UH2wEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2YCvQEeWNKd-GIYRskA" base_Class="_PMKAoH2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2YSvQEeWNKd-GIYRskA" base_StructuralFeature="_t5gjIH2wEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2YivQEeWNKd-GIYRskA" base_Class="_PeVVwH2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2YyvQEeWNKd-GIYRskA" base_StructuralFeature="_FrXOwH2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2ZCvQEeWNKd-GIYRskA" base_Class="_P9U-4H2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2ZSvQEeWNKd-GIYRskA" base_StructuralFeature="_MNffAH2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2ZivQEeWNKd-GIYRskA" base_Class="_cLqEgH20Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2ZyvQEeWNKd-GIYRskA" base_StructuralFeature="_cLqEg320Ed2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2aCvQEeWNKd-GIYRskA" base_Class="_cyYlwH2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2aSvQEeWNKd-GIYRskA" base_StructuralFeature="_RL7u8H2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2aivQEeWNKd-GIYRskA" base_StructuralFeature="_WnuCMH2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2ayvQEeWNKd-GIYRskA" base_Class="_dEaJ4H2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2bCvQEeWNKd-GIYRskA" base_StructuralFeature="_dhZPwH2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2bSvQEeWNKd-GIYRskA" base_StructuralFeature="_n2Qx0H2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2bivQEeWNKd-GIYRskA" base_StructuralFeature="_ruqmwH2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2byvQEeWNKd-GIYRskA" base_Class="_dX7i0H2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2cCvQEeWNKd-GIYRskA" base_StructuralFeature="_27tG8H2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2cSvQEeWNKd-GIYRskA" base_StructuralFeature="_7KA6cH2xEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2civQEeWNKd-GIYRskA" base_StructuralFeature="_AZ44oH2yEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2cyvQEeWNKd-GIYRskA" base_Class="_m4DOMH2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnH2dCvQEeWNKd-GIYRskA" base_Class="_0LgBQH2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2dSvQEeWNKd-GIYRskA" base_StructuralFeature="_0LgBQ32SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnH2divQEeWNKd-GIYRskA" base_StructuralFeature="_0LgBRH2SEd23zLSjbYwcFw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9ACvQEeWNKd-GIYRskA" base_StructuralFeature="_HLiWIH2zEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9ASvQEeWNKd-GIYRskA" base_StructuralFeature="_DOq38H2zEd2CEuIB5xoW6g"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9AivQEeWNKd-GIYRskA" base_Class="_YQhwIJKuEdybINoKQq_hfQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9AyvQEeWNKd-GIYRskA" base_StructuralFeature="_-KAYcHLMEd6R-oxtU8C0HQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9BCvQEeWNKd-GIYRskA" base_StructuralFeature="_AL5XsHLNEd6R-oxtU8C0HQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9BSvQEeWNKd-GIYRskA" base_StructuralFeature="_Dz-4sHLNEd6R-oxtU8C0HQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9BivQEeWNKd-GIYRskA" base_StructuralFeature="_KoJ7MHLNEd6R-oxtU8C0HQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9ByvQEeWNKd-GIYRskA" base_Class="_uvYUEJK0EdybINoKQq_hfQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9CCvQEeWNKd-GIYRskA" base_StructuralFeature="_x0fZ8JKrEdybINoKQq_hfQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9CSvQEeWNKd-GIYRskA" base_Class="_T7Mj8JQ1EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9CivQEeWNKd-GIYRskA" base_Class="_11A-EJQ1EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9CyvQEeWNKd-GIYRskA" base_Class="_8GaqsJQ1EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9DCvQEeWNKd-GIYRskA" base_Class="_IBadEJQ2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9DSvQEeWNKd-GIYRskA" base_Class="_hd7eQJQ3EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9DivQEeWNKd-GIYRskA" base_Class="_kcp5MJQ3EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnN9DyvQEeWNKd-GIYRskA" base_Class="_IopFAOw-EeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9ECvQEeWNKd-GIYRskA" base_StructuralFeature="_rHBn8OxCEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9ESvQEeWNKd-GIYRskA" base_StructuralFeature="_rHBn9OxCEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9EivQEeWNKd-GIYRskA" base_StructuralFeature="_3HyEEuxCEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9EyvQEeWNKd-GIYRskA" base_StructuralFeature="_3HoTEexCEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9FCvQEeWNKd-GIYRskA" base_StructuralFeature="_DidcEuxDEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9FSvQEeWNKd-GIYRskA" base_StructuralFeature="_DiUSIexDEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9FivQEeWNKd-GIYRskA" base_StructuralFeature="_T-UT8JQ2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9FyvQEeWNKd-GIYRskA" base_StructuralFeature="_T-ONUZQ2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9GCvQEeWNKd-GIYRskA" base_StructuralFeature="_VHSuM5Q2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9GSvQEeWNKd-GIYRskA" base_StructuralFeature="_VHSuMJQ2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9GivQEeWNKd-GIYRskA" base_StructuralFeature="_WGIVA5Q2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnN9GyvQEeWNKd-GIYRskA" base_StructuralFeature="_WGIVAJQ2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDoCvQEeWNKd-GIYRskA" base_StructuralFeature="_W42LY5Q2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDoSvQEeWNKd-GIYRskA" base_StructuralFeature="_W42LYJQ2EdyEFKh3Yw3Zsg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDoivQEeWNKd-GIYRskA" base_Class="_s_aKIHnFEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDoyvQEeWNKd-GIYRskA" base_StructuralFeature="_h14B9nsuEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDpCvQEeWNKd-GIYRskA" base_StructuralFeature="_u_UhgHnHEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDpSvQEeWNKd-GIYRskA" base_StructuralFeature="_P8k6EJKrEeCbGfKiQZfIJg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDpivQEeWNKd-GIYRskA" base_Class="_q7yL4HnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDpyvQEeWNKd-GIYRskA" base_StructuralFeature="_h14B7HsuEd2PiqoIrXuTbA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDqCvQEeWNKd-GIYRskA" base_StructuralFeature="_upySMHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDqSvQEeWNKd-GIYRskA" base_StructuralFeature="_zDHp8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDqivQEeWNKd-GIYRskA" base_StructuralFeature="_q7yL8nnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDqyvQEeWNKd-GIYRskA" base_StructuralFeature="_vOIbgHp1Ed2F76X026nNcA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDrCvQEeWNKd-GIYRskA" base_StructuralFeature="_0_GOcHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDrSvQEeWNKd-GIYRskA" base_StructuralFeature="__KuU8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDrivQEeWNKd-GIYRskA" base_Class="_iuOGkHzYEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDryvQEeWNKd-GIYRskA" base_StructuralFeature="_LpAAEJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDsCvQEeWNKd-GIYRskA" base_StructuralFeature="_Xo3rYJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDsSvQEeWNKd-GIYRskA" base_Class="_kfrrMDqaEeCu35lketJ8Yg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDsivQEeWNKd-GIYRskA" base_StructuralFeature="_ukk3kDqaEeCu35lketJ8Yg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDsyvQEeWNKd-GIYRskA" base_Class="_-A0TIJMuEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDtCvQEeWNKd-GIYRskA" base_StructuralFeature="_-A0TI5MuEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDtSvQEeWNKd-GIYRskA" base_Class="_hBZhAJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDtivQEeWNKd-GIYRskA" base_StructuralFeature="_hBZhA5MvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDtyvQEeWNKd-GIYRskA" base_Class="_Vdj6YDiDEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDuCvQEeWNKd-GIYRskA" base_StructuralFeature="_mT9PwDiDEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnUDuSvQEeWNKd-GIYRskA" base_Class="_VAOosDiEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnUDuivQEeWNKd-GIYRskA" base_StructuralFeature="_VAOosziEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnaKQCvQEeWNKd-GIYRskA" base_Class="_7us8IGEqEeG_P5asDyU-5Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKQSvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7k0NUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKQivQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7lkNUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKQyvQEeWNKd-GIYRskA" base_StructuralFeature="_0P-7jkNUEeGRwI_G1r0rnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKRCvQEeWNKd-GIYRskA" base_StructuralFeature="_2fZvcF7qEeGyKcjKnV9Bqg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_mnaKRSvQEeWNKd-GIYRskA" base_Class="_MhpnUGD2EeSYfK4iPcXSGA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKRivQEeWNKd-GIYRskA" base_StructuralFeature="_FYTwoGD3EeSYfK4iPcXSGA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKRyvQEeWNKd-GIYRskA" base_StructuralFeature="_03LH9KHfEeKb96dZOhIJOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKSCvQEeWNKd-GIYRskA" base_StructuralFeature="_WpPwdKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKSSvQEeWNKd-GIYRskA" base_StructuralFeature="_WQqRVKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKSivQEeWNKd-GIYRskA" base_StructuralFeature="_V9bzVKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKSyvQEeWNKd-GIYRskA" base_StructuralFeature="_Vsl69KHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKTCvQEeWNKd-GIYRskA" base_StructuralFeature="_nqlzgKKMEd6HZZ41m6oXAg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKTSvQEeWNKd-GIYRskA" base_StructuralFeature="_a0hMdKHhEeKb96dZOhIJOg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKTivQEeWNKd-GIYRskA" base_StructuralFeature="_tDygUKHdEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKTyvQEeWNKd-GIYRskA" base_StructuralFeature="_VYLxNKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKUCvQEeWNKd-GIYRskA" base_StructuralFeature="_VED7VKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKUSvQEeWNKd-GIYRskA" base_StructuralFeature="_UyoNFKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKUivQEeWNKd-GIYRskA" base_StructuralFeature="_Ugc39KHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKUyvQEeWNKd-GIYRskA" base_StructuralFeature="_UFokNKHeEd6Wos2BGooEOQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_mnaKVCvQEeWNKd-GIYRskA" base_StructuralFeature="_xCPfcJVKEeKd8oT75MgdlA"/>
+  <OpenModel_Profile:Deprecated xmi:id="_Igo9wNfkEeWxCJwKtt2ENg" base_Element="_XWZTQK50Ed6cFIpdu8eLhA"/>
+  <OpenModel_Profile:Deprecated xmi:id="_vY-gUNfkEeWxCJwKtt2ENg" base_Element="_zUI_oNg5Ed6jmbGvnR96rQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Dyus4TIoEeaoO_KBR-Aghw" base_Class="_Dyus4DIoEeaoO_KBR-Aghw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XlGj0DIrEeaoO_KBR-Aghw" base_StructuralFeature="_XlAdMDIrEeaoO_KBR-Aghw"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F1isQDlGEeaHY8ihI-WgZg" base_Class="_T7cP0DN7Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1jTUDlGEeaHY8ihI-WgZg" base_StructuralFeature="__18Z0jN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1jTUTlGEeaHY8ihI-WgZg" base_StructuralFeature="_ITjfUjN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1jTUjlGEeaHY8ihI-WgZg" base_StructuralFeature="__19A4DN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6YDlGEeaHY8ihI-WgZg" base_StructuralFeature="_ITkGYDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6YTlGEeaHY8ihI-WgZg" base_StructuralFeature="_MWtywDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6YjlGEeaHY8ihI-WgZg" base_StructuralFeature="_STrgcDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6YzlGEeaHY8ihI-WgZg" base_StructuralFeature="_STq5YTN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6ZDlGEeaHY8ihI-WgZg" base_StructuralFeature="_2uD9YTN_Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6ZTlGEeaHY8ihI-WgZg" base_StructuralFeature="_2uD9YDN_Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1j6ZjlGEeaHY8ihI-WgZg" base_StructuralFeature="_3D3B4DO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1khcDlGEeaHY8ihI-WgZg" base_StructuralFeature="_3D1zwTO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1khcTlGEeaHY8ihI-WgZg" base_StructuralFeature="_AbzosDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1khcjlGEeaHY8ihI-WgZg" base_StructuralFeature="_AbyakjO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1khczlGEeaHY8ihI-WgZg" base_StructuralFeature="_RjrIkDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1khdDlGEeaHY8ihI-WgZg" base_StructuralFeature="_SxKPYDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1khdTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Tvff4DO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lIgDlGEeaHY8ihI-WgZg" base_StructuralFeature="_UpDlIDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F1lIgTlGEeaHY8ihI-WgZg" base_Class="_8QR1UK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lIgjlGEeaHY8ihI-WgZg" base_StructuralFeature="_Tg7zoOhhEeG35t-G7oiZlg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lIgzlGEeaHY8ihI-WgZg" base_StructuralFeature="_8QR1U64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lIhDlGEeaHY8ihI-WgZg" base_StructuralFeature="_PHrv4LoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F1lIhTlGEeaHY8ihI-WgZg" base_Class="_8QIrYK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lIhjlGEeaHY8ihI-WgZg" base_StructuralFeature="_8QIrYq4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lvkDlGEeaHY8ihI-WgZg" base_StructuralFeature="_8QIrY64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lvkTlGEeaHY8ihI-WgZg" base_StructuralFeature="_UtUisLoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1lvkjlGEeaHY8ihI-WgZg" base_StructuralFeature="_u4pyoOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F1r2NDlGEeaHY8ihI-WgZg" base_Class="_udkZQEVwEd6WrOYSXNJbnw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1r2NTlGEeaHY8ihI-WgZg" base_StructuralFeature="_5HJIAm7yEd-KS-RjpPlIeg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1r2NjlGEeaHY8ihI-WgZg" base_StructuralFeature="_5HJIAG7yEd-KS-RjpPlIeg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F1r2NzlGEeaHY8ihI-WgZg" base_StructuralFeature="_vk1BYEwPEeGk0vxVMJiPiA"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F11AIDlGEeaHY8ihI-WgZg" base_Class="_7ySKwOuGEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11AITlGEeaHY8ihI-WgZg" base_StructuralFeature="_Osz7EOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11AIjlGEeaHY8ihI-WgZg" base_StructuralFeature="_VAOosziEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11AIzlGEeaHY8ihI-WgZg" base_StructuralFeature="_-A0TI5MuEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11AJDlGEeaHY8ihI-WgZg" base_StructuralFeature="_hBZhA5MvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11nMDlGEeaHY8ihI-WgZg" base_StructuralFeature="_LpAAEJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11nMTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Xo3rYJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11nMjlGEeaHY8ihI-WgZg" base_StructuralFeature="__7TK8C01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11nMzlGEeaHY8ihI-WgZg" base_StructuralFeature="_0_3YIC01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11nNDlGEeaHY8ihI-WgZg" base_StructuralFeature="_pU1bwC0yEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F11nNTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Styy4C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F12OQDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Ny8pgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F12OQTlGEeaHY8ihI-WgZg" base_StructuralFeature="_QsAhUC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F12OQjlGEeaHY8ihI-WgZg" base_StructuralFeature="_dOaR8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F12OQzlGEeaHY8ihI-WgZg" base_StructuralFeature="_bXqLsC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F12ORDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Zg5eYC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F121UDlGEeaHY8ihI-WgZg" base_StructuralFeature="_VVbjgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F121UTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Xkn-8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F121UjlGEeaHY8ihI-WgZg" base_StructuralFeature="_ukk3kDqaEeCu35lketJ8Yg"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F121UzlGEeaHY8ihI-WgZg" base_Class="_W8ZgwOuJEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F13cYDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cw5ut65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F13cYTlGEeaHY8ihI-WgZg" base_StructuralFeature="_CvRXAK5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F13cYjlGEeaHY8ihI-WgZg" base_StructuralFeature="_CwwkwK5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14DcDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cw5us65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14DcTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cwwkw65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14DcjlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cwwkxa5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14qgDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cwwkx65TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14qgTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cw5usa5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14qgjlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cw5uua5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F14qgzlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cw5uva5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F15RkDlGEeaHY8ihI-WgZg" base_StructuralFeature="_iWO58CFREeWxnoblgNdj6g"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F15RkTlGEeaHY8ihI-WgZg" base_StructuralFeature="_VRWTkFEEEd6VSrclB-Ybig"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F15RkjlGEeaHY8ihI-WgZg" base_StructuralFeature="_VRWTkVEEEd6VSrclB-Ybig"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F15RkzlGEeaHY8ihI-WgZg" base_StructuralFeature="_Lx5DgHu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F154oDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Cw5uwa5TEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F154oTlGEeaHY8ihI-WgZg" base_StructuralFeature="_ljgjQEKUEeGOU_Aog4a34g"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F154ojlGEeaHY8ihI-WgZg" base_StructuralFeature="_w3AmUJNhEdyK0-bKI_zx1A"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F154ozlGEeaHY8ihI-WgZg" base_StructuralFeature="_ORBewEKVEeGOU_Aog4a34g"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F16fsDlGEeaHY8ihI-WgZg" base_StructuralFeature="_zRwE0K5tEeKbRfTRicRZzQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F16fsTlGEeaHY8ihI-WgZg" base_StructuralFeature="_RFsbQkKUEeGOU_Aog4a34g"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F16fsjlGEeaHY8ihI-WgZg" base_StructuralFeature="_RFsbREKUEeGOU_Aog4a34g"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F16fszlGEeaHY8ihI-WgZg" base_StructuralFeature="_PzqLAHmsEd2GobjTM4neEA"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F16ftDlGEeaHY8ihI-WgZg" base_Class="_ACUEMOxFEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17GwDlGEeaHY8ihI-WgZg" base_StructuralFeature="_upySMHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17GwTlGEeaHY8ihI-WgZg" base_StructuralFeature="_vOIbgHp1Ed2F76X026nNcA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17GwjlGEeaHY8ihI-WgZg" base_StructuralFeature="__KuU8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17GwzlGEeaHY8ihI-WgZg" base_StructuralFeature="_0_GOcHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17GxDlGEeaHY8ihI-WgZg" base_StructuralFeature="_zDHp8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17t0DlGEeaHY8ihI-WgZg" base_StructuralFeature="_q7yL8nnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F17t0TlGEeaHY8ihI-WgZg" base_StructuralFeature="_MWtLsjN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelClass xmi:id="_F17t0jlGEeaHY8ihI-WgZg" base_Class="_fzLz0OxQEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F18U4DlGEeaHY8ihI-WgZg" base_StructuralFeature="_J3_wsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F18U4TlGEeaHY8ihI-WgZg" base_StructuralFeature="_ibtJIC0kEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F18U4jlGEeaHY8ihI-WgZg" base_StructuralFeature="_PFLnQHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F18U4zlGEeaHY8ihI-WgZg" base_StructuralFeature="_QoRxsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2H7EDlGEeaHY8ihI-WgZg" base_StructuralFeature="_inWUgq5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2H7ETlGEeaHY8ihI-WgZg" base_StructuralFeature="_inWUga5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2IiIDlGEeaHY8ihI-WgZg" base_StructuralFeature="_lUUGgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2IiITlGEeaHY8ihI-WgZg" base_StructuralFeature="_u9XrcK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2IiIjlGEeaHY8ihI-WgZg" base_StructuralFeature="_vWtYgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2IiIzlGEeaHY8ihI-WgZg" base_StructuralFeature="_ru2d0K5FEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2JJMDlGEeaHY8ihI-WgZg" base_StructuralFeature="_DFS_0K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2JJMTlGEeaHY8ihI-WgZg" base_StructuralFeature="_Dc1WEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2JJMjlGEeaHY8ihI-WgZg" base_StructuralFeature="_Dw9L8K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2JwQDlGEeaHY8ihI-WgZg" base_StructuralFeature="_KSMrYK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2JwQTlGEeaHY8ihI-WgZg" base_StructuralFeature="_KnNSEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2JwQjlGEeaHY8ihI-WgZg" base_StructuralFeature="_nQw7kOuTEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2Qd8TlGEeaHY8ihI-WgZg" base_StructuralFeature="_JJfGYCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2Qd8jlGEeaHY8ihI-WgZg" base_StructuralFeature="_3BAMICbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2RFADlGEeaHY8ihI-WgZg" base_StructuralFeature="_3ey7YCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2RFATlGEeaHY8ihI-WgZg" base_StructuralFeature="_3-PQcCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2RFAjlGEeaHY8ihI-WgZg" base_StructuralFeature="_4T_eACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2RFAzlGEeaHY8ihI-WgZg" base_StructuralFeature="_4mnfECbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2RsEDlGEeaHY8ihI-WgZg" base_StructuralFeature="_46SB8CbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2RsETlGEeaHY8ihI-WgZg" base_StructuralFeature="_5ND0ACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2ThQTlGEeaHY8ihI-WgZg" base_StructuralFeature="_u99zIKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2ThQjlGEeaHY8ihI-WgZg" base_StructuralFeature="_3jh6wKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2UIUDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Rjka4TO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2UIUTlGEeaHY8ihI-WgZg" base_StructuralFeature="_SxHMEjO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2UIUjlGEeaHY8ihI-WgZg" base_StructuralFeature="_TvcckjO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2UvYDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Uou1AjO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2dSQDlGEeaHY8ihI-WgZg" base_StructuralFeature="_rIRxQK2GEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2dSQTlGEeaHY8ihI-WgZg" base_StructuralFeature="_G-8WIK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2dSQjlGEeaHY8ihI-WgZg" base_StructuralFeature="_lUPgoK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2dSQzlGEeaHY8ihI-WgZg" base_StructuralFeature="_lz-woK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2d5UDlGEeaHY8ihI-WgZg" base_StructuralFeature="_mKelEK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2d5UTlGEeaHY8ihI-WgZg" base_StructuralFeature="_mczrMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2d5UjlGEeaHY8ihI-WgZg" base_StructuralFeature="_musscK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2d5UzlGEeaHY8ihI-WgZg" base_StructuralFeature="_nAuQkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2egYDlGEeaHY8ihI-WgZg" base_StructuralFeature="_naW4kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2egYTlGEeaHY8ihI-WgZg" base_StructuralFeature="_ntlWkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2egYjlGEeaHY8ihI-WgZg" base_StructuralFeature="_n_6csK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2egYzlGEeaHY8ihI-WgZg" base_StructuralFeature="_oRWK8K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2fHcDlGEeaHY8ihI-WgZg" base_StructuralFeature="_ol6FsK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2fugDlGEeaHY8ihI-WgZg" base_StructuralFeature="_o4PL0K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2fugTlGEeaHY8ihI-WgZg" base_StructuralFeature="_pM83kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2gVkDlGEeaHY8ihI-WgZg" base_StructuralFeature="_phOecK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2gVkTlGEeaHY8ihI-WgZg" base_StructuralFeature="_p1yZMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2g8oDlGEeaHY8ihI-WgZg" base_StructuralFeature="_bebnMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2g8oTlGEeaHY8ihI-WgZg" base_StructuralFeature="_frjH4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2hjsDlGEeaHY8ihI-WgZg" base_StructuralFeature="_gN0ugK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2hjsTlGEeaHY8ihI-WgZg" base_StructuralFeature="_gkeT8K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2hjsjlGEeaHY8ihI-WgZg" base_StructuralFeature="_g5VJoK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2iKwDlGEeaHY8ihI-WgZg" base_StructuralFeature="_hOVwUK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2iKwTlGEeaHY8ihI-WgZg" base_StructuralFeature="_hjWXAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2iKwjlGEeaHY8ihI-WgZg" base_StructuralFeature="_h3Ub4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2iKwzlGEeaHY8ihI-WgZg" base_StructuralFeature="_iNrGYK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2ix0DlGEeaHY8ihI-WgZg" base_StructuralFeature="_igTHcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2ix0TlGEeaHY8ihI-WgZg" base_StructuralFeature="_i1AzMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2ix0jlGEeaHY8ihI-WgZg" base_StructuralFeature="_jJbkAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2ix0zlGEeaHY8ihI-WgZg" base_StructuralFeature="_jf7YcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2jY4DlGEeaHY8ihI-WgZg" base_StructuralFeature="_jzJ2cK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2jY4TlGEeaHY8ihI-WgZg" base_StructuralFeature="_kIwTAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2jY4jlGEeaHY8ihI-WgZg" base_StructuralFeature="_lBOzIK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2rUszlGEeaHY8ihI-WgZg" base_StructuralFeature="_RGPHcHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2r7wDlGEeaHY8ihI-WgZg" base_StructuralFeature="_Vt2y0Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2r7wTlGEeaHY8ihI-WgZg" base_StructuralFeature="_aARqQHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_1:OpenModelAttribute xmi:id="_F2r7wjlGEeaHY8ihI-WgZg" base_StructuralFeature="_gbmu8Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_1:Choice xmi:id="_5-SU8DlGEeaHY8ihI-WgZg" base_DataType="_v3pIQOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe8UWlEeaB8vMnkFQLXQ" base_Element="_FOdHAJKmEdybINoKQq_hfQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe8kWlEeaB8vMnkFQLXQ" base_Element="_MP5wgJKmEdybINoKQq_hfQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe80WlEeaB8vMnkFQLXQ" base_Element="_SdNnUJKmEdybINoKQq_hfQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe9EWlEeaB8vMnkFQLXQ" base_Element="_7ySKwOuGEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="_W0Fe9UWlEeaB8vMnkFQLXQ" base_Class="_7ySKwOuGEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe9kWlEeaB8vMnkFQLXQ" base_Element="_Osz7EOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Fe90WlEeaB8vMnkFQLXQ" base_StructuralFeature="_Osz7EOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe-EWlEeaB8vMnkFQLXQ" base_Element="_UtlxwOuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe-UWlEeaB8vMnkFQLXQ" base_Element="_njp40OuHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe-kWlEeaB8vMnkFQLXQ" base_Element="_njp40euHEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe-0WlEeaB8vMnkFQLXQ" base_Element="_VTGRcCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe_EWlEeaB8vMnkFQLXQ" base_Element="_VAOosziEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Fe_UWlEeaB8vMnkFQLXQ" base_StructuralFeature="_VAOosziEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe_kWlEeaB8vMnkFQLXQ" base_Element="_VAOotDiEEeGKKvtWtO2aIg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Fe_0WlEeaB8vMnkFQLXQ" base_Element="_VTer8CFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfAEWlEeaB8vMnkFQLXQ" base_Element="_-A0TI5MuEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfAUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_-A0TI5MuEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfAkWlEeaB8vMnkFQLXQ" base_Element="_hbwIsMNpEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfA0WlEeaB8vMnkFQLXQ" base_Element="_j0ycoMNpEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfBEWlEeaB8vMnkFQLXQ" base_Element="_hBZhA5MvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfBUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_hBZhA5MvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfBkWlEeaB8vMnkFQLXQ" base_Element="_HVNoMMNqEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfB0WlEeaB8vMnkFQLXQ" base_Element="_JSFkkMNqEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfCEWlEeaB8vMnkFQLXQ" base_Element="_LpAAEJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfCUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_LpAAEJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfCkWlEeaB8vMnkFQLXQ" base_Element="_LpAAEZMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfC0WlEeaB8vMnkFQLXQ" base_Element="_t9NOIOuCEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfDEWlEeaB8vMnkFQLXQ" base_Element="_t9NOIeuCEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfDUWlEeaB8vMnkFQLXQ" base_Element="_Xo3rYJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfDkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Xo3rYJMvEeCKK9uc7Khnmg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfD0WlEeaB8vMnkFQLXQ" base_Element="_eyLeYMNpEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfEEWlEeaB8vMnkFQLXQ" base_Element="_3lSysMNpEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfEUWlEeaB8vMnkFQLXQ" base_Element="__7TK8C01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfEkWlEeaB8vMnkFQLXQ" base_StructuralFeature="__7TK8C01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfE0WlEeaB8vMnkFQLXQ" base_Element="_YiP1YI3gEeGyj-TNVzlOGQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfFEWlEeaB8vMnkFQLXQ" base_Element="_hDbuEOt8EeGPOswgCwFOKw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfFUWlEeaB8vMnkFQLXQ" base_Element="_hDbuEet8EeGPOswgCwFOKw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfFkWlEeaB8vMnkFQLXQ" base_Element="_VSTAMSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfF0WlEeaB8vMnkFQLXQ" base_Element="_0_3YIC01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfGEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_0_3YIC01EeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfGUWlEeaB8vMnkFQLXQ" base_Element="_M0ktUI3gEeGyj-TNVzlOGQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfGkWlEeaB8vMnkFQLXQ" base_Element="_NSrloI3gEeGyj-TNVzlOGQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfG0WlEeaB8vMnkFQLXQ" base_Element="_pU1bwC0yEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfHEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_pU1bwC0yEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfHUWlEeaB8vMnkFQLXQ" base_Element="_u4IrADBNEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfHkWlEeaB8vMnkFQLXQ" base_Element="_6WJhwEXMEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfH0WlEeaB8vMnkFQLXQ" base_Element="_6WJhwUXMEeKyK7rRd9C5sg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfIEWlEeaB8vMnkFQLXQ" base_Element="_Styy4C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfIUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Styy4C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfIkWlEeaB8vMnkFQLXQ" base_Element="_5QEaEDBLEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfI0WlEeaB8vMnkFQLXQ" base_Element="_VSUOUCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfJEWlEeaB8vMnkFQLXQ" base_Element="_Ny8pgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfJUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Ny8pgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfJkWlEeaB8vMnkFQLXQ" base_Element="_p-lNADBLEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfJ0WlEeaB8vMnkFQLXQ" base_Element="_VSTnQCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfKEWlEeaB8vMnkFQLXQ" base_Element="_QsAhUC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfKUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_QsAhUC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfKkWlEeaB8vMnkFQLXQ" base_Element="_v4BFkDBLEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfK0WlEeaB8vMnkFQLXQ" base_Element="_VSTnQSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfLEWlEeaB8vMnkFQLXQ" base_Element="_dOaR8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfLUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_dOaR8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfLkWlEeaB8vMnkFQLXQ" base_Element="_Bywz4DBMEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfL0WlEeaB8vMnkFQLXQ" base_Element="_VSVccCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfMEWlEeaB8vMnkFQLXQ" base_Element="_bXqLsC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfMUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_bXqLsC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfMkWlEeaB8vMnkFQLXQ" base_Element="_BRiWIDBMEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfM0WlEeaB8vMnkFQLXQ" base_Element="_VSU1YSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfNEWlEeaB8vMnkFQLXQ" base_Element="_Zg5eYC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfNUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Zg5eYC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfNkWlEeaB8vMnkFQLXQ" base_Element="_AuX-sDBMEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfN0WlEeaB8vMnkFQLXQ" base_Element="_VSU1YCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfOEWlEeaB8vMnkFQLXQ" base_Element="_VVbjgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfOUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_VVbjgC0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfOkWlEeaB8vMnkFQLXQ" base_Element="_-NcTADBLEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfO0WlEeaB8vMnkFQLXQ" base_Element="_VSUOUSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfPEWlEeaB8vMnkFQLXQ" base_Element="_Xkn-8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfPUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Xkn-8C0xEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfPkWlEeaB8vMnkFQLXQ" base_Element="_AJH8kDBMEeC_I_YldZCMxA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfP0WlEeaB8vMnkFQLXQ" base_Element="_VSUOUiFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfQEWlEeaB8vMnkFQLXQ" base_Element="_ukk3kDqaEeCu35lketJ8Yg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfQUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_ukk3kDqaEeCu35lketJ8Yg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfQkWlEeaB8vMnkFQLXQ" base_Element="_4eC1EMNoEeCUp9m8vv2E5A"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfQ0WlEeaB8vMnkFQLXQ" base_Element="_T7cP0DN7Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="_W0FfREWlEeaB8vMnkFQLXQ" base_Class="_T7cP0DN7Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfRUWlEeaB8vMnkFQLXQ" base_Element="__18Z0jN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfRkWlEeaB8vMnkFQLXQ" base_StructuralFeature="__18Z0jN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfR0WlEeaB8vMnkFQLXQ" base_Element="_ITjfUjN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfSEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_ITjfUjN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfSUWlEeaB8vMnkFQLXQ" base_Element="_ACUEMOxFEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="_W0FfSkWlEeaB8vMnkFQLXQ" base_Class="_ACUEMOxFEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfS0WlEeaB8vMnkFQLXQ" base_Element="_ACUEMuxFEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfTEWlEeaB8vMnkFQLXQ" base_Element="_upySMHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfTUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_upySMHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfTkWlEeaB8vMnkFQLXQ" base_Element="_kYZu0CEkEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfT0WlEeaB8vMnkFQLXQ" base_Element="_AEiUECbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfUEWlEeaB8vMnkFQLXQ" base_Element="_AEiUESbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfUUWlEeaB8vMnkFQLXQ" base_Element="_VTdd0CFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfUkWlEeaB8vMnkFQLXQ" base_Element="_vOIbgHp1Ed2F76X026nNcA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfU0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_vOIbgHp1Ed2F76X026nNcA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfVEWlEeaB8vMnkFQLXQ" base_Element="_musQwCEkEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfVUWlEeaB8vMnkFQLXQ" base_Element="_VTeE4CFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfVkWlEeaB8vMnkFQLXQ" base_Element="__KuU8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfV0WlEeaB8vMnkFQLXQ" base_StructuralFeature="__KuU8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfWEWlEeaB8vMnkFQLXQ" base_Element="_odulcCEkEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfWUWlEeaB8vMnkFQLXQ" base_Element="_fJJ9YOxmEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfWkWlEeaB8vMnkFQLXQ" base_Element="_fJJ9YexmEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfW0WlEeaB8vMnkFQLXQ" base_Element="_VTeE4SFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfXEWlEeaB8vMnkFQLXQ" base_Element="_0_GOcHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfXUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_0_GOcHnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfXkWlEeaB8vMnkFQLXQ" base_Element="_n4a48CEkEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfX0WlEeaB8vMnkFQLXQ" base_Element="_zkGjUCEsEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfYEWlEeaB8vMnkFQLXQ" base_Element="_zDHp8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfYUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_zDHp8HnOEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfYkWlEeaB8vMnkFQLXQ" base_Element="_lDqSUCEkEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfY0WlEeaB8vMnkFQLXQ" base_Element="_G82S4CbOEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfZEWlEeaB8vMnkFQLXQ" base_Element="_q7yL8nnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0FfZUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_q7yL8nnNEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfZkWlEeaB8vMnkFQLXQ" base_Element="_loFOACEkEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfZ0WlEeaB8vMnkFQLXQ" base_Element="_VTdd0SFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfaEWlEeaB8vMnkFQLXQ" base_Element="_fzLz0OxQEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="_W0FfaUWlEeaB8vMnkFQLXQ" base_Class="_fzLz0OxQEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfakWlEeaB8vMnkFQLXQ" base_Element="_J3_wsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Ffa0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_J3_wsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfbEWlEeaB8vMnkFQLXQ" base_Element="_vwvUUOxeEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfbUWlEeaB8vMnkFQLXQ" base_Element="_yCn3YOxeEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfbkWlEeaB8vMnkFQLXQ" base_Element="_ibtJIC0kEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Ffb0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_ibtJIC0kEeC5VOR5P4wONQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfcEWlEeaB8vMnkFQLXQ" base_Element="_yXiUQOxaEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfcUWlEeaB8vMnkFQLXQ" base_Element="_4Xiu4OxaEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfckWlEeaB8vMnkFQLXQ" base_Element="_PFLnQHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Ffc0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_PFLnQHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfdEWlEeaB8vMnkFQLXQ" base_Element="_39t80OxeEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfdUWlEeaB8vMnkFQLXQ" base_Element="_iICjoNHUEeKzI4N0oSjmcw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfdkWlEeaB8vMnkFQLXQ" base_Element="_QoRxsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Ffd0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_QoRxsHzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfeEWlEeaB8vMnkFQLXQ" base_Element="_q3xvYOxgEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfeUWlEeaB8vMnkFQLXQ" base_Element="_R5yc4HzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FfekWlEeaB8vMnkFQLXQ" base_Element="_R5yc4XzUEd2S7rQMqMRYLA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Ffe0WlEeaB8vMnkFQLXQ" base_Element="_VSlUECFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0FffEWlEeaB8vMnkFQLXQ" base_Element="_8QR1UK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="_W0PP8EWlEeaB8vMnkFQLXQ" base_Class="_8QR1UK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP8UWlEeaB8vMnkFQLXQ" base_Element="_zib-AOuSEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP8kWlEeaB8vMnkFQLXQ" base_Element="_I4OBgFBDEeWBGOds9dR2yw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP80WlEeaB8vMnkFQLXQ" base_Element="_Tg7zoOhhEeG35t-G7oiZlg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PP9EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Tg7zoOhhEeG35t-G7oiZlg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP9UWlEeaB8vMnkFQLXQ" base_Element="_4ctfoOuSEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP9kWlEeaB8vMnkFQLXQ" base_Element="_ThE9kehhEeG35t-G7oiZlg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP90WlEeaB8vMnkFQLXQ" base_Element="_ThE9kOhhEeG35t-G7oiZlg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP-EWlEeaB8vMnkFQLXQ" base_Element="_VSLEYSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP-UWlEeaB8vMnkFQLXQ" base_Element="_8QR1U64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PP-kWlEeaB8vMnkFQLXQ" base_StructuralFeature="_8QR1U64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP-0WlEeaB8vMnkFQLXQ" base_Element="_aeY1QOuTEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP_EWlEeaB8vMnkFQLXQ" base_Element="_8QR1Va4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP_UWlEeaB8vMnkFQLXQ" base_Element="_8QR1VK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP_kWlEeaB8vMnkFQLXQ" base_Element="_VSLrcCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PP_0WlEeaB8vMnkFQLXQ" base_Element="_PHrv4LoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQAEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_PHrv4LoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQAUWlEeaB8vMnkFQLXQ" base_Element="_XllKMOuVEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQAkWlEeaB8vMnkFQLXQ" base_Element="_VSNgoCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQA0WlEeaB8vMnkFQLXQ" base_Element="_8QIrYK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="_W0PQBEWlEeaB8vMnkFQLXQ" base_Class="_8QIrYK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQBUWlEeaB8vMnkFQLXQ" base_Element="_ju-k8OuVEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQBkWlEeaB8vMnkFQLXQ" base_Element="_Ql3CoFBDEeWBGOds9dR2yw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQB0WlEeaB8vMnkFQLXQ" base_Element="_8QIrYq4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQCEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_8QIrYq4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQCUWlEeaB8vMnkFQLXQ" base_Element="_nCRhsOuVEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQCkWlEeaB8vMnkFQLXQ" base_Element="_3gl0QK5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQC0WlEeaB8vMnkFQLXQ" base_Element="_3gl0Qa5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQDEWlEeaB8vMnkFQLXQ" base_Element="_VSOHsCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQDUWlEeaB8vMnkFQLXQ" base_Element="_8QIrY64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQDkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_8QIrY64wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQD0WlEeaB8vMnkFQLXQ" base_Element="_6ePLIOuVEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQEEWlEeaB8vMnkFQLXQ" base_Element="_8QIrZa4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQEUWlEeaB8vMnkFQLXQ" base_Element="_8QIrZK4wEeGjbtFXtCFKWg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQEkWlEeaB8vMnkFQLXQ" base_Element="_VSOHsSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQE0WlEeaB8vMnkFQLXQ" base_Element="_UtUisLoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQFEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_UtUisLoIEeGh2ojTLz6Azw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQFUWlEeaB8vMnkFQLXQ" base_Element="_T7Y68OuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQFkWlEeaB8vMnkFQLXQ" base_Element="_VSOuwCFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQF0WlEeaB8vMnkFQLXQ" base_Element="_u4pyoOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQGEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_u4pyoOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQGUWlEeaB8vMnkFQLXQ" base_Element="_u4pyoeuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQGkWlEeaB8vMnkFQLXQ" base_Element="_VSOuwSFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQG0WlEeaB8vMnkFQLXQ" base_Element="_dP6U4JKmEdybINoKQq_hfQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQHEWlEeaB8vMnkFQLXQ" base_Element="_inWUgK5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQHUWlEeaB8vMnkFQLXQ" base_Element="_inWUgq5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQHkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_inWUgq5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQH0WlEeaB8vMnkFQLXQ" base_Element="_VTTs0SFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQIEWlEeaB8vMnkFQLXQ" base_Element="_inWUga5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQIUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_inWUga5KEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQIkWlEeaB8vMnkFQLXQ" base_Element="_VTUT4CFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQI0WlEeaB8vMnkFQLXQ" base_Element="_fDoLkK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQJEWlEeaB8vMnkFQLXQ" base_Element="_lUUGgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQJUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_lUUGgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQJkWlEeaB8vMnkFQLXQ" base_Element="_74ZzENHDEeKzI4N0oSjmcw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQJ0WlEeaB8vMnkFQLXQ" base_Element="_VTUT4SFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQKEWlEeaB8vMnkFQLXQ" base_Element="_u9XrcK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQKUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_u9XrcK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQKkWlEeaB8vMnkFQLXQ" base_Element="_NN7kcOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQK0WlEeaB8vMnkFQLXQ" base_Element="_VTUT4iFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQLEWlEeaB8vMnkFQLXQ" base_Element="_vWtYgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQLUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_vWtYgK5JEeGXRumldg-1oA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQLkWlEeaB8vMnkFQLXQ" base_Element="_QELY0OuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQL0WlEeaB8vMnkFQLXQ" base_Element="_VTU68CFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQMEWlEeaB8vMnkFQLXQ" base_Element="_l70IMK5FEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQMUWlEeaB8vMnkFQLXQ" base_Element="_ru2d0K5FEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQMkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_ru2d0K5FEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQM0WlEeaB8vMnkFQLXQ" base_Element="_Cl4SkOuUEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQNEWlEeaB8vMnkFQLXQ" base_Element="_VTU68SFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQNUWlEeaB8vMnkFQLXQ" base_Element="_DFS_0K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQNkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_DFS_0K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQN0WlEeaB8vMnkFQLXQ" base_Element="_DNEOYOuUEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQOEWlEeaB8vMnkFQLXQ" base_Element="_VTViACFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQOUWlEeaB8vMnkFQLXQ" base_Element="_Dc1WEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQOkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Dc1WEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQO0WlEeaB8vMnkFQLXQ" base_Element="_EXk5sOuUEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQPEWlEeaB8vMnkFQLXQ" base_Element="_VTViASFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQPUWlEeaB8vMnkFQLXQ" base_Element="_Dw9L8K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQPkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Dw9L8K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQP0WlEeaB8vMnkFQLXQ" base_Element="_DuSsIOuUEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQQEWlEeaB8vMnkFQLXQ" base_Element="_VTViAiFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQQUWlEeaB8vMnkFQLXQ" base_Element="_KSMrYK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQQkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_KSMrYK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQQ0WlEeaB8vMnkFQLXQ" base_Element="_G5PDQNHEEeKzI4N0oSjmcw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQREWlEeaB8vMnkFQLXQ" base_Element="_VTWJECFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQRUWlEeaB8vMnkFQLXQ" base_Element="_KnNSEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQRkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_KnNSEK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQR0WlEeaB8vMnkFQLXQ" base_Element="_DUNdUNHEEeKzI4N0oSjmcw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQSEWlEeaB8vMnkFQLXQ" base_Element="_VTWJESFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQSUWlEeaB8vMnkFQLXQ" base_Element="_nQw7kOuTEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQSkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_nQw7kOuTEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQS0WlEeaB8vMnkFQLXQ" base_Element="_CAefcOuUEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQTEWlEeaB8vMnkFQLXQ" base_Element="_VTWwICFqEeWrHvhCHfosZA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQTUWlEeaB8vMnkFQLXQ" base_Element="_hYZs0BWEEd-Si5Ih_dYBog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQTkWlEeaB8vMnkFQLXQ" base_Element="_vtSuwBWEEd-Si5Ih_dYBog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQT0WlEeaB8vMnkFQLXQ" base_Element="_GjpskCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQUEWlEeaB8vMnkFQLXQ" base_Element="_b0Lq8CbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQUUWlEeaB8vMnkFQLXQ" base_Element="_JJfGYCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQUkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_JJfGYCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQU0WlEeaB8vMnkFQLXQ" base_Element="_0U3LcCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQVEWlEeaB8vMnkFQLXQ" base_Element="_JJfGYibKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQVUWlEeaB8vMnkFQLXQ" base_Element="_JJfGYSbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQVkWlEeaB8vMnkFQLXQ" base_Element="_OTrTUCbKEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQV0WlEeaB8vMnkFQLXQ" base_Element="_3BAMICbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQWEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_3BAMICbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQWUWlEeaB8vMnkFQLXQ" base_Element="_3BAMISbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQWkWlEeaB8vMnkFQLXQ" base_Element="_3BAMIybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQW0WlEeaB8vMnkFQLXQ" base_Element="_3BAMIibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQXEWlEeaB8vMnkFQLXQ" base_Element="_3BAMJCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQXUWlEeaB8vMnkFQLXQ" base_Element="_3ey7YCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQXkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_3ey7YCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQX0WlEeaB8vMnkFQLXQ" base_Element="_3ey7YSbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQYEWlEeaB8vMnkFQLXQ" base_Element="_3ey7YybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQYUWlEeaB8vMnkFQLXQ" base_Element="_3ey7YibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQYkWlEeaB8vMnkFQLXQ" base_Element="_3ey7ZCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQY0WlEeaB8vMnkFQLXQ" base_Element="_3-PQcCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQZEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_3-PQcCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQZUWlEeaB8vMnkFQLXQ" base_Element="_3-PQcSbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQZkWlEeaB8vMnkFQLXQ" base_Element="_3-PQcybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQZ0WlEeaB8vMnkFQLXQ" base_Element="_3-PQcibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQaEWlEeaB8vMnkFQLXQ" base_Element="_3-PQdCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQaUWlEeaB8vMnkFQLXQ" base_Element="_4T_eACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQakWlEeaB8vMnkFQLXQ" base_StructuralFeature="_4T_eACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQa0WlEeaB8vMnkFQLXQ" base_Element="_4T_eASbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQbEWlEeaB8vMnkFQLXQ" base_Element="_4T_eAybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQbUWlEeaB8vMnkFQLXQ" base_Element="_4T_eAibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQbkWlEeaB8vMnkFQLXQ" base_Element="_4T_eBCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQb0WlEeaB8vMnkFQLXQ" base_Element="_4mnfECbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQcEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_4mnfECbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQcUWlEeaB8vMnkFQLXQ" base_Element="_4mnfESbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQckWlEeaB8vMnkFQLXQ" base_Element="_4mnfEybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQc0WlEeaB8vMnkFQLXQ" base_Element="_4mnfEibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQdEWlEeaB8vMnkFQLXQ" base_Element="_4mnfFCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQdUWlEeaB8vMnkFQLXQ" base_Element="_46SB8CbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQdkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_46SB8CbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQd0WlEeaB8vMnkFQLXQ" base_Element="_46SB8SbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQeEWlEeaB8vMnkFQLXQ" base_Element="_46SB8ybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQeUWlEeaB8vMnkFQLXQ" base_Element="_46SB8ibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQekWlEeaB8vMnkFQLXQ" base_Element="_46SB9CbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQe0WlEeaB8vMnkFQLXQ" base_Element="_5ND0ACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQfEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_5ND0ACbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQfUWlEeaB8vMnkFQLXQ" base_Element="_5ND0ASbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQfkWlEeaB8vMnkFQLXQ" base_Element="_5ND0AybLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQf0WlEeaB8vMnkFQLXQ" base_Element="_5ND0AibLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQgEWlEeaB8vMnkFQLXQ" base_Element="_5ND0BCbLEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQgUWlEeaB8vMnkFQLXQ" base_Element="_d1LyACbNEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQgkWlEeaB8vMnkFQLXQ" base_Element="_976d4CbNEd-tK43JMxNtYw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQg0WlEeaB8vMnkFQLXQ" base_Element="_7hrFkJHNEeCZGJGlR2UAKg"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQhEWlEeaB8vMnkFQLXQ" base_Element="_traBgLFXEeC6XaWwVljZZQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQhUWlEeaB8vMnkFQLXQ" base_Element="_GkCQEKtIEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQhkWlEeaB8vMnkFQLXQ" base_Element="_u99zIKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQh0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_u99zIKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQiEWlEeaB8vMnkFQLXQ" base_Element="_u99zIatGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0PQiUWlEeaB8vMnkFQLXQ" base_Element="_3jh6wKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0PQikWlEeaB8vMnkFQLXQ" base_StructuralFeature="_3jh6wKtGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ4EWlEeaB8vMnkFQLXQ" base_Element="_3jh6watGEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ4UWlEeaB8vMnkFQLXQ" base_Element="_YVEeMKtHEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ4kWlEeaB8vMnkFQLXQ" base_Element="_YVEeMatHEeKnAKpr1sW3qQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ40WlEeaB8vMnkFQLXQ" base_Element="_ZadywOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ5EWlEeaB8vMnkFQLXQ" base_Element="_dtr7cOuWEeGZr5p9Vdkojw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ5UWlEeaB8vMnkFQLXQ" base_Element="_s3CEAK2EEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ5kWlEeaB8vMnkFQLXQ" base_Element="_JRR3EK2FEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ50WlEeaB8vMnkFQLXQ" base_Element="_rIRxQK2GEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YZ6EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_rIRxQK2GEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ6UWlEeaB8vMnkFQLXQ" base_Element="_F_KUIK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ6kWlEeaB8vMnkFQLXQ" base_Element="_xMmrMK2GEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ60WlEeaB8vMnkFQLXQ" base_Element="_G-8WIK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YZ7EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_G-8WIK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ7UWlEeaB8vMnkFQLXQ" base_Element="_G-8WIa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ7kWlEeaB8vMnkFQLXQ" base_Element="_G-8WIq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ70WlEeaB8vMnkFQLXQ" base_Element="_lUPgoK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YZ8EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_lUPgoK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ8UWlEeaB8vMnkFQLXQ" base_Element="_lUPgoa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ8kWlEeaB8vMnkFQLXQ" base_Element="_lUPgoq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ80WlEeaB8vMnkFQLXQ" base_Element="_lz-woK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YZ9EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_lz-woK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ9UWlEeaB8vMnkFQLXQ" base_Element="_lz-woa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ9kWlEeaB8vMnkFQLXQ" base_Element="_lz-woq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ90WlEeaB8vMnkFQLXQ" base_Element="_mKelEK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YZ-EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_mKelEK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ-UWlEeaB8vMnkFQLXQ" base_Element="_mKelEa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ-kWlEeaB8vMnkFQLXQ" base_Element="_mKelEq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ-0WlEeaB8vMnkFQLXQ" base_Element="_mczrMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YZ_EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_mczrMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ_UWlEeaB8vMnkFQLXQ" base_Element="_mczrMa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ_kWlEeaB8vMnkFQLXQ" base_Element="_mczrMq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YZ_0WlEeaB8vMnkFQLXQ" base_Element="_musscK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaAEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_musscK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaAUWlEeaB8vMnkFQLXQ" base_Element="_mussca2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaAkWlEeaB8vMnkFQLXQ" base_Element="_musscq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaA0WlEeaB8vMnkFQLXQ" base_Element="_nAuQkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaBEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_nAuQkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaBUWlEeaB8vMnkFQLXQ" base_Element="_nAuQka2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaBkWlEeaB8vMnkFQLXQ" base_Element="_nAuQkq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaB0WlEeaB8vMnkFQLXQ" base_Element="_naW4kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaCEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_naW4kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaCUWlEeaB8vMnkFQLXQ" base_Element="_naW4ka2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaCkWlEeaB8vMnkFQLXQ" base_Element="_naW4kq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaC0WlEeaB8vMnkFQLXQ" base_Element="_ntlWkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaDEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_ntlWkK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaDUWlEeaB8vMnkFQLXQ" base_Element="_ntlWka2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaDkWlEeaB8vMnkFQLXQ" base_Element="_ntlWkq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaD0WlEeaB8vMnkFQLXQ" base_Element="_n_6csK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaEEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_n_6csK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaEUWlEeaB8vMnkFQLXQ" base_Element="_n_6csa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaEkWlEeaB8vMnkFQLXQ" base_Element="_n_6csq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaE0WlEeaB8vMnkFQLXQ" base_Element="_oRWK8K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaFEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_oRWK8K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaFUWlEeaB8vMnkFQLXQ" base_Element="_oRWK8a2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaFkWlEeaB8vMnkFQLXQ" base_Element="_oRWK8q2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaF0WlEeaB8vMnkFQLXQ" base_Element="_ol6FsK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaGEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_ol6FsK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaGUWlEeaB8vMnkFQLXQ" base_Element="_ol6Fsa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaGkWlEeaB8vMnkFQLXQ" base_Element="_ol6Fsq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaG0WlEeaB8vMnkFQLXQ" base_Element="_o4PL0K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaHEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_o4PL0K2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaHUWlEeaB8vMnkFQLXQ" base_Element="_o4PL0a2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaHkWlEeaB8vMnkFQLXQ" base_Element="_o4PL0q2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaH0WlEeaB8vMnkFQLXQ" base_Element="_pM83kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaIEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_pM83kK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaIUWlEeaB8vMnkFQLXQ" base_Element="_pM83ka2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaIkWlEeaB8vMnkFQLXQ" base_Element="_pM83kq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaI0WlEeaB8vMnkFQLXQ" base_Element="_phOecK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaJEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_phOecK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaJUWlEeaB8vMnkFQLXQ" base_Element="_phOeca2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaJkWlEeaB8vMnkFQLXQ" base_Element="_phOecq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaJ0WlEeaB8vMnkFQLXQ" base_Element="_p1yZMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaKEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_p1yZMK2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaKUWlEeaB8vMnkFQLXQ" base_Element="_p1yZMa2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaKkWlEeaB8vMnkFQLXQ" base_Element="_p1yZMq2HEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaK0WlEeaB8vMnkFQLXQ" base_Element="_bebnMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaLEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_bebnMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaLUWlEeaB8vMnkFQLXQ" base_Element="_bebnMa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaLkWlEeaB8vMnkFQLXQ" base_Element="_bebnMq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaL0WlEeaB8vMnkFQLXQ" base_Element="_frjH4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaMEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_frjH4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaMUWlEeaB8vMnkFQLXQ" base_Element="_frjH4a2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaMkWlEeaB8vMnkFQLXQ" base_Element="_frjH4q2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaM0WlEeaB8vMnkFQLXQ" base_Element="_gN0ugK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaNEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_gN0ugK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaNUWlEeaB8vMnkFQLXQ" base_Element="_gN0uga2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaNkWlEeaB8vMnkFQLXQ" base_Element="_gN0ugq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaN0WlEeaB8vMnkFQLXQ" base_Element="_gkeT8K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaOEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_gkeT8K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaOUWlEeaB8vMnkFQLXQ" base_Element="_gkeT8a2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaOkWlEeaB8vMnkFQLXQ" base_Element="_gkeT8q2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaO0WlEeaB8vMnkFQLXQ" base_Element="_g5VJoK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaPEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_g5VJoK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaPUWlEeaB8vMnkFQLXQ" base_Element="_g5VJoa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaPkWlEeaB8vMnkFQLXQ" base_Element="_g5VJoq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaP0WlEeaB8vMnkFQLXQ" base_Element="_hOVwUK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaQEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_hOVwUK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaQUWlEeaB8vMnkFQLXQ" base_Element="_hOVwUa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaQkWlEeaB8vMnkFQLXQ" base_Element="_hOVwUq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaQ0WlEeaB8vMnkFQLXQ" base_Element="_hjWXAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaREWlEeaB8vMnkFQLXQ" base_StructuralFeature="_hjWXAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaRUWlEeaB8vMnkFQLXQ" base_Element="_hjWXAa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaRkWlEeaB8vMnkFQLXQ" base_Element="_hjWXAq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaR0WlEeaB8vMnkFQLXQ" base_Element="_h3Ub4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaSEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_h3Ub4K2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaSUWlEeaB8vMnkFQLXQ" base_Element="_h3Ub4a2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaSkWlEeaB8vMnkFQLXQ" base_Element="_h3Ub4q2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaS0WlEeaB8vMnkFQLXQ" base_Element="_iNrGYK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaTEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_iNrGYK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaTUWlEeaB8vMnkFQLXQ" base_Element="_iNrGYa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaTkWlEeaB8vMnkFQLXQ" base_Element="_iNrGYq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaT0WlEeaB8vMnkFQLXQ" base_Element="_igTHcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaUEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_igTHcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaUUWlEeaB8vMnkFQLXQ" base_Element="_igTHca2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaUkWlEeaB8vMnkFQLXQ" base_Element="_igTHcq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaU0WlEeaB8vMnkFQLXQ" base_Element="_i1AzMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaVEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_i1AzMK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaVUWlEeaB8vMnkFQLXQ" base_Element="_i1AzMa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaVkWlEeaB8vMnkFQLXQ" base_Element="_i1AzMq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaV0WlEeaB8vMnkFQLXQ" base_Element="_jJbkAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaWEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_jJbkAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaWUWlEeaB8vMnkFQLXQ" base_Element="_jJbkAa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaWkWlEeaB8vMnkFQLXQ" base_Element="_jJbkAq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaW0WlEeaB8vMnkFQLXQ" base_Element="_jf7YcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaXEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_jf7YcK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaXUWlEeaB8vMnkFQLXQ" base_Element="_jf7Yca2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaXkWlEeaB8vMnkFQLXQ" base_Element="_jf7Ycq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaX0WlEeaB8vMnkFQLXQ" base_Element="_jzJ2cK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaYEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_jzJ2cK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaYUWlEeaB8vMnkFQLXQ" base_Element="_jzJ2ca2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaYkWlEeaB8vMnkFQLXQ" base_Element="_jzJ2cq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaY0WlEeaB8vMnkFQLXQ" base_Element="_kIwTAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaZEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_kIwTAK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaZUWlEeaB8vMnkFQLXQ" base_Element="_kIwTAa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaZkWlEeaB8vMnkFQLXQ" base_Element="_kIwTAq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaZ0WlEeaB8vMnkFQLXQ" base_Element="_lBOzIK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YaaEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_lBOzIK2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaaUWlEeaB8vMnkFQLXQ" base_Element="_lBOzIa2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaakWlEeaB8vMnkFQLXQ" base_Element="_lBOzIq2JEeKoWKjPsL4xyQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yaa0WlEeaB8vMnkFQLXQ" base_Element="_MCQ3QHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YabEWlEeaB8vMnkFQLXQ" base_Element="_qmnxcHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YabUWlEeaB8vMnkFQLXQ" base_Element="_RGPHcHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YabkWlEeaB8vMnkFQLXQ" base_StructuralFeature="_RGPHcHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yab0WlEeaB8vMnkFQLXQ" base_Element="_FJxgAHu_EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YacEWlEeaB8vMnkFQLXQ" base_Element="_Vt2y0Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YacUWlEeaB8vMnkFQLXQ" base_StructuralFeature="_Vt2y0Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YackWlEeaB8vMnkFQLXQ" base_Element="_4zPoMHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yac0WlEeaB8vMnkFQLXQ" base_Element="_aARqQHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0YadEWlEeaB8vMnkFQLXQ" base_StructuralFeature="_aARqQHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YadUWlEeaB8vMnkFQLXQ" base_Element="_0ghOwHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YadkWlEeaB8vMnkFQLXQ" base_Element="_gbmu8Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0Yad0WlEeaB8vMnkFQLXQ" base_StructuralFeature="_gbmu8Hu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaeEWlEeaB8vMnkFQLXQ" base_Element="_w3TsYHu-EeSSGKd_EdTB1w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaeUWlEeaB8vMnkFQLXQ" base_Element="_KPwN0Hm9Ed2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaekWlEeaB8vMnkFQLXQ" base_Element="_MmZ8IHm9Ed2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yae0WlEeaB8vMnkFQLXQ" base_Element="_Pa3AwHm9Ed2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YafEWlEeaB8vMnkFQLXQ" base_Element="_Tw2XIK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YafUWlEeaB8vMnkFQLXQ" base_Element="_ZKac0K5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YafkWlEeaB8vMnkFQLXQ" base_Element="_b62kIK5GEeGvr_m5yJYoog"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yaf0WlEeaB8vMnkFQLXQ" base_Element="_10eLcKNEEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YagEWlEeaB8vMnkFQLXQ" base_Element="_4HsLQKNEEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YagUWlEeaB8vMnkFQLXQ" base_Element="_DCbagKNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YagkWlEeaB8vMnkFQLXQ" base_Element="_R1RjwKNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yag0WlEeaB8vMnkFQLXQ" base_Element="_R1RjwaNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YahEWlEeaB8vMnkFQLXQ" base_Element="_aDI9EKNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YahUWlEeaB8vMnkFQLXQ" base_Element="_aDI9EaNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YahkWlEeaB8vMnkFQLXQ" base_Element="_i2jTcKNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yah0WlEeaB8vMnkFQLXQ" base_Element="_i2jTcaNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaiEWlEeaB8vMnkFQLXQ" base_Element="_nh6PUKNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaiUWlEeaB8vMnkFQLXQ" base_Element="_nh6PUaNFEeKZoeGA12VHIQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaikWlEeaB8vMnkFQLXQ" base_Element="_AdKOUOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yai0WlEeaB8vMnkFQLXQ" base_Element="_HbwYIOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YajEWlEeaB8vMnkFQLXQ" base_Element="_I44dcOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YajUWlEeaB8vMnkFQLXQ" base_Element="_LGmSMOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YajkWlEeaB8vMnkFQLXQ" base_Element="_MWUNoOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yaj0WlEeaB8vMnkFQLXQ" base_Element="_Rv4TUOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YakEWlEeaB8vMnkFQLXQ" base_Element="_VpLgIOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YakUWlEeaB8vMnkFQLXQ" base_Element="_cqwFcOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YakkWlEeaB8vMnkFQLXQ" base_Element="_gh9nkOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yak0WlEeaB8vMnkFQLXQ" base_Element="_j1jfQOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YalEWlEeaB8vMnkFQLXQ" base_Element="_mUjRQOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YalUWlEeaB8vMnkFQLXQ" base_Element="_oohfAOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YalkWlEeaB8vMnkFQLXQ" base_Element="_rUCDAOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yal0WlEeaB8vMnkFQLXQ" base_Element="_tu3GsOxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YamEWlEeaB8vMnkFQLXQ" base_Element="_wY4c8OxfEeGzwM2Uvwf5Xw"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YamUWlEeaB8vMnkFQLXQ" base_Element="_n3YdgCEsEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YamkWlEeaB8vMnkFQLXQ" base_Element="_q3c8QCEsEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yam0WlEeaB8vMnkFQLXQ" base_Element="_tKgkACEsEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YanEWlEeaB8vMnkFQLXQ" base_Element="_vRp2sCEsEd-ysdtezPKi3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YanUWlEeaB8vMnkFQLXQ" base_Element="_XmBCIHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YankWlEeaB8vMnkFQLXQ" base_Element="_1v9S4GfMEd6DJYBL2b692Q"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yan0WlEeaB8vMnkFQLXQ" base_Element="_auSaoHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaoEWlEeaB8vMnkFQLXQ" base_Element="_v_-4UGfMEd6DJYBL2b692Q"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaoUWlEeaB8vMnkFQLXQ" base_Element="_clyu0HmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YaokWlEeaB8vMnkFQLXQ" base_Element="_dwJpIHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yao0WlEeaB8vMnkFQLXQ" base_Element="_e6NogHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YapEWlEeaB8vMnkFQLXQ" base_Element="_gBSlUHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YapUWlEeaB8vMnkFQLXQ" base_Element="_hFFkoHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0YapkWlEeaB8vMnkFQLXQ" base_Element="_iRiJoHmuEd2GobjTM4neEA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0Yap0WlEeaB8vMnkFQLXQ" base_Element="_tjBD8CdpEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK4EWlEeaB8vMnkFQLXQ" base_Element="_ZJwZ4CdrEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK4UWlEeaB8vMnkFQLXQ" base_Element="_8pdeoCdpEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK4kWlEeaB8vMnkFQLXQ" base_Element="__Lsx4CdpEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK40WlEeaB8vMnkFQLXQ" base_Element="_BYL3kCdqEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK5EWlEeaB8vMnkFQLXQ" base_Element="_DW94cCdqEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK5UWlEeaB8vMnkFQLXQ" base_Element="_HRtPsCdqEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK5kWlEeaB8vMnkFQLXQ" base_Element="_W7UW8CdsEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK50WlEeaB8vMnkFQLXQ" base_Element="_kQIFACelEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK6EWlEeaB8vMnkFQLXQ" base_Element="_vsEHYCemEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK6UWlEeaB8vMnkFQLXQ" base_Element="_rJUxcCelEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK6kWlEeaB8vMnkFQLXQ" base_Element="_Wiv5kCemEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK60WlEeaB8vMnkFQLXQ" base_Element="_x-pDcCelEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK7EWlEeaB8vMnkFQLXQ" base_Element="_YVN8wCemEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK7UWlEeaB8vMnkFQLXQ" base_Element="_zPRk4CelEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK7kWlEeaB8vMnkFQLXQ" base_Element="_afPkUCemEd-sQoLP0EY2BQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK70WlEeaB8vMnkFQLXQ" base_Element="_x3G-wDxBEeaRI-H69PghuA"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK8EWlEeaB8vMnkFQLXQ" base_Element="_ITi4QDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK8UWlEeaB8vMnkFQLXQ" base_Element="_ITkGYDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0iK8kWlEeaB8vMnkFQLXQ" base_StructuralFeature="_ITkGYDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK80WlEeaB8vMnkFQLXQ" base_Element="_3Dz-kDO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK9EWlEeaB8vMnkFQLXQ" base_Element="_3D3B4DO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0iK9UWlEeaB8vMnkFQLXQ" base_StructuralFeature="_3D3B4DO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK9kWlEeaB8vMnkFQLXQ" base_Element="_3D1zwTO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0iK90WlEeaB8vMnkFQLXQ" base_StructuralFeature="_3D1zwTO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK-EWlEeaB8vMnkFQLXQ" base_Element="_8pTncDO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK-UWlEeaB8vMnkFQLXQ" base_Element="_8pcxYDO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK-kWlEeaB8vMnkFQLXQ" base_Element="_AbxMcDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK-0WlEeaB8vMnkFQLXQ" base_Element="_AbzosDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0iK_EWlEeaB8vMnkFQLXQ" base_StructuralFeature="_AbzosDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK_UWlEeaB8vMnkFQLXQ" base_Element="_AbyakjO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0iK_kWlEeaB8vMnkFQLXQ" base_StructuralFeature="_AbyakjO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iK_0WlEeaB8vMnkFQLXQ" base_Element="_C7qWUDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iLAEWlEeaB8vMnkFQLXQ" base_Element="_C7ySIDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iLAUWlEeaB8vMnkFQLXQ" base_Element="__17LsDN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iLAkWlEeaB8vMnkFQLXQ" base_Element="__19A4DN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_W0iLA0WlEeaB8vMnkFQLXQ" base_StructuralFeature="__19A4DN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_W0iLBEWlEeaB8vMnkFQLXQ" base_Element="_Wz7t8EWlEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:ExtendedComposite xmi:id="_YOr_QEWmEeaB8vMnkFQLXQ" base_Association="__17LsDN9Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:ExtendedComposite xmi:id="_ZbmeUEWmEeaB8vMnkFQLXQ" base_Association="_ITi4QDN-Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:ExtendedComposite xmi:id="_auK5cEWmEeaB8vMnkFQLXQ" base_Association="_AbxMcDO6Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:ExtendedComposite xmi:id="_bvDHoEWmEeaB8vMnkFQLXQ" base_Association="_3Dz-kDO5Eea40e5DA9KE3w"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_fhZtAUWoEeaB8vMnkFQLXQ" base_Element="_fhZtAEWoEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_kV26gUWoEeaB8vMnkFQLXQ" base_Element="_kV26gEWoEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_kWJ1cUWoEeaB8vMnkFQLXQ" base_Element="_kWJ1cEWoEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_kWcwYUWoEeaB8vMnkFQLXQ" base_Element="_kWcwYEWoEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_zsepwUWpEeaB8vMnkFQLXQ" base_Element="_zsepwEWpEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="__0LJcUWrEeaB8vMnkFQLXQ" base_Element="__0LJcEWrEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelClass xmi:id="__0LJckWrEeaB8vMnkFQLXQ" base_Class="__0LJcEWrEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_D9VXMUWsEeaB8vMnkFQLXQ" base_Element="_D9VXMEWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_IyE4kUWsEeaB8vMnkFQLXQ" base_Element="_IyE4kEWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_IyOCg0WsEeaB8vMnkFQLXQ" base_Element="_IyOCgkWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_IyOChEWsEeaB8vMnkFQLXQ" base_StructuralFeature="_IyOCgkWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_IyOChkWsEeaB8vMnkFQLXQ" base_Element="_IyOChUWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_IyOCh0WsEeaB8vMnkFQLXQ" base_StructuralFeature="_IyOChUWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_EqOc8UWtEeaB8vMnkFQLXQ" base_Element="_EqOc8EWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_EqOc80WtEeaB8vMnkFQLXQ" base_Element="_EqOc8kWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:ExtendedComposite xmi:id="_GCAIMEWtEeaB8vMnkFQLXQ" base_Association="_IyE4kEWsEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_JC0N0UWtEeaB8vMnkFQLXQ" base_Element="_JC0N0EWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_JC0N00WtEeaB8vMnkFQLXQ" base_Element="_JC0N0kWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_ds3bAUWtEeaB8vMnkFQLXQ" base_Element="_ds3bAEWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_ds3bA0WtEeaB8vMnkFQLXQ" base_Element="_ds3bAkWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_fcjcsUW9EeaB8vMnkFQLXQ" base_Element="_fcjcsEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_fcjcskW9EeaB8vMnkFQLXQ" base_StructuralFeature="_fcjcsEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_koShwUW9EeaB8vMnkFQLXQ" base_Element="_koShwEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_kocSwEW9EeaB8vMnkFQLXQ" base_StructuralFeature="_koShwEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:SpecReference xmi:id="_mekG4EW9EeaB8vMnkFQLXQ" base_StructuralFeature="_fcjcsEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:SpecTarget xmi:id="_oTu4wEW9EeaB8vMnkFQLXQ" base_StructuralFeature="_koShwEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_xTg3MUW9EeaB8vMnkFQLXQ" base_Element="_xTg3MEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_xTg3MkW9EeaB8vMnkFQLXQ" base_StructuralFeature="_xTg3MEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_03vL4UW9EeaB8vMnkFQLXQ" base_Element="_03vL4EW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelAttribute xmi:id="_03vL4kW9EeaB8vMnkFQLXQ" base_StructuralFeature="_03vL4EW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_B8c_YUW-EeaB8vMnkFQLXQ" base_Element="_B8c_YEW-EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_G88dwUW-EeaB8vMnkFQLXQ" base_Element="_G88dwEW-EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_Kjj_IUW-EeaB8vMnkFQLXQ" base_Element="_Kjj_IEW-EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:OpenModelElement xmi:id="_Oh75MUW-EeaB8vMnkFQLXQ" base_Element="_Oh75MEW-EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:SpecReference xmi:id="_j8NYQE2nEeaVmblocARh6A" base_StructuralFeature="_xTg3MEW9EeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile_2:SpecTarget xmi:id="_pQOPkE2nEeaVmblocARh6A" base_StructuralFeature="_03vL4EW9EeaB8vMnkFQLXQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiModel.uml
+++ b/xmi2yang tool-v2.0/project/TapiModel.uml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_I3IboDBLEeaSroGqGbZ6jg" name="TapiModel">
+    <packagedElement xmi:type="uml:Package" xmi:id="_AivIMOKxEeSq5fATALSQkQ" name="Diagrams"/>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_JPOzFDBLEeaSroGqGbZ6jg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_9xgjQDOFEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9xgjQTOFEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9xgjQjOFEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9xgjQzOFEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9xgjRDOFEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9xgjRTOFEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JPYjkDBLEeaSroGqGbZ6jg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_JQuAUDBLEeaSroGqGbZ6jg" base_Element="_I3IboDBLEeaSroGqGbZ6jg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_JQuAUTBLEeaSroGqGbZ6jg" base_Element="_JPOzFDBLEeaSroGqGbZ6jg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCSR31EeaVEcfXx-aEqQ" base_Element="_AivIMOKxEeSq5fATALSQkQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiNotification.uml
+++ b/xmi2yang tool-v2.0/project/TapiNotification.uml
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_R72poDA5Eea4fKwSGMr6CA" name="TapiNotification">
+    <packagedElement xmi:type="uml:Package" xmi:id="_yeC9sC5xEea0_JngOlSKcA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_rZ7rwCzyEeaYO8M_h7XJ5A" name="NotifSubscriptionHasFilter" memberEnd="_rZ7rxCzyEeaYO8M_h7XJ5A _raE1sCzyEeaYO8M_h7XJ5A">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rZ7rwizyEeaYO8M_h7XJ5A" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rZ7rwyzyEeaYO8M_h7XJ5A" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_raE1sCzyEeaYO8M_h7XJ5A" name="_notifSubscription" type="_oVDs4CzvEeaYO8M_h7XJ5A" association="_rZ7rwCzyEeaYO8M_h7XJ5A"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_5oI2cC1sEeair-8ZDvf8jw" name="NotifSubscriptionAccessesNotification" memberEnd="_5oI2dC1sEeair-8ZDvf8jw _5oI2dy1sEeair-8ZDvf8jw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5oI2ci1sEeair-8ZDvf8jw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5oI2cy1sEeair-8ZDvf8jw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_5oI2dy1sEeair-8ZDvf8jw" name="_notifSubscription" type="_oVDs4CzvEeaYO8M_h7XJ5A" association="_5oI2cC1sEeair-8ZDvf8jw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_kFsxgE8SEea3rq3M7G3w3w" name="NotificationHasTarget" memberEnd="_kF1UYE8SEea3rq3M7G3w3w _kF17cU8SEea3rq3M7G3w3w" navigableOwnedEnd="_kF1UYE8SEea3rq3M7G3w3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_kFzfME8SEea3rq3M7G3w3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_kF0GQE8SEea3rq3M7G3w3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_kF17cU8SEea3rq3M7G3w3w" name="_notification" type="_7CEIsC1qEeair-8ZDvf8jw" association="_kFsxgE8SEea3rq3M7G3w3w">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sykbAE8SEea3rq3M7G3w3w"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_syrIsE8SEea3rq3M7G3w3w" value="*"/>
+        </ownedEnd>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_kF1UYE8SEea3rq3M7G3w3w" name="_targetObject" association="_kFsxgE8SEea3rq3M7G3w3w">
+          <type xmi:type="uml:Class" href="Tapi.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_xbgioC5xEea0_JngOlSKcA" name="Diagrams">
+      <packagedElement xmi:type="uml:Association" xmi:id="_Nsg9cE8cEea3rq3M7G3w3w" name="NotifSubscriptionHasChannel" memberEnd="_Nsg9dE8cEea3rq3M7G3w3w _Nsg9d08cEea3rq3M7G3w3w">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Nsg9ck8cEea3rq3M7G3w3w" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Nsg9c08cEea3rq3M7G3w3w" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Nsg9d08cEea3rq3M7G3w3w" name="_notifSubscription" type="_oVDs4CzvEeaYO8M_h7XJ5A" association="_Nsg9cE8cEea3rq3M7G3w3w"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_wQFRUC5xEea0_JngOlSKcA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_DygpADA8Eea4fKwSGMr6CA">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_431KQC5xEea0_JngOlSKcA" name="Interfaces">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_2HbQwC0UEeah7qIgVNfKeA" name="NotificationSubscriptionService" isLeaf="true">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_1JlTAC0VEeah7qIgVNfKeA" name="getSupportedNotificationTypes" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_IbBHcC0WEeah7qIgVNfKeA" name="supportedNotificationTypes" type="_hZotgCzcEeaYO8M_h7XJ5A" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_STH1AC0WEeah7qIgVNfKeA" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_STH1Ai0WEeah7qIgVNfKeA" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_MIrE8C0WEeah7qIgVNfKeA" name="supportedObjectTypes" type="_FFtS8CzeEeaYO8M_h7XJ5A" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_RBcxwC0WEeah7qIgVNfKeA" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_RBmiwC0WEeah7qIgVNfKeA" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_2Iz7YC0VEeah7qIgVNfKeA" name="createNotificationSubscriptionService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_juqM4C0YEeah7qIgVNfKeA" name="subscriptionFilter" type="_phsNMCzxEeaYO8M_h7XJ5A" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_LNaH0C0cEeah7qIgVNfKeA" name="subscriptionState" type="_Rjd84C0aEeah7qIgVNfKeA" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qyYuUC0YEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_Sgs2oC0ZEeah7qIgVNfKeA" name="updateNotificationSubscriptionService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YSIpwC0ZEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Sgs2oS0ZEeah7qIgVNfKeA" name="subscriptionFilter" type="_phsNMCzxEeaYO8M_h7XJ5A" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_HalWcC0cEeah7qIgVNfKeA" name="subscriptionState" type="_Rjd84C0aEeah7qIgVNfKeA" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Sgs2oi0ZEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out" effect="update"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_o5NJsC0ZEeah7qIgVNfKeA" name="deleteNotificationSubscriptionService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_o5NJsS0ZEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_o5NJsy0ZEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out" effect="delete"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_BDuFkC0dEeah7qIgVNfKeA" name="getNotificationSubscriptionServiceDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_BDuFkS0dEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_BDuFlC0dEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_MQ03MC0dEeah7qIgVNfKeA" name="getNotificationSubscriptionServiceList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_MQ03Mi0dEeah7qIgVNfKeA" name="subscriptionService" type="_oVDs4CzvEeaYO8M_h7XJ5A" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Oys-EC0dEeah7qIgVNfKeA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Oys-Ei0dEeah7qIgVNfKeA" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_SumL4C0dEeah7qIgVNfKeA" name="getNotificationList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SumL4S0dEeah7qIgVNfKeA" name="subscriptionIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_4zwy0C0iEeah7qIgVNfKeA" name="timePeriod" effect="read">
+            <type xmi:type="uml:Class" href="Tapi.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SumL4i0dEeah7qIgVNfKeA" name="notification" type="_7CEIsC1qEeair-8ZDvf8jw" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aVAjoC0dEeah7qIgVNfKeA"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aVAjoi0dEeah7qIgVNfKeA" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_z6g7sC5xEea0_JngOlSKcA" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_oVDs4CzvEeaYO8M_h7XJ5A" name="NotificationSubscriptionService">
+        <generalization xmi:type="uml:Generalization" xmi:id="_2viZcCzvEeaYO8M_h7XJ5A">
+          <general xmi:type="uml:Class" href="Tapi.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QAttwEThEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_QAttwUThEead1bezhJG4aw" value="/TapiNotification:NotificationSubscriptionService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_36HEED3jEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_aE3TQEThEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_aE3TQUThEead1bezhJG4aw" value="/Tapi:Context/Tapi:_notifSubscription"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_4oopgEJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_5oI2dC1sEeair-8ZDvf8jw" name="_notification" type="_7CEIsC1qEeair-8ZDvf8jw" isReadOnly="true" aggregation="shared" association="_5oI2cC1sEeair-8ZDvf8jw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_97CPAC1sEeair-8ZDvf8jw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_97LY8C1sEeair-8ZDvf8jw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Nsg9dE8cEea3rq3M7G3w3w" name="_notificationChannel" type="_aQ9x8E8bEea3rq3M7G3w3w" aggregation="composite" association="_Nsg9cE8cEea3rq3M7G3w3w"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rZ7rxCzyEeaYO8M_h7XJ5A" name="_subscriptionFilter" type="_phsNMCzxEeaYO8M_h7XJ5A" aggregation="composite" association="_rZ7rwCzyEeaYO8M_h7XJ5A">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_u6BHUCzyEeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_u6K4UCzyEeaYO8M_h7XJ5A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BeqnEC0bEeah7qIgVNfKeA" name="subscriptionState" type="_Rjd84C0aEeah7qIgVNfKeA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0iGcECzwEeaYO8M_h7XJ5A" name="supportedNotificationTypes" type="_hZotgCzcEeaYO8M_h7XJ5A" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Hx1AUCzxEeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Hx1AUizxEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4HEXoCzwEeaYO8M_h7XJ5A" name="supportedObjectTypes" type="_FFtS8CzeEeaYO8M_h7XJ5A" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Jj9FQCzxEeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Jj9FQizxEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_phsNMCzxEeaYO8M_h7XJ5A" name="SubscriptionFilter" isLeaf="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8YhJQCzxEeaYO8M_h7XJ5A" name="requestedNotificationTypes" type="_hZotgCzcEeaYO8M_h7XJ5A" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VsFfQCzyEeaYO8M_h7XJ5A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VsFfQizyEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__0cdkCzxEeaYO8M_h7XJ5A" name="requestedObjectTypes" type="_FFtS8CzeEeaYO8M_h7XJ5A" isReadOnly="true">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XQ_nkCzyEeaYO8M_h7XJ5A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XQ_nkizyEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FwOfgCzyEeaYO8M_h7XJ5A" name="requestedLayerProtocols" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Yw8-cCzyEeaYO8M_h7XJ5A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Yw8-cizyEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KPrGUCzyEeaYO8M_h7XJ5A" name="requestedObjectIdentifier" isReadOnly="true">
+          <type xmi:type="uml:DataType" href="Tapi.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aDVzYCzyEeaYO8M_h7XJ5A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aDVzYizyEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_q0nuUE8XEea3rq3M7G3w3w" name="includeContent" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_q0nuUU8XEea3rq3M7G3w3w" annotatedElement="_q0nuUE8XEea3rq3M7G3w3w">
+            <body>Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Signal" xmi:id="_7CEIsC1qEeair-8ZDvf8jw" name="Notification">
+        <generalization xmi:type="uml:Generalization" xmi:id="_6OQ7MD3nEea-1_BGg-qcjQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oMeHIEThEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_oMeHIUThEead1bezhJG4aw" value="/TapiNotification:Notification"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_vow5kEThEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_vow5kUThEead1bezhJG4aw" value="/Tapi:Context/Tapi:_notification"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__HbVoCzoEeaYO8M_h7XJ5A" name="notificationType" type="_hZotgCzcEeaYO8M_h7XJ5A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RH-xACzpEeaYO8M_h7XJ5A" name="targetObjectType" type="_FFtS8CzeEeaYO8M_h7XJ5A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TLUZYE8lEea3rq3M7G3w3w" name="targetObjectIdentifier">
+          <type xmi:type="uml:DataType" href="Tapi.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_fbcaICzqEeaYO8M_h7XJ5A" name="targetObjectName">
+          <type xmi:type="uml:DataType" href="Tapi.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_i-DlQCzqEeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_i-DlQizqEeaYO8M_h7XJ5A" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_p0dcYCzqEeaYO8M_h7XJ5A" name="eventTimeStamp">
+          <type xmi:type="uml:DataType" href="Tapi.uml#_6iCS8O-fEeWLlrwIF3w0vA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9CxHgE8cEea3rq3M7G3w3w" name="sequenceNumber" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_9CxHgU8cEea3rq3M7G3w3w" annotatedElement="_9CxHgE8cEea3rq3M7G3w3w">
+            <body>A monotonous increasing sequence number associated with the notification.&#xD;
+The exact semantics of how this sequence number is assigned (per channel or subscription or source or system) is left undefined.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_virjcCzqEeaYO8M_h7XJ5A" name="sourceIndicator" type="_bgwjsCzeEeaYO8M_h7XJ5A"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gu8iACztEeaYO8M_h7XJ5A" name="layerProtocolName">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u53agCzrEeaYO8M_h7XJ5A" name="changedAttributes" type="__Pe64CznEeaYO8M_h7XJ5A">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AHMaAC1sEeair-8ZDvf8jw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AHMaAi1sEeair-8ZDvf8jw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3CrUsCzrEeaYO8M_h7XJ5A" name="additionalInfo">
+          <type xmi:type="uml:DataType" href="Tapi.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CZa7UC1sEeair-8ZDvf8jw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CZkFQC1sEeair-8ZDvf8jw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_x4d5oCzrEeaYO8M_h7XJ5A" name="additionalText">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_aQ9x8E8bEea3rq3M7G3w3w" name="NotificationChannel">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xvMMYE8aEea3rq3M7G3w3w" name="streamAddress" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_5u9fUE8aEea3rq3M7G3w3w" annotatedElement="_xvMMYE8aEea3rq3M7G3w3w">
+            <body>The address/location/URI of the channel/stream to which the subscribed notifications are published.&#xD;
+This specifics of this is typically dependent on the implementation protocol &amp; mechanism and hence is typed as a string.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LYuLUE8bEea3rq3M7G3w3w" name="nextSequenceNo" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_LYuLUU8bEea3rq3M7G3w3w" annotatedElement="_LYuLUE8bEea3rq3M7G3w3w">
+            <body>The sequence number of the next notification that will be published on the channel</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_1Xq2MC5xEea0_JngOlSKcA" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:DataType" xmi:id="__Pe64CznEeaYO8M_h7XJ5A" name="NameAndValueChange" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="__Pe64SznEeaYO8M_h7XJ5A" annotatedElement="__Pe64CznEeaYO8M_h7XJ5A">
+          <body>A scoped name-value triple, including old value and new value</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__Pe64iznEeaYO8M_h7XJ5A" name="valueName" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__Pe64yznEeaYO8M_h7XJ5A" annotatedElement="__Pe64iznEeaYO8M_h7XJ5A">
+            <body>The name of the value. The value need not have a name.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__Pe65CznEeaYO8M_h7XJ5A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__Pe65SznEeaYO8M_h7XJ5A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__Pe65iznEeaYO8M_h7XJ5A" name="oldValue" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="__Pe65yznEeaYO8M_h7XJ5A" annotatedElement="__Pe65iznEeaYO8M_h7XJ5A">
+            <body>The value</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__Pe66CznEeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__Pe66SznEeaYO8M_h7XJ5A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_E_LBkCzoEeaYO8M_h7XJ5A" name="newValue" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_E_LBkSzoEeaYO8M_h7XJ5A" annotatedElement="_E_LBkCzoEeaYO8M_h7XJ5A">
+            <body>The value</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_E_LBkizoEeaYO8M_h7XJ5A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_E_LBkyzoEeaYO8M_h7XJ5A" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_hZotgCzcEeaYO8M_h7XJ5A" name="NotificationType" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_hZotgSzcEeaYO8M_h7XJ5A" annotatedElement="_hZotgCzcEeaYO8M_h7XJ5A">
+          <body>The orientation of flow at the Port of a Forwarding entity</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_hZotiCzcEeaYO8M_h7XJ5A" name="OBJECT_CREATION">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_hZotiSzcEeaYO8M_h7XJ5A" annotatedElement="_hZotiCzcEeaYO8M_h7XJ5A">
+            <body>Not a normal state. The system is unable to determine the correct value.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_qgPssCzcEeaYO8M_h7XJ5A" name="OBJECT_DELETION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sa1KECzcEeaYO8M_h7XJ5A" name="ATTRIBUTE_VALUE_CHANGE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_FFtS8CzeEeaYO8M_h7XJ5A" name="ObjectType" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_FFtS8SzeEeaYO8M_h7XJ5A" annotatedElement="_FFtS8CzeEeaYO8M_h7XJ5A">
+          <body>The orientation of flow at the Port of a Forwarding entity</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Jsw9oCzeEeaYO8M_h7XJ5A" name="TOPOLOGY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KpUFcCzeEeaYO8M_h7XJ5A" name="NODE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LaJFcCzeEeaYO8M_h7XJ5A" name="LINK"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_MakAoCzeEeaYO8M_h7XJ5A" name="CONNECTION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_NRwuYCzeEeaYO8M_h7XJ5A" name="PATH"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_OxHoUCzeEeaYO8M_h7XJ5A" name="CONNECTIVITY_SERVICE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_RB-QoCzeEeaYO8M_h7XJ5A" name="VIRTUAL_NETWORK_SERVICE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_SlD0ACzeEeaYO8M_h7XJ5A" name="PATH_COMPUTATION_SERVICE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_UVnLoCzeEeaYO8M_h7XJ5A" name="NODE_EDGE_POINT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Vq3uYCzeEeaYO8M_h7XJ5A" name="SERVICE_END_POINT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_XRFeQCzeEeaYO8M_h7XJ5A" name="CONNECTION_END_POINT"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_bgwjsCzeEeaYO8M_h7XJ5A" name="SourceIndicator" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ggplICzeEeaYO8M_h7XJ5A" name="RESOURCE_OPERATION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_h_dFcCzeEeaYO8M_h7XJ5A" name="MANAGEMENT_OPERATION"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jrUKUCzeEeaYO8M_h7XJ5A" name="UNKNOWN"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_Rjd84C0aEeah7qIgVNfKeA" name="SubscriptionState" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_0ThbcC0aEeah7qIgVNfKeA" name="SUSPENDED"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1QrAMC0aEeah7qIgVNfKeA" name="ACTIVE"/>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_STaOhDA5Eea4fKwSGMr6CA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QWb3DjOGEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QWb3DzOGEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QWb3EDOGEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QWb3ETOGEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QWb3EjOGEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QWb3EzOGEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_STaOhTA5Eea4fKwSGMr6CA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SUTm-zA5Eea4fKwSGMr6CA" base_Element="_R72poDA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SUTm_DA5Eea4fKwSGMr6CA" base_Element="_STaOhDA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hcUOECzcEeaYO8M_h7XJ5A" base_Element="_hZotgCzcEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hcdYACzcEeaYO8M_h7XJ5A" base_Element="_hZotgSzcEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hcdYByzcEeaYO8M_h7XJ5A" base_Element="_hZotiCzcEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hcdYCCzcEeaYO8M_h7XJ5A" base_Element="_hZotiSzcEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qgPssSzcEeaYO8M_h7XJ5A" base_Element="_qgPssCzcEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sa-7ECzcEeaYO8M_h7XJ5A" base_Element="_sa1KECzcEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_FHCvsCzeEeaYO8M_h7XJ5A" base_Element="_FFtS8CzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_FHCvsSzeEeaYO8M_h7XJ5A" base_Element="_FFtS8SzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Jsw9oSzeEeaYO8M_h7XJ5A" base_Element="_Jsw9oCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_KpUFcSzeEeaYO8M_h7XJ5A" base_Element="_KpUFcCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LaJFcSzeEeaYO8M_h7XJ5A" base_Element="_LaJFcCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MakAoSzeEeaYO8M_h7XJ5A" base_Element="_MakAoCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NRwuYSzeEeaYO8M_h7XJ5A" base_Element="_NRwuYCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_OxHoUSzeEeaYO8M_h7XJ5A" base_Element="_OxHoUCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_RB-QoSzeEeaYO8M_h7XJ5A" base_Element="_RB-QoCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SlD0ASzeEeaYO8M_h7XJ5A" base_Element="_SlD0ACzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_UVnLoSzeEeaYO8M_h7XJ5A" base_Element="_UVnLoCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Vq3uYSzeEeaYO8M_h7XJ5A" base_Element="_Vq3uYCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_XRFeQSzeEeaYO8M_h7XJ5A" base_Element="_XRFeQCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_biPxcCzeEeaYO8M_h7XJ5A" base_Element="_bgwjsCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ggplISzeEeaYO8M_h7XJ5A" base_Element="_ggplICzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_h_dFcSzeEeaYO8M_h7XJ5A" base_Element="_h_dFcCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_jrUKUSzeEeaYO8M_h7XJ5A" base_Element="_jrUKUCzeEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNsCznEeaYO8M_h7XJ5A" base_Element="__Pe64CznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNsSznEeaYO8M_h7XJ5A" base_Element="__Pe64SznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNsiznEeaYO8M_h7XJ5A" base_Element="__Pe64iznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__QrNsyznEeaYO8M_h7XJ5A" base_StructuralFeature="__Pe64iznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNtCznEeaYO8M_h7XJ5A" base_Element="__Pe64yznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNtSznEeaYO8M_h7XJ5A" base_Element="__Pe65CznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNtiznEeaYO8M_h7XJ5A" base_Element="__Pe65SznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNtyznEeaYO8M_h7XJ5A" base_Element="__Pe65iznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__QrNuCznEeaYO8M_h7XJ5A" base_StructuralFeature="__Pe65iznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNuSznEeaYO8M_h7XJ5A" base_Element="__Pe65yznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNuiznEeaYO8M_h7XJ5A" base_Element="__Pe66CznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__QrNuyznEeaYO8M_h7XJ5A" base_Element="__Pe66SznEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_E_LBlCzoEeaYO8M_h7XJ5A" base_Element="_E_LBkCzoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_E_LBlSzoEeaYO8M_h7XJ5A" base_StructuralFeature="_E_LBkCzoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_E_LBlizoEeaYO8M_h7XJ5A" base_Element="_E_LBkSzoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_E_LBlyzoEeaYO8M_h7XJ5A" base_Element="_E_LBkizoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_E_LBmCzoEeaYO8M_h7XJ5A" base_Element="_E_LBkyzoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__HbVoSzoEeaYO8M_h7XJ5A" base_Element="__HbVoCzoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__HbVoizoEeaYO8M_h7XJ5A" base_StructuralFeature="__HbVoCzoEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_RH-xASzpEeaYO8M_h7XJ5A" base_Element="_RH-xACzpEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_RH-xAizpEeaYO8M_h7XJ5A" base_StructuralFeature="_RH-xACzpEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_fbcaISzqEeaYO8M_h7XJ5A" base_Element="_fbcaICzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_fbcaIizqEeaYO8M_h7XJ5A" base_StructuralFeature="_fbcaICzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_i-DlQSzqEeaYO8M_h7XJ5A" base_Element="_i-DlQCzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_i-DlQyzqEeaYO8M_h7XJ5A" base_Element="_i-DlQizqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_p0dcYSzqEeaYO8M_h7XJ5A" base_Element="_p0dcYCzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_p0dcYizqEeaYO8M_h7XJ5A" base_StructuralFeature="_p0dcYCzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_virjcSzqEeaYO8M_h7XJ5A" base_Element="_virjcCzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_virjcizqEeaYO8M_h7XJ5A" base_StructuralFeature="_virjcCzqEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_u53agSzrEeaYO8M_h7XJ5A" base_Element="_u53agCzrEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_u53agizrEeaYO8M_h7XJ5A" base_StructuralFeature="_u53agCzrEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_x4d5oSzrEeaYO8M_h7XJ5A" base_Element="_x4d5oCzrEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_x4d5oizrEeaYO8M_h7XJ5A" base_StructuralFeature="_x4d5oCzrEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_3CrUsSzrEeaYO8M_h7XJ5A" base_Element="_3CrUsCzrEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3CrUsizrEeaYO8M_h7XJ5A" base_StructuralFeature="_3CrUsCzrEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_gu8iASztEeaYO8M_h7XJ5A" base_Element="_gu8iACztEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gu8iAiztEeaYO8M_h7XJ5A" base_StructuralFeature="_gu8iACztEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_oVDs4SzvEeaYO8M_h7XJ5A" base_Element="_oVDs4CzvEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oVDs4izvEeaYO8M_h7XJ5A" base_Class="_oVDs4CzvEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2viZcSzvEeaYO8M_h7XJ5A" base_Element="_2viZcCzvEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_0iGcESzwEeaYO8M_h7XJ5A" base_Element="_0iGcECzwEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_0iPmACzwEeaYO8M_h7XJ5A" base_StructuralFeature="_0iGcECzwEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_4HEXoSzwEeaYO8M_h7XJ5A" base_Element="_4HEXoCzwEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_4HEXoizwEeaYO8M_h7XJ5A" base_StructuralFeature="_4HEXoCzwEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Hx1AUSzxEeaYO8M_h7XJ5A" base_Element="_Hx1AUCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Hx1AUyzxEeaYO8M_h7XJ5A" base_Element="_Hx1AUizxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Jj9FQSzxEeaYO8M_h7XJ5A" base_Element="_Jj9FQCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Jj9FQyzxEeaYO8M_h7XJ5A" base_Element="_Jj9FQizxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_phsNMSzxEeaYO8M_h7XJ5A" base_Element="_phsNMCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_phsNMizxEeaYO8M_h7XJ5A" base_Class="_phsNMCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_8YhJQSzxEeaYO8M_h7XJ5A" base_Element="_8YhJQCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8YhJQizxEeaYO8M_h7XJ5A" base_StructuralFeature="_8YhJQCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__0cdkSzxEeaYO8M_h7XJ5A" base_Element="__0cdkCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__0cdkizxEeaYO8M_h7XJ5A" base_StructuralFeature="__0cdkCzxEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_FwOfgSzyEeaYO8M_h7XJ5A" base_Element="_FwOfgCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FwOfgizyEeaYO8M_h7XJ5A" base_StructuralFeature="_FwOfgCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_KPrGUSzyEeaYO8M_h7XJ5A" base_Element="_KPrGUCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KPrGUizyEeaYO8M_h7XJ5A" base_StructuralFeature="_KPrGUCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VsFfQSzyEeaYO8M_h7XJ5A" base_Element="_VsFfQCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VsFfQyzyEeaYO8M_h7XJ5A" base_Element="_VsFfQizyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_XQ_nkSzyEeaYO8M_h7XJ5A" base_Element="_XQ_nkCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_XQ_nkyzyEeaYO8M_h7XJ5A" base_Element="_XQ_nkizyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Yw8-cSzyEeaYO8M_h7XJ5A" base_Element="_Yw8-cCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Yw8-cyzyEeaYO8M_h7XJ5A" base_Element="_Yw8-cizyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aDVzYSzyEeaYO8M_h7XJ5A" base_Element="_aDVzYCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aDVzYyzyEeaYO8M_h7XJ5A" base_Element="_aDVzYizyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_rZ7rwSzyEeaYO8M_h7XJ5A" base_Element="_rZ7rwCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_rZ7rxSzyEeaYO8M_h7XJ5A" base_Element="_rZ7rxCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rZ7rxizyEeaYO8M_h7XJ5A" base_StructuralFeature="_rZ7rxCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_raE1sSzyEeaYO8M_h7XJ5A" base_Element="_raE1sCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_raE1sizyEeaYO8M_h7XJ5A" base_StructuralFeature="_raE1sCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_u6BHUSzyEeaYO8M_h7XJ5A" base_Element="_u6BHUCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_u6K4USzyEeaYO8M_h7XJ5A" base_Element="_u6K4UCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_7ql20CzyEeaYO8M_h7XJ5A" base_Association="_rZ7rwCzyEeaYO8M_h7XJ5A"/>
+  <OpenModel_Profile:OpenModelInterface xmi:id="_2LcOEC0UEeah7qIgVNfKeA" base_Interface="_2HbQwC0UEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2LcOES0UEeah7qIgVNfKeA" base_Element="_2HbQwC0UEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_IbK4cC0WEeah7qIgVNfKeA" base_Parameter="_IbBHcC0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IbK4cS0WEeah7qIgVNfKeA" base_Element="_IbBHcC0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_MIrE8S0WEeah7qIgVNfKeA" base_Parameter="_MIrE8C0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MIrE8i0WEeah7qIgVNfKeA" base_Element="_MIrE8C0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_RBcxwS0WEeah7qIgVNfKeA" base_Element="_RBcxwC0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_RBmiwS0WEeah7qIgVNfKeA" base_Element="_RBmiwC0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_STH1AS0WEeah7qIgVNfKeA" base_Element="_STH1AC0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_STH1Ay0WEeah7qIgVNfKeA" base_Element="_STH1Ai0WEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_juqM4S0YEeah7qIgVNfKeA" base_Parameter="_juqM4C0YEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_juqM4i0YEeah7qIgVNfKeA" base_Element="_juqM4C0YEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_qyYuUS0YEeah7qIgVNfKeA" base_Parameter="_qyYuUC0YEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qyYuUi0YEeah7qIgVNfKeA" base_Element="_qyYuUC0YEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_SiV1Yi0ZEeah7qIgVNfKeA" base_Parameter="_Sgs2oS0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SiV1Yy0ZEeah7qIgVNfKeA" base_Element="_Sgs2oS0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_SiV1ZC0ZEeah7qIgVNfKeA" base_Parameter="_Sgs2oi0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SiV1ZS0ZEeah7qIgVNfKeA" base_Element="_Sgs2oi0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_YSIpwS0ZEeah7qIgVNfKeA" base_Parameter="_YSIpwC0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YSIpwi0ZEeah7qIgVNfKeA" base_Element="_YSIpwC0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_o5NJti0ZEeah7qIgVNfKeA" base_Parameter="_o5NJsS0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_o5NJty0ZEeah7qIgVNfKeA" base_Element="_o5NJsS0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_o5NJui0ZEeah7qIgVNfKeA" base_Parameter="_o5NJsy0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_o5NJuy0ZEeah7qIgVNfKeA" base_Element="_o5NJsy0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Rjd84S0aEeah7qIgVNfKeA" base_Element="_Rjd84C0aEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_0TqlYC0aEeah7qIgVNfKeA" base_Element="_0ThbcC0aEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1QrAMS0aEeah7qIgVNfKeA" base_Element="_1QrAMC0aEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BeqnES0bEeah7qIgVNfKeA" base_StructuralFeature="_BeqnEC0bEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Be0YEC0bEeah7qIgVNfKeA" base_Element="_BeqnEC0bEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_HalWcS0cEeah7qIgVNfKeA" base_Parameter="_HalWcC0cEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_HalWci0cEeah7qIgVNfKeA" base_Element="_HalWcC0cEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_LNaH0S0cEeah7qIgVNfKeA" base_Parameter="_LNaH0C0cEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LNaH0i0cEeah7qIgVNfKeA" base_Element="_LNaH0C0cEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_BDuFly0dEeah7qIgVNfKeA" base_Parameter="_BDuFkS0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BDuFmC0dEeah7qIgVNfKeA" base_Element="_BDuFkS0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_BDuFnS0dEeah7qIgVNfKeA" base_Parameter="_BDuFlC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BDuFni0dEeah7qIgVNfKeA" base_Element="_BDuFlC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_MQ-oMi0dEeah7qIgVNfKeA" base_Parameter="_MQ03Mi0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MQ-oMy0dEeah7qIgVNfKeA" base_Element="_MQ03Mi0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Oys-ES0dEeah7qIgVNfKeA" base_Element="_Oys-EC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Oys-Ey0dEeah7qIgVNfKeA" base_Element="_Oys-Ei0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Suv84i0dEeah7qIgVNfKeA" base_Parameter="_SumL4S0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Suv84y0dEeah7qIgVNfKeA" base_Element="_SumL4S0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Suv85C0dEeah7qIgVNfKeA" base_Parameter="_SumL4i0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Suv85S0dEeah7qIgVNfKeA" base_Element="_SumL4i0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aVAjoS0dEeah7qIgVNfKeA" base_Element="_aVAjoC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aVAjoy0dEeah7qIgVNfKeA" base_Element="_aVAjoi0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_4zwy0S0iEeah7qIgVNfKeA" base_Parameter="_4zwy0C0iEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_4zwy0i0iEeah7qIgVNfKeA" base_Element="_4zwy0C0iEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_AHMaAS1sEeair-8ZDvf8jw" base_Element="_AHMaAC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_AHMaAy1sEeair-8ZDvf8jw" base_Element="_AHMaAi1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_CZa7US1sEeair-8ZDvf8jw" base_Element="_CZa7UC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_CZkFQS1sEeair-8ZDvf8jw" base_Element="_CZkFQC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_5oI2cS1sEeair-8ZDvf8jw" base_Element="_5oI2cC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5oI2dS1sEeair-8ZDvf8jw" base_StructuralFeature="_5oI2dC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_5oI2di1sEeair-8ZDvf8jw" base_Element="_5oI2dC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_5oI2eC1sEeair-8ZDvf8jw" base_StructuralFeature="_5oI2dy1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_5oI2eS1sEeair-8ZDvf8jw" base_Element="_5oI2dy1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_97CPAS1sEeair-8ZDvf8jw" base_Element="_97CPAC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_97LY8S1sEeair-8ZDvf8jw" base_Element="_97LY8C1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7CN5sC1qEeair-8ZDvf8jw" base_Element="_7CEIsC1qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2Iz7Yi0VEeah7qIgVNfKeA" base_Element="_2Iz7YC0VEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_2Iz7YS0VEeah7qIgVNfKeA" base_Operation="_2Iz7YC0VEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_o5NJtS0ZEeah7qIgVNfKeA" base_Element="_o5NJsC0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_o5NJtC0ZEeah7qIgVNfKeA" base_Operation="_o5NJsC0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Suv84S0dEeah7qIgVNfKeA" base_Element="_SumL4C0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_Suv84C0dEeah7qIgVNfKeA" base_Operation="_SumL4C0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BDuFli0dEeah7qIgVNfKeA" base_Element="_BDuFkC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_BDuFlS0dEeah7qIgVNfKeA" base_Operation="_BDuFkC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MQ03NC0dEeah7qIgVNfKeA" base_Element="_MQ03MC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_MQ03My0dEeah7qIgVNfKeA" base_Operation="_MQ03MC0dEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1JlTAi0VEeah7qIgVNfKeA" base_Element="_1JlTAC0VEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_1JlTAS0VEeah7qIgVNfKeA" base_Operation="_1JlTAC0VEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SiV1YS0ZEeah7qIgVNfKeA" base_Element="_Sgs2oC0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_SiV1YC0ZEeah7qIgVNfKeA" base_Operation="_Sgs2oC0ZEeah7qIgVNfKeA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wQF4YC5xEea0_JngOlSKcA" base_Element="_wQFRUC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_xbhJsC5xEea0_JngOlSKcA" base_Element="_xbgioC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yeC9sS5xEea0_JngOlSKcA" base_Element="_yeC9sC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_z6g7sS5xEea0_JngOlSKcA" base_Element="_z6g7sC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1Xq2MS5xEea0_JngOlSKcA" base_Element="_1Xq2MC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_431xUC5xEea0_JngOlSKcA" base_Element="_431KQC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_DygpATA8Eea4fKwSGMr6CA" base_Element="_DygpADA8Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelNotification xmi:id="_7CEIsS1qEeair-8ZDvf8jw" base_Signal="_7CEIsC1qEeair-8ZDvf8jw">
+    <triggerConditionList>OBJECT_CREATION</triggerConditionList>
+    <triggerConditionList>OBJECT_DELETION</triggerConditionList>
+    <triggerConditionList>STATE_CHANGE</triggerConditionList>
+    <triggerConditionList>ATTRIBUTE_VALUE_CHANGE</triggerConditionList>
+  </OpenModel_Profile:OpenModelNotification>
+  <OpenModel_Profile:OpenModelElement xmi:id="_6OQ7MT3nEea-1_BGg-qcjQ" base_Element="_6OQ7MD3nEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_aYvBUD4ZEea-1_BGg-qcjQ" base_StructuralFeature="_5oI2dC1sEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QAttwkThEead1bezhJG4aw" base_StructuralFeature="_QAttwEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_QAttw0ThEead1bezhJG4aw" base_Element="_QAttwEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_QAttxEThEead1bezhJG4aw" base_Element="_QAttwUThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aE3TQkThEead1bezhJG4aw" base_StructuralFeature="_aE3TQEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aE3TQ0ThEead1bezhJG4aw" base_Element="_aE3TQEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aE3TREThEead1bezhJG4aw" base_Element="_aE3TQUThEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_c9FdkEThEead1bezhJG4aw" base_StructuralFeature="_QAttwEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_emAjMEThEead1bezhJG4aw" base_StructuralFeature="_aE3TQEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oMeHIkThEead1bezhJG4aw" base_StructuralFeature="_oMeHIEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_oMeHI0ThEead1bezhJG4aw" base_Element="_oMeHIEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_oMeHJEThEead1bezhJG4aw" base_Element="_oMeHIUThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vow5kkThEead1bezhJG4aw" base_StructuralFeature="_vow5kEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_vow5k0ThEead1bezhJG4aw" base_Element="_vow5kEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_vow5lEThEead1bezhJG4aw" base_Element="_vow5kUThEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_y8WKMEThEead1bezhJG4aw" base_StructuralFeature="_oMeHIEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_02_R8EThEead1bezhJG4aw" base_StructuralFeature="_vow5kEThEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_kFt_oE8SEea3rq3M7G3w3w" base_Element="_kFsxgE8SEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_kF1UYU8SEea3rq3M7G3w3w" base_Element="_kF1UYE8SEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kF17cE8SEea3rq3M7G3w3w" base_StructuralFeature="_kF1UYE8SEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sylCEE8SEea3rq3M7G3w3w" base_Element="_sykbAE8SEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_syrvwE8SEea3rq3M7G3w3w" base_Element="_syrIsE8SEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_q0nuUk8XEea3rq3M7G3w3w" base_Element="_q0nuUE8XEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_q0oVYE8XEea3rq3M7G3w3w" base_StructuralFeature="_q0nuUE8XEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_q0oVYU8XEea3rq3M7G3w3w" base_Element="_q0nuUU8XEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_xvMMYU8aEea3rq3M7G3w3w" base_Element="_xvMMYE8aEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xvMMYk8aEea3rq3M7G3w3w" base_StructuralFeature="_xvMMYE8aEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_5u9fUU8aEea3rq3M7G3w3w" base_Element="_5u9fUE8aEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LYuLUk8bEea3rq3M7G3w3w" base_Element="_LYuLUE8bEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LYuLU08bEea3rq3M7G3w3w" base_StructuralFeature="_LYuLUE8bEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LYuLVE8bEea3rq3M7G3w3w" base_Element="_LYuLUU8bEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aQ9x8U8bEea3rq3M7G3w3w" base_Class="_aQ9x8E8bEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aQ9x8k8bEea3rq3M7G3w3w" base_Element="_aQ9x8E8bEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Nsg9cU8cEea3rq3M7G3w3w" base_Element="_Nsg9cE8cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Nsg9dU8cEea3rq3M7G3w3w" base_Element="_Nsg9dE8cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Nsg9dk8cEea3rq3M7G3w3w" base_StructuralFeature="_Nsg9dE8cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Nsg9eE8cEea3rq3M7G3w3w" base_Element="_Nsg9d08cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Nsg9eU8cEea3rq3M7G3w3w" base_StructuralFeature="_Nsg9d08cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_9CxHgk8cEea3rq3M7G3w3w" base_Element="_9CxHgE8cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9CxHg08cEea3rq3M7G3w3w" base_StructuralFeature="_9CxHgE8cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_9CxHhE8cEea3rq3M7G3w3w" base_Element="_9CxHgU8cEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_TLUZYU8lEea3rq3M7G3w3w" base_Element="_TLUZYE8lEea3rq3M7G3w3w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TLVAcE8lEea3rq3M7G3w3w" base_StructuralFeature="_TLUZYE8lEea3rq3M7G3w3w"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiOch.uml
+++ b/xmi2yang tool-v2.0/project/TapiOch.uml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_1qX9MBKNEeajhbtskMXJfw" name="TapiOch">
+    <packagedElement xmi:type="uml:Package" xmi:id="_KjQ3oBKOEeajhbtskMXJfw" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_KjQ3ohKOEeajhbtskMXJfw" name="LpSpecHasAdapterPac" memberEnd="_KjQ3oxKOEeajhbtskMXJfw _KjQ3rhKOEeajhbtskMXJfw">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_KjQ3oxKOEeajhbtskMXJfw" name="lpSpec" type="_KjQ3rRKOEeajhbtskMXJfw" association="_KjQ3ohKOEeajhbtskMXJfw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3pBKOEeajhbtskMXJfw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3pRKOEeajhbtskMXJfw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_KjQ3phKOEeajhbtskMXJfw" name="LpSpecHasTerminationPac" memberEnd="_KjQ3pxKOEeajhbtskMXJfw _KjQ3sRKOEeajhbtskMXJfw">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_KjQ3pxKOEeajhbtskMXJfw" name="_lpSpec" type="_KjQ3rRKOEeajhbtskMXJfw" association="_KjQ3phKOEeajhbtskMXJfw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3qBKOEeajhbtskMXJfw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3qRKOEeajhbtskMXJfw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_hv9NsNnYEeWIOYiRCk5bbQ" name="LpSpecHasPoolPropertyPac" memberEnd="_hv9Ns9nYEeWIOYiRCk5bbQ _hv9NtdnYEeWIOYiRCk5bbQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_hv9NsdnYEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_hv9NstnYEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_hv9NtdnYEeWIOYiRCk5bbQ" name="_lpSpec" type="_VvSIYEUIEead1bezhJG4aw" association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_UyBxsBKOEeajhbtskMXJfw" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_bTHgIBKOEeajhbtskMXJfw" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3qhKOEeajhbtskMXJfw" name="AdapterAndConnectionPointPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3qxKOEeajhbtskMXJfw" name="monitoredDirection" visibility="public" type="_KjQ3wBKOEeajhbtskMXJfw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3rBKOEeajhbtskMXJfw" annotatedElement="_KjQ3qxKOEeajhbtskMXJfw">
+            <body>This attribute indicates the monitored direction.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSource then the value is fixed to SOURCE.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSink then the value is fixed to SINK.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointBidirectional then there is one instance that is fixed to SOURCE and one instance that is fixed to SINK.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3rRKOEeajhbtskMXJfw" name="ConnectionEndPointLpSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_hgaisDK1Eeau3Z0jZdArnw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_AICzUDK2Eeau3Z0jZdArnw" name="extensionsSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_AICzUTK2Eeau3Z0jZdArnw" value="/TapiOch:ConnectionEndPointLpSpec"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_VZkuoS6BEea0_JngOlSKcA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sPQsIDOTEeansfg7-s4Unw" name="extensionsSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_sPQsITOTEeansfg7-s4Unw" value="/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_EGSwgDOFEeansfg7-s4Unw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3rhKOEeajhbtskMXJfw" name="_adapterSpec" type="_KjQ3qhKOEeajhbtskMXJfw" aggregation="composite" association="_KjQ3ohKOEeajhbtskMXJfw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3rxKOEeajhbtskMXJfw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sBKOEeajhbtskMXJfw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3sRKOEeajhbtskMXJfw" name="_terminationSpec" type="_KjQ3tBKOEeajhbtskMXJfw" aggregation="composite" association="_KjQ3phKOEeajhbtskMXJfw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjQ3shKOEeajhbtskMXJfw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjQ3sxKOEeajhbtskMXJfw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjQ3tBKOEeajhbtskMXJfw" name="TerminationPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uRKOEeajhbtskMXJfw" name="selectedApplicationIdentifier" visibility="public" type="_KjQ3vRKOEeajhbtskMXJfw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3uhKOEeajhbtskMXJfw" annotatedElement="_KjQ3uRKOEeajhbtskMXJfw">
+            <body>This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3uxKOEeajhbtskMXJfw" name="nominalCentralFrequencyOrWavelength" visibility="public" type="_KjQ3xBKOEeajhbtskMXJfw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3vBKOEeajhbtskMXJfw" annotatedElement="_KjQ3uxKOEeajhbtskMXJfw">
+            <body>This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.&#xD;
+This attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.&#xD;
+</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_PKMDsEUIEead1bezhJG4aw" name="PoolPropertyPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ta37gEUqEead1bezhJG4aw" name="clientCapacity">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KzYUUEUwEeaJmZR8pYan5A" name="maxClientInstances">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_M7URMEUwEeaJmZR8pYan5A" name="maxClientSize">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_VvSIYEUIEead1bezhJG4aw" name="NodeEdgePointLpSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_iXciwEUIEead1bezhJG4aw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_2EvMwEUIEead1bezhJG4aw" name="extensionsSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_2EvMwUUIEead1bezhJG4aw" value="/TapiOch:NodeEdgePointLpSpec"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_VZkuoS6BEea0_JngOlSKcA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QVdmMEUXEead1bezhJG4aw" name="extensionsSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_WOQlkEUXEead1bezhJG4aw" value="/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_EGSwgDOFEeansfg7-s4Unw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_ochPoolPropertySpec" type="_PKMDsEUIEead1bezhJG4aw" isReadOnly="true" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ldi5wNnYEeWIOYiRCk5bbQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ldi5wdnYEeWIOYiRCk5bbQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_gyFqQBKOEeajhbtskMXJfw" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3vRKOEeajhbtskMXJfw" name="ApplicationIdentifier">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3vhKOEeajhbtskMXJfw" name="applicationIdentifierType" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3vxKOEeajhbtskMXJfw" name="applicationIdentifierValue" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_KjQ3wBKOEeajhbtskMXJfw" name="MonitoredDirection">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjQ3wRKOEeajhbtskMXJfw" annotatedElement="_KjQ3wBKOEeajhbtskMXJfw">
+          <body>The enumeration with the options for directionality for nonintrusive monitoring.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KjQ3whKOEeajhbtskMXJfw" name="SINK"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KjQ3wxKOEeajhbtskMXJfw" name="SOURCE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_KjQ3xBKOEeajhbtskMXJfw" name="NominalCentralFrequencyOrWavelength">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3xRKOEeajhbtskMXJfw" name="linkType" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjQ3xhKOEeajhbtskMXJfw" name="nominalCentralFrequencyOrWavelength" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_MSvNkBMEEeaOevPmmmHXcA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_eTzcwDK1Eeau3Z0jZdArnw">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_HQHNQEUBEead1bezhJG4aw">
+        <importedPackage xmi:type="uml:Model" href="TapiConnectivity.uml#_6fxZsDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_HRdREEUBEead1bezhJG4aw">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_5j3-UBKNEeajhbtskMXJfw">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1GT4RDOGEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1GT4RTOGEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1GT4RjOGEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1GT4RzOGEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1GT4SDOGEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1GT4STOGEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5j4lYBKNEeajhbtskMXJfw" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjResBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3oxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjSFwBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3pxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KjSs0BKOEeajhbtskMXJfw" base_Class="_KjQ3qhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjSs0RKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3qxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KjTT4BKOEeajhbtskMXJfw" base_Class="_KjQ3rRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjTT4RKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3rhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjTT4hKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3sRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KjT68BKOEeajhbtskMXJfw" base_Class="_KjQ3tBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjUiABKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3uRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjUiARKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3uxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJEBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3vhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJERKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3vxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVJEhKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KjVwIBKOEeajhbtskMXJfw" base_StructuralFeature="_KjQ3xhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="_1G8qkBKOEeajhbtskMXJfw" base_Element="_KjQ3vRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="_2RLpEBKOEeajhbtskMXJfw" base_Element="_KjQ3wBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="_3eqI0BKOEeajhbtskMXJfw" base_Element="_KjQ3xBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="_9F-9sBKOEeajhbtskMXJfw" base_Element="_KjQ3qxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="__ocTYBKOEeajhbtskMXJfw" base_Element="_KjQ3rhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="_HKhtUBKmEeajhbtskMXJfw" base_Element="_KjQ3uxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Experimental xmi:id="_InurIBKmEeajhbtskMXJfw" base_Element="_KjQ3uRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4MB32EeaVEcfXx-aEqQ" base_Element="_1qX9MBKNEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4MR32EeaVEcfXx-aEqQ" base_Element="_KjQ3oBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Mh32EeaVEcfXx-aEqQ" base_Element="_KjQ3ohKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Mx32EeaVEcfXx-aEqQ" base_Element="_KjQ3oxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4NB32EeaVEcfXx-aEqQ" base_Element="_KjQ3pBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4NR32EeaVEcfXx-aEqQ" base_Element="_KjQ3pRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Nh32EeaVEcfXx-aEqQ" base_Element="_KjQ3phKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Nx32EeaVEcfXx-aEqQ" base_Element="_KjQ3pxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4OB32EeaVEcfXx-aEqQ" base_Element="_KjQ3qBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4OR32EeaVEcfXx-aEqQ" base_Element="_KjQ3qRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Oh32EeaVEcfXx-aEqQ" base_Element="_UyBxsBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4PB32EeaVEcfXx-aEqQ" base_Element="_bTHgIBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4PR32EeaVEcfXx-aEqQ" base_Element="_KjQ3qhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Ph32EeaVEcfXx-aEqQ" base_Element="_KjQ3qxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Px32EeaVEcfXx-aEqQ" base_Element="_KjQ3rBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4QB32EeaVEcfXx-aEqQ" base_Element="_KjQ3rRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4RB32EeaVEcfXx-aEqQ" base_Element="_KjQ3sRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4RR32EeaVEcfXx-aEqQ" base_Element="_KjQ3shKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Rh32EeaVEcfXx-aEqQ" base_Element="_KjQ3sxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Rx32EeaVEcfXx-aEqQ" base_Element="_KjQ3rhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4SB32EeaVEcfXx-aEqQ" base_Element="_KjQ3rxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4SR32EeaVEcfXx-aEqQ" base_Element="_KjQ3sBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Sh32EeaVEcfXx-aEqQ" base_Element="_KjQ3tBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4Sx32EeaVEcfXx-aEqQ" base_Element="_KjQ3uRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-W4TB32EeaVEcfXx-aEqQ" base_Element="_KjQ3uhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCIB32EeaVEcfXx-aEqQ" base_Element="_KjQ3uxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCIR32EeaVEcfXx-aEqQ" base_Element="_KjQ3vBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCIh32EeaVEcfXx-aEqQ" base_Element="_gyFqQBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCIx32EeaVEcfXx-aEqQ" base_Element="_KjQ3vRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCJB32EeaVEcfXx-aEqQ" base_Element="_KjQ3vhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCJR32EeaVEcfXx-aEqQ" base_Element="_KjQ3vxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCJh32EeaVEcfXx-aEqQ" base_Element="_KjQ3wBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCJx32EeaVEcfXx-aEqQ" base_Element="_KjQ3wRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCKB32EeaVEcfXx-aEqQ" base_Element="_KjQ3whKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCKR32EeaVEcfXx-aEqQ" base_Element="_KjQ3wxKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCKh32EeaVEcfXx-aEqQ" base_Element="_KjQ3xBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCKx32EeaVEcfXx-aEqQ" base_Element="_KjQ3xRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCLB32EeaVEcfXx-aEqQ" base_Element="_KjQ3xhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCLR32EeaVEcfXx-aEqQ" base_Element="_MSvNkBMEEeaOevPmmmHXcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F-gCLx32EeaVEcfXx-aEqQ" base_Element="_5j3-UBKNEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_eT9NwDK1Eeau3Z0jZdArnw" base_Element="_eTzcwDK1Eeau3Z0jZdArnw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hgaisTK1Eeau3Z0jZdArnw" base_Element="_hgaisDK1Eeau3Z0jZdArnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_AICzUjK2Eeau3Z0jZdArnw" base_StructuralFeature="_AICzUDK2Eeau3Z0jZdArnw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_AICzUzK2Eeau3Z0jZdArnw" base_Element="_AICzUDK2Eeau3Z0jZdArnw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_AICzVDK2Eeau3Z0jZdArnw" base_Element="_AICzUTK2Eeau3Z0jZdArnw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_sPadIDOTEeansfg7-s4Unw" base_StructuralFeature="_sPQsIDOTEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sPadITOTEeansfg7-s4Unw" base_Element="_sPQsIDOTEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sPadIjOTEeansfg7-s4Unw" base_Element="_sPQsITOTEeansfg7-s4Unw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_HRKWIEUBEead1bezhJG4aw" base_Element="_HQHNQEUBEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_HRdREUUBEead1bezhJG4aw" base_Element="_HRdREEUBEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_a7T90EUHEead1bezhJG4aw" base_StructuralFeature="_sPQsIDOTEeansfg7-s4Unw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_myoxIEUHEead1bezhJG4aw" base_StructuralFeature="_AICzUDK2Eeau3Z0jZdArnw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_K1TuIEUIEead1bezhJG4aw" base_Element="_KjQ3rRKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_MOIiQEUIEead1bezhJG4aw" base_Element="_KjQ3tBKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_NIAJgEUIEead1bezhJG4aw" base_Element="_KjQ3qhKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_PKMDsUUIEead1bezhJG4aw" base_Class="_PKMDsEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_PKMDskUIEead1bezhJG4aw" base_Element="_PKMDsEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_VvSIYUUIEead1bezhJG4aw" base_Class="_VvSIYEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VvSIYkUIEead1bezhJG4aw" base_Element="_VvSIYEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_ceqKcEUIEead1bezhJG4aw" base_Element="_VvSIYEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_eXBaQEUIEead1bezhJG4aw" base_Element="_PKMDsEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_iXciwUUIEead1bezhJG4aw" base_Element="_iXciwEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2EvMwkUIEead1bezhJG4aw" base_StructuralFeature="_2EvMwEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2EvMw0UIEead1bezhJG4aw" base_Element="_2EvMwEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2EvMxEUIEead1bezhJG4aw" base_Element="_2EvMwUUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_HcLRUEUXEead1bezhJG4aw" base_StructuralFeature="_2EvMwEUIEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QVdmMUUXEead1bezhJG4aw" base_StructuralFeature="_QVdmMEUXEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_QVdmMkUXEead1bezhJG4aw" base_Element="_QVdmMEUXEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WOQlkUUXEead1bezhJG4aw" base_Element="_WOQlkEUXEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_YceJkEUXEead1bezhJG4aw" base_StructuralFeature="_QVdmMEUXEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ta37gUUqEead1bezhJG4aw" base_StructuralFeature="_ta37gEUqEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ta37gkUqEead1bezhJG4aw" base_Element="_ta37gEUqEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KzYUUUUwEeaJmZR8pYan5A" base_StructuralFeature="_KzYUUEUwEeaJmZR8pYan5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_KzYUUkUwEeaJmZR8pYan5A" base_Element="_KzYUUEUwEeaJmZR8pYan5A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_M7URMUUwEeaJmZR8pYan5A" base_StructuralFeature="_M7URMEUwEeaJmZR8pYan5A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_M7URMkUwEeaJmZR8pYan5A" base_Element="_M7URMEUwEeaJmZR8pYan5A"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_ue4nIEUzEeaB8vMnkFQLXQ" base_Association="_KjQ3ohKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_vn9IAEUzEeaB8vMnkFQLXQ" base_Association="_KjQ3phKOEeajhbtskMXJfw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_stfQEEU1EeaB8vMnkFQLXQ" base_Element="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_st78AEU1EeaB8vMnkFQLXQ" base_Association="_hv9NsNnYEeWIOYiRCk5bbQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiOdu.uml
+++ b/xmi2yang tool-v2.0/project/TapiOdu.uml
@@ -1,0 +1,829 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_LTrOcBwyEea2UIYIpgn3Zw" name="TapiOdu">
+    <packagedElement xmi:type="uml:Package" xmi:id="_sYw7sB3BEea2UIYIpgn3Zw" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_sYw7sR3BEea2UIYIpgn3Zw" name="LpSpecHasAdapterPac" memberEnd="_sYxjIh3BEea2UIYIpgn3Zw _sYw7tB3BEea2UIYIpgn3Zw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_sYw7sh3BEea2UIYIpgn3Zw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_sYw7sx3BEea2UIYIpgn3Zw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_sYw7tB3BEea2UIYIpgn3Zw" name="_lpSpec" type="_sYxjIR3BEea2UIYIpgn3Zw" association="_sYw7sR3BEea2UIYIpgn3Zw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_sYw7tR3BEea2UIYIpgn3Zw" name="LpSpecHasTerminationPac" memberEnd="_sYxjIx3BEea2UIYIpgn3Zw _sYw7uB3BEea2UIYIpgn3Zw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_sYw7th3BEea2UIYIpgn3Zw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_sYw7tx3BEea2UIYIpgn3Zw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_sYw7uB3BEea2UIYIpgn3Zw" name="_lpSpec" type="_sYxjIR3BEea2UIYIpgn3Zw" association="_sYw7tR3BEea2UIYIpgn3Zw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_cOYiQDIOEeaBg9FoTfINnA" name="LpSpecHasPoolPropertyPac" memberEnd="_cOYiRDIOEeaBg9FoTfINnA _cOYiRzIOEeaBg9FoTfINnA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cOYiQjIOEeaBg9FoTfINnA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cOYiQzIOEeaBg9FoTfINnA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_cOYiRzIOEeaBg9FoTfINnA" name="_lpSpec" type="_Um-Q8EKhEea-2Meh9kw1kA" association="_cOYiQDIOEeaBg9FoTfINnA"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_sYw7vx3BEea2UIYIpgn3Zw" name="Diagrams">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_sYw7wx3BEea2UIYIpgn3Zw">
+        <body>we are not modelling currentProblemList</body>
+      </ownedComment>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_sYxiwB3BEea2UIYIpgn3Zw" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_sYxiwR3BEea2UIYIpgn3Zw" name="AdapterAndConnectionPointPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxixR3BEea2UIYIpgn3Zw" name="adaptationActive" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxixh3BEea2UIYIpgn3Zw" annotatedElement="_sYxixR3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxixx3BEea2UIYIpgn3Zw" name="apsEnable" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxiyB3BEea2UIYIpgn3Zw" annotatedElement="_sYxixx3BEea2UIYIpgn3Zw">
+            <body>This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_sYxiyR3BEea2UIYIpgn3Zw" value="true">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </defaultValue>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxiyh3BEea2UIYIpgn3Zw" name="apsLevel" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxiyx3BEea2UIYIpgn3Zw" annotatedElement="_sYxiyh3BEea2UIYIpgn3Zw">
+            <body>This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxizB3BEea2UIYIpgn3Zw" name="k" visibility="public" type="_sYyxGx3BEea2UIYIpgn3Zw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxizR3BEea2UIYIpgn3Zw" annotatedElement="_sYxizB3BEea2UIYIpgn3Zw">
+            <body>This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.&#xD;
+When the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.&#xD;
+When the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.&#xD;
+</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxizh3BEea2UIYIpgn3Zw" name="oduTypeAndRate" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxizx3BEea2UIYIpgn3Zw" annotatedElement="_sYxizh3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi0B3BEea2UIYIpgn3Zw" name="positionSeq" visibility="public" type="_sYyw_h3BEea2UIYIpgn3Zw" isOrdered="true" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi0R3BEea2UIYIpgn3Zw" annotatedElement="_sYxi0B3BEea2UIYIpgn3Zw">
+            <body>This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.&#xD;
+The order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.&#xD;
+Within the ODUk_CTP, the position order is going from adaptation to connection function. Within the ODUk_TTP, the order is going from connection to adaptation function.&#xD;
+The syntax of the PositionSeq attribute will be a SEQUENCE OF pointers, which point to the contained TCM and GCC function.&#xD;
+The order of TCM and GCC access function in the positionSeq attribute is significant only when there are more than one TCM functions within the ODUk TP and also at least one of them have the TimActDisabled attribute set to FALSE (i.e. AIS is inserted upon TIM).&#xD;
+If a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.&#xD;
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sYxi0h3BEea2UIYIpgn3Zw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sYxi0x3BEea2UIYIpgn3Zw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi2B3BEea2UIYIpgn3Zw" name="tributarySlotList" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi2R3BEea2UIYIpgn3Zw" annotatedElement="_sYxi2B3BEea2UIYIpgn3Zw">
+            <body>This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sYxi2h3BEea2UIYIpgn3Zw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sYxi2x3BEea2UIYIpgn3Zw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi3B3BEea2UIYIpgn3Zw" name="applicableProblems" visibility="public" type="_sYyxER3BEea2UIYIpgn3Zw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi3R3BEea2UIYIpgn3Zw" annotatedElement="_sYxi3B3BEea2UIYIpgn3Zw">
+            <body>This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi3h3BEea2UIYIpgn3Zw" name="expectedMSI" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi3x3BEea2UIYIpgn3Zw" annotatedElement="_sYxi3h3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi4B3BEea2UIYIpgn3Zw" name="acceptedMSI" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi4R3BEea2UIYIpgn3Zw" annotatedElement="_sYxi4B3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi4h3BEea2UIYIpgn3Zw" name="acceptedPayloadType" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi4x3BEea2UIYIpgn3Zw" annotatedElement="_sYxi4h3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi5B3BEea2UIYIpgn3Zw" name="transmittedMSI" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi5R3BEea2UIYIpgn3Zw" annotatedElement="_sYxi5B3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi5h3BEea2UIYIpgn3Zw" name="autoPayloadType" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi5x3BEea2UIYIpgn3Zw" annotatedElement="_sYxi5h3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi6B3BEea2UIYIpgn3Zw" name="insertedPayloadType" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi6R3BEea2UIYIpgn3Zw" annotatedElement="_sYxi6B3BEea2UIYIpgn3Zw">
+            <body>This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. </body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi7R3BEea2UIYIpgn3Zw" name="currentNumberOfTributarySlots" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi7h3BEea2UIYIpgn3Zw" annotatedElement="_sYxi7R3BEea2UIYIpgn3Zw">
+            <body>This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. &#xD;
+&#xD;
+The upper bound of this attribute is dependent on the HO-ODUk server layer. &#xD;
+When the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):&#xD;
+- After the Bandwidth Resize (BWR) phase completes (In the case of bandwidth increase)&#xD;
+- After the Link Connection Resize (LCR) phase of the ODUflex resize operation (in the case of bandwidth decrease)&#xD;
+This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).&#xD;
+&#xD;
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sYxi7x3BEea2UIYIpgn3Zw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sYxi8B3BEea2UIYIpgn3Zw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxi8x3BEea2UIYIpgn3Zw" name="nominalBitRateAndTolerance" visibility="public" type="_sYyxMB3BEea2UIYIpgn3Zw" isUnique="false">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxi9B3BEea2UIYIpgn3Zw" annotatedElement="_sYxi8x3BEea2UIYIpgn3Zw">
+            <body>This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_sYxi9R3BEea2UIYIpgn3Zw" name="TerminationPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjAR3BEea2UIYIpgn3Zw" name="rate" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjAh3BEea2UIYIpgn3Zw" annotatedElement="_sYxjAR3BEea2UIYIpgn3Zw">
+            <body>This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).&#xD;
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml#float"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjAx3BEea2UIYIpgn3Zw" name="dmSource" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjBB3BEea2UIYIpgn3Zw" annotatedElement="_sYxjAx3BEea2UIYIpgn3Zw">
+            <body>This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjBR3BEea2UIYIpgn3Zw" name="dmValue">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjBh3BEea2UIYIpgn3Zw" annotatedElement="_sYxjBR3BEea2UIYIpgn3Zw">
+            <body>This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjCx3BEea2UIYIpgn3Zw" name="acti" visibility="public" type="_sYyw4R3BEea2UIYIpgn3Zw" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjDB3BEea2UIYIpgn3Zw" annotatedElement="_sYxjCx3BEea2UIYIpgn3Zw">
+            <body>The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjDR3BEea2UIYIpgn3Zw" name="degM" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjDh3BEea2UIYIpgn3Zw" annotatedElement="_sYxjDR3BEea2UIYIpgn3Zw">
+            <body>This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjDx3BEea2UIYIpgn3Zw" name="degThr" visibility="public" type="_sYyw4x3BEea2UIYIpgn3Zw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjEB3BEea2UIYIpgn3Zw" annotatedElement="_sYxjDx3BEea2UIYIpgn3Zw">
+            <body>This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjER3BEea2UIYIpgn3Zw" name="exDapi" visibility="public" type="_sYyw4R3BEea2UIYIpgn3Zw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjEh3BEea2UIYIpgn3Zw" annotatedElement="_sYxjER3BEea2UIYIpgn3Zw">
+            <body>The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjEx3BEea2UIYIpgn3Zw" name="exSapi" visibility="public" type="_sYyw4R3BEea2UIYIpgn3Zw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjFB3BEea2UIYIpgn3Zw" annotatedElement="_sYxjEx3BEea2UIYIpgn3Zw">
+            <body>The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjFR3BEea2UIYIpgn3Zw" name="timActDisabled" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjFh3BEea2UIYIpgn3Zw" annotatedElement="_sYxjFR3BEea2UIYIpgn3Zw">
+            <body>This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjFx3BEea2UIYIpgn3Zw" name="timDetMode" visibility="public" type="_sYyxAB3BEea2UIYIpgn3Zw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjGB3BEea2UIYIpgn3Zw" annotatedElement="_sYxjFx3BEea2UIYIpgn3Zw">
+            <body>This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI</body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjGR3BEea2UIYIpgn3Zw" name="txti" visibility="public" type="_sYyw4R3BEea2UIYIpgn3Zw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYxjGh3BEea2UIYIpgn3Zw" annotatedElement="_sYxjGR3BEea2UIYIpgn3Zw">
+            <body>The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.</body>
+          </ownedComment>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_sYxjIR3BEea2UIYIpgn3Zw" name="ConnectionEndPointLpSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_01JBUB6hEeaVEcfXx-aEqQ">
+          <general xmi:type="uml:Class" href="TapiSpec.uml#_OSPsAPVcEeWQB8HQFBfkJQ"/>
+        </generalization>
+        <generalization xmi:type="uml:Generalization" xmi:id="_WX4NIDNnEea2QIuFbbE3OA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__8RGQDNnEea2QIuFbbE3OA" name="extensionsSpecification">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="__8RGQTNnEea2QIuFbbE3OA" value="/TapiOdu:ConnectionEndPointLpSpec"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_VZkuoS6BEea0_JngOlSKcA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_JjnkgDQ4EeanX4TaGUWPQA" name="extensionsSpecTarget">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_JjnkgTQ4EeanX4TaGUWPQA" value="/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_EGSwgDOFEeansfg7-s4Unw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjIx3BEea2UIYIpgn3Zw" name="_terminationSpec" type="_sYxi9R3BEea2UIYIpgn3Zw" aggregation="composite" association="_sYw7tR3BEea2UIYIpgn3Zw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NpgFEEWtEeaB8vMnkFQLXQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NpgFEkWtEeaB8vMnkFQLXQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYxjIh3BEea2UIYIpgn3Zw" name="_adapterSpec" type="_sYxiwR3BEea2UIYIpgn3Zw" aggregation="composite" association="_sYw7sR3BEea2UIYIpgn3Zw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_-akw4B6pEeaVEcfXx-aEqQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_-aq3gB6pEeaVEcfXx-aEqQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_CJrDMDIOEeaBg9FoTfINnA" name="PoolPropertyPac">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_dq0IoEKkEea-2Meh9kw1kA" name="clientCapacity">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iK8r8EKkEea-2Meh9kw1kA" name="maxClientInstances" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_knm7oEKkEea-2Meh9kw1kA" name="maxClientSize" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_Um-Q8EKhEea-2Meh9kw1kA" name="NodeEdgePointLpSpec">
+        <generalization xmi:type="uml:Generalization" xmi:id="_c1dVUEKhEea-2Meh9kw1kA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_VZkuoC6BEea0_JngOlSKcA"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__VK1UEKiEea-2Meh9kw1kA" name="extensionsSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="__VK1UUKiEea-2Meh9kw1kA" value="/TapiOdu:NodeEdgePointLpSpec"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_VZkuoS6BEea0_JngOlSKcA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_NkIOYEKjEea-2Meh9kw1kA" name="extensionsSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_NkIOYUKjEea-2Meh9kw1kA" value="/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_EGSwgDOFEeansfg7-s4Unw"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cOYiRDIOEeaBg9FoTfINnA" name="_oduPoolPropertySpec" type="_CJrDMDIOEeaBg9FoTfINnA" aggregation="composite" association="_cOYiQDIOEeaBg9FoTfINnA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ez0TcDIOEeaBg9FoTfINnA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ez-EcTIOEeaBg9FoTfINnA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_sYyw4B3BEea2UIYIpgn3Zw" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:PrimitiveType" xmi:id="_sYyw4R3BEea2UIYIpgn3Zw" name="BitString">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw4h3BEea2UIYIpgn3Zw" annotatedElement="_sYyw4R3BEea2UIYIpgn3Zw">
+          <body>This primitive type defines a bit oriented string.&#xD;
+The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).&#xD;
+The semantic of each bit position will be defined in the Documentation field of the attribute.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_sYyw4x3BEea2UIYIpgn3Zw" name="DegThr">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw5B3BEea2UIYIpgn3Zw" annotatedElement="_sYyw4x3BEea2UIYIpgn3Zw">
+          <body>Degraded Threshold, specify either the percentage or the number of Errored Blocks in the defined interval. &#xD;
+&#xD;
+degThrValue when type is PERCENTAGE:&#xD;
+percentageGranularity is used to indicate the number of decimal points&#xD;
+So if percentageGranularity is 0 a value of 1 in degThrValue would indicate 1%, a value of 10 = 10%, a value of 100 = 100%&#xD;
+So if percentageGranularity is 3 (thousandths) a value of 1 in degThrValue would indicate 0.001%, a value of 1000 = 1%, a value of 1000000 = 100%&#xD;
+&#xD;
+degThrValue when type is NUMBER_ERROR_BLOCKS:&#xD;
+Number of Errored Blocks is captured in an integer value.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYyw5R3BEea2UIYIpgn3Zw" name="degThrValue" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw5h3BEea2UIYIpgn3Zw" annotatedElement="_sYyw5R3BEea2UIYIpgn3Zw">
+            <body>Percentage of detected errored blocks</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYyw5x3BEea2UIYIpgn3Zw" name="degThrType" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw6B3BEea2UIYIpgn3Zw" annotatedElement="_sYyw5x3BEea2UIYIpgn3Zw">
+            <body>Number of errored blocks</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYyw6R3BEea2UIYIpgn3Zw" name="percentageGranularity" visibility="public">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyw6h3BEea2UIYIpgn3Zw" name="ODUk_TtpKBitRate">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw6x3BEea2UIYIpgn3Zw" annotatedElement="_sYyw6h3BEea2UIYIpgn3Zw">
+          <body>Provides an enumeration with the meaning of each k value.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw7B3BEea2UIYIpgn3Zw" name="1.25_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw7R3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw7h3BEea2UIYIpgn3Zw" name="2.5_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw7x3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw8B3BEea2UIYIpgn3Zw" name="10_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw8R3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw8h3BEea2UIYIpgn3Zw" name="10_G_2E">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw8x3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw9B3BEea2UIYIpgn3Zw" name="40_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw9R3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw9h3BEea2UIYIpgn3Zw" name="100_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw9x3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw-B3BEea2UIYIpgn3Zw" name="FLEX_CBR">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw-R3BEea2UIYIpgn3Zw" annotatedElement="_sYyw-B3BEea2UIYIpgn3Zw">
+            <body>Represents ODUflex connection which carry a CBR client</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw-h3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyw-x3BEea2UIYIpgn3Zw" name="FLEX_GFP">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw_B3BEea2UIYIpgn3Zw" annotatedElement="_sYyw-x3BEea2UIYIpgn3Zw">
+            <body>Represents ODUflex connection which carry packet traffic</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyw_R3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_sYyw_h3BEea2UIYIpgn3Zw" name="ODUk_TcmOrGccChoice">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyw_x3BEea2UIYIpgn3Zw" annotatedElement="_sYyw_h3BEea2UIYIpgn3Zw">
+          <body>A data type to constrain the values to particular types of ODUk CTPs.</body>
+        </ownedComment>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxAB3BEea2UIYIpgn3Zw" name="TimDetMo">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxAR3BEea2UIYIpgn3Zw" annotatedElement="_sYyxAB3BEea2UIYIpgn3Zw">
+          <body>List of modes for trace identifier mismatch detection.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxAh3BEea2UIYIpgn3Zw" name="DAPI"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxAx3BEea2UIYIpgn3Zw" name="SAPI"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxBB3BEea2UIYIpgn3Zw" name="BOTH"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxBR3BEea2UIYIpgn3Zw" name="ODUk-h_ResizingProtocolStatus">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxBh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxBR3BEea2UIYIpgn3Zw">
+          <body>The valid status' of the resizing protocol.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxBx3BEea2UIYIpgn3Zw" name="LCR_INITIATED">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxCB3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxCR3BEea2UIYIpgn3Zw" name="LCR_FAILED">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxCh3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxCx3BEea2UIYIpgn3Zw" name="LCR_COMPLETED">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxDB3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxDR3BEea2UIYIpgn3Zw" name="BWR_INITIATED">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxDh3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxDx3BEea2UIYIpgn3Zw" name="BWR_COMPLETED">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxEB3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxER3BEea2UIYIpgn3Zw" name="ODUk_CtpProblemList">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxEh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxER3BEea2UIYIpgn3Zw">
+          <body>The valid list of problems for the entity.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxEx3BEea2UIYIpgn3Zw" name="PLM">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxFB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxEx3BEea2UIYIpgn3Zw">
+            <body>Payload Mismatch</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxFR3BEea2UIYIpgn3Zw" name="MSIM">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxFh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxFR3BEea2UIYIpgn3Zw">
+            <body>MultiplexStructureIdentifier Mismatch, per time slot</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxFx3BEea2UIYIpgn3Zw" name="LOF_LOM">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxGB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxFx3BEea2UIYIpgn3Zw">
+            <body>Loss of Frame, Loss of Multiframe, per time slot</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxGR3BEea2UIYIpgn3Zw" name="LOOMFI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxGh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxGR3BEea2UIYIpgn3Zw">
+            <body>Loss of OPU Multiframe Indicator</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxGx3BEea2UIYIpgn3Zw" name="ODUk_CtpKBitRate">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxHB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxGx3BEea2UIYIpgn3Zw">
+          <body>Provides an enumeration with the meaning of each k value.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxHR3BEea2UIYIpgn3Zw" name="1.25_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxHh3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxHx3BEea2UIYIpgn3Zw" name="2.5_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxIB3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxIR3BEea2UIYIpgn3Zw" name="10_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxIh3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxIx3BEea2UIYIpgn3Zw" name="10_G_2E">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxJB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxIx3BEea2UIYIpgn3Zw">
+            <body>2e represents an approximate bit rate of 10 Gbit/s as a logical wrapper 10GBASE-R</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxJR3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxJh3BEea2UIYIpgn3Zw" name="40_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxJx3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxKB3BEea2UIYIpgn3Zw" name="100_G">
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxKR3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxKh3BEea2UIYIpgn3Zw" name="FLEX_CBR">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxKx3BEea2UIYIpgn3Zw" annotatedElement="_sYyxKh3BEea2UIYIpgn3Zw">
+            <body>Represents ODUflex connection which carry a CBR client</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxLB3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxLR3BEea2UIYIpgn3Zw" name="FLEX_GFP">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxLh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxLR3BEea2UIYIpgn3Zw">
+            <body>Represents ODUflex connection which carry packet traffic</body>
+          </ownedComment>
+          <specification xmi:type="uml:LiteralString" xmi:id="_sYyxLx3BEea2UIYIpgn3Zw"/>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_sYyxMB3BEea2UIYIpgn3Zw" name="ODUk-h_nominalBitRateAndTolerance">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxMR3BEea2UIYIpgn3Zw" annotatedElement="_sYyxMB3BEea2UIYIpgn3Zw">
+          <body>Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYyxMh3BEea2UIYIpgn3Zw" name="tolerance">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxMx3BEea2UIYIpgn3Zw" annotatedElement="_sYyxMh3BEea2UIYIpgn3Zw">
+            <body>tolerance in ppm</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_sYyxNB3BEea2UIYIpgn3Zw" name="frequency" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxNR3BEea2UIYIpgn3Zw" annotatedElement="_sYyxNB3BEea2UIYIpgn3Zw">
+            <body>frequency in kilohertz</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxNh3BEea2UIYIpgn3Zw" name="TcmMode">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxNx3BEea2UIYIpgn3Zw" annotatedElement="_sYyxNh3BEea2UIYIpgn3Zw">
+          <body>List of value modes for the sink side of the tandem connection monitoring function.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxOB3BEea2UIYIpgn3Zw" name="OPERATIONAL"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxOR3BEea2UIYIpgn3Zw" name="TRANSPARENT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxOh3BEea2UIYIpgn3Zw" name="MONITOR"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxOx3BEea2UIYIpgn3Zw" name="ODUkT_tcmExtension">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxPB3BEea2UIYIpgn3Zw" name="NORMAL"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxPR3BEea2UIYIpgn3Zw" name="PASS-THROUGH"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxPh3BEea2UIYIpgn3Zw" name="ERASE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxPx3BEea2UIYIpgn3Zw" name="ODUkT_AdministrationState">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxQB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxPx3BEea2UIYIpgn3Zw">
+          <body>The list of valid adminstration states.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxQR3BEea2UIYIpgn3Zw" name="LOCKED"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxQh3BEea2UIYIpgn3Zw" name="NORMAL"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_sYyxQx3BEea2UIYIpgn3Zw" name="ODUk_TcmStatus">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxRB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxQx3BEea2UIYIpgn3Zw">
+          <body>See Table 15-5/G.709/Y.1331 </body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxRR3BEea2UIYIpgn3Zw" name="NO_SOURCE_TC">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxRh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxRR3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxRx3BEea2UIYIpgn3Zw" name="IN_USE_WITHOUT_IAE">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxSB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxRx3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxSR3BEea2UIYIpgn3Zw" name="IN_USE_WITH_IAE">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxSh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxSR3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxSx3BEea2UIYIpgn3Zw" name="RESERVED_1">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxTB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxSx3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxTR3BEea2UIYIpgn3Zw" name="RESERVED_2">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxTh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxTR3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxTx3BEea2UIYIpgn3Zw" name="LCK">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxUB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxTx3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODUk-LCK</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxUR3BEea2UIYIpgn3Zw" name="OCI">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxUh3BEea2UIYIpgn3Zw" annotatedElement="_sYyxUR3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODUk-OCI</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sYyxUx3BEea2UIYIpgn3Zw" name="AIS">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_sYyxVB3BEea2UIYIpgn3Zw" annotatedElement="_sYyxUx3BEea2UIYIpgn3Zw">
+            <body>TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODUk-AIS</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_ZJaWkB6gEeaVEcfXx-aEqQ" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_dZ3I0DIMEeaBg9FoTfINnA">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_AGyaIEUBEead1bezhJG4aw">
+        <importedPackage xmi:type="uml:Model" href="TapiConnectivity.uml#_6fxZsDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_AGyaIkUBEead1bezhJG4aw">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_2YFFoB6fEeaVEcfXx-aEqQ">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1QY74DQ3EeanX4TaGUWPQA" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1QY74TQ3EeanX4TaGUWPQA" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1QY74jQ3EeanX4TaGUWPQA" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1QY74zQ3EeanX4TaGUWPQA" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1QY75DQ3EeanX4TaGUWPQA" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1QY75TQ3EeanX4TaGUWPQA" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2YFFoR6fEeaVEcfXx-aEqQ" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYQB6fEeaVEcfXx-aEqQ" base_Element="_LTrOcBwyEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYQR6fEeaVEcfXx-aEqQ" base_Element="_sYw7sB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYQh6fEeaVEcfXx-aEqQ" base_Element="_sYw7sR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYQx6fEeaVEcfXx-aEqQ" base_Element="_sYw7tB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYRB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYw7tB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYRR6fEeaVEcfXx-aEqQ" base_Element="_sYw7tR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYRh6fEeaVEcfXx-aEqQ" base_Element="_sYw7uB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYRx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYw7uB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYTR6fEeaVEcfXx-aEqQ" base_Element="_sYw7vx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYUR6fEeaVEcfXx-aEqQ" base_Element="_sYw7wx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYUh6fEeaVEcfXx-aEqQ" base_Element="_sYxiwB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYUx6fEeaVEcfXx-aEqQ" base_Element="_sYxiwR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_2aAYVB6fEeaVEcfXx-aEqQ" base_Class="_sYxiwR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYWR6fEeaVEcfXx-aEqQ" base_Element="_sYxixR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYWh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxixR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYWx6fEeaVEcfXx-aEqQ" base_Element="_sYxixh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYXB6fEeaVEcfXx-aEqQ" base_Element="_sYxixx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYXR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxixx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYXh6fEeaVEcfXx-aEqQ" base_Element="_sYxiyB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYXx6fEeaVEcfXx-aEqQ" base_Element="_sYxiyR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYYB6fEeaVEcfXx-aEqQ" base_Element="_sYxiyh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYYR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxiyh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYYh6fEeaVEcfXx-aEqQ" base_Element="_sYxiyx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYYx6fEeaVEcfXx-aEqQ" base_Element="_sYxizB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYZB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxizB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYZR6fEeaVEcfXx-aEqQ" base_Element="_sYxizR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYZh6fEeaVEcfXx-aEqQ" base_Element="_sYxizh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYZx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxizh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYaB6fEeaVEcfXx-aEqQ" base_Element="_sYxizx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYaR6fEeaVEcfXx-aEqQ" base_Element="_sYxi0B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYah6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi0B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYax6fEeaVEcfXx-aEqQ" base_Element="_sYxi0R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYbB6fEeaVEcfXx-aEqQ" base_Element="_sYxi0h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYbR6fEeaVEcfXx-aEqQ" base_Element="_sYxi0x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYcx6fEeaVEcfXx-aEqQ" base_Element="_sYxi2B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYdB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi2B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYdR6fEeaVEcfXx-aEqQ" base_Element="_sYxi2R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYdh6fEeaVEcfXx-aEqQ" base_Element="_sYxi2h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYdx6fEeaVEcfXx-aEqQ" base_Element="_sYxi2x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYeB6fEeaVEcfXx-aEqQ" base_Element="_sYxi3B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYeR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi3B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYeh6fEeaVEcfXx-aEqQ" base_Element="_sYxi3R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYex6fEeaVEcfXx-aEqQ" base_Element="_sYxi3h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYfB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi3h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYfR6fEeaVEcfXx-aEqQ" base_Element="_sYxi3x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYfh6fEeaVEcfXx-aEqQ" base_Element="_sYxi4B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYfx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi4B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYgB6fEeaVEcfXx-aEqQ" base_Element="_sYxi4R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYgR6fEeaVEcfXx-aEqQ" base_Element="_sYxi4h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYgh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi4h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYgx6fEeaVEcfXx-aEqQ" base_Element="_sYxi4x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYhB6fEeaVEcfXx-aEqQ" base_Element="_sYxi5B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYhR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi5B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYhh6fEeaVEcfXx-aEqQ" base_Element="_sYxi5R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYhx6fEeaVEcfXx-aEqQ" base_Element="_sYxi5h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYiB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi5h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYiR6fEeaVEcfXx-aEqQ" base_Element="_sYxi5x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYih6fEeaVEcfXx-aEqQ" base_Element="_sYxi6B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYix6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi6B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYjB6fEeaVEcfXx-aEqQ" base_Element="_sYxi6R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYkR6fEeaVEcfXx-aEqQ" base_Element="_sYxi7R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aAYkh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi7R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYkx6fEeaVEcfXx-aEqQ" base_Element="_sYxi7h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYlB6fEeaVEcfXx-aEqQ" base_Element="_sYxi7x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aAYlR6fEeaVEcfXx-aEqQ" base_Element="_sYxi8B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJQR6fEeaVEcfXx-aEqQ" base_Element="_sYxi8x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJQh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxi8x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJQx6fEeaVEcfXx-aEqQ" base_Element="_sYxi9B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJRB6fEeaVEcfXx-aEqQ" base_Element="_sYxi9R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_2aKJRR6fEeaVEcfXx-aEqQ" base_Class="_sYxi9R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJVB6fEeaVEcfXx-aEqQ" base_Element="_sYxjAR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJVR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjAR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJVh6fEeaVEcfXx-aEqQ" base_Element="_sYxjAh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJVx6fEeaVEcfXx-aEqQ" base_Element="_sYxjAx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJWB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjAx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJWR6fEeaVEcfXx-aEqQ" base_Element="_sYxjBB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJWh6fEeaVEcfXx-aEqQ" base_Element="_sYxjBR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJWx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjBR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJXB6fEeaVEcfXx-aEqQ" base_Element="_sYxjBh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJYh6fEeaVEcfXx-aEqQ" base_Element="_sYxjCx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJYx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjCx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJZB6fEeaVEcfXx-aEqQ" base_Element="_sYxjDB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJZR6fEeaVEcfXx-aEqQ" base_Element="_sYxjDR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJZh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjDR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJZx6fEeaVEcfXx-aEqQ" base_Element="_sYxjDh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJaB6fEeaVEcfXx-aEqQ" base_Element="_sYxjDx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJaR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjDx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJah6fEeaVEcfXx-aEqQ" base_Element="_sYxjEB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJax6fEeaVEcfXx-aEqQ" base_Element="_sYxjER3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJbB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjER3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJbR6fEeaVEcfXx-aEqQ" base_Element="_sYxjEh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJbh6fEeaVEcfXx-aEqQ" base_Element="_sYxjEx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJbx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjEx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJcB6fEeaVEcfXx-aEqQ" base_Element="_sYxjFB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJcR6fEeaVEcfXx-aEqQ" base_Element="_sYxjFR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJch6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjFR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJcx6fEeaVEcfXx-aEqQ" base_Element="_sYxjFh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJdB6fEeaVEcfXx-aEqQ" base_Element="_sYxjFx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJdR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjFx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJdh6fEeaVEcfXx-aEqQ" base_Element="_sYxjGB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJdx6fEeaVEcfXx-aEqQ" base_Element="_sYxjGR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJeB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjGR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJeR6fEeaVEcfXx-aEqQ" base_Element="_sYxjGh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJgh6fEeaVEcfXx-aEqQ" base_Element="_sYxjIR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_2aKJgx6fEeaVEcfXx-aEqQ" base_Class="_sYxjIR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJhB6fEeaVEcfXx-aEqQ" base_Element="_sYxjIh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJhR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjIh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJhh6fEeaVEcfXx-aEqQ" base_Element="_sYxjIx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJhx6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYxjIx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJwB6fEeaVEcfXx-aEqQ" base_Element="_sYyw4B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJwR6fEeaVEcfXx-aEqQ" base_Element="_sYyw4R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJwh6fEeaVEcfXx-aEqQ" base_Element="_sYyw4h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJwx6fEeaVEcfXx-aEqQ" base_Element="_sYyw4x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJxB6fEeaVEcfXx-aEqQ" base_Element="_sYyw5B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJxR6fEeaVEcfXx-aEqQ" base_Element="_sYyw5R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJxh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYyw5R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJxx6fEeaVEcfXx-aEqQ" base_Element="_sYyw5h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJyB6fEeaVEcfXx-aEqQ" base_Element="_sYyw5x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJyR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYyw5x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJyh6fEeaVEcfXx-aEqQ" base_Element="_sYyw6B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJyx6fEeaVEcfXx-aEqQ" base_Element="_sYyw6R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKJzB6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYyw6R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJzR6fEeaVEcfXx-aEqQ" base_Element="_sYyw6h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJzh6fEeaVEcfXx-aEqQ" base_Element="_sYyw6x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJzx6fEeaVEcfXx-aEqQ" base_Element="_sYyw7B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ0B6fEeaVEcfXx-aEqQ" base_Element="_sYyw7R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ0R6fEeaVEcfXx-aEqQ" base_Element="_sYyw7h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ0h6fEeaVEcfXx-aEqQ" base_Element="_sYyw7x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ0x6fEeaVEcfXx-aEqQ" base_Element="_sYyw8B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ1B6fEeaVEcfXx-aEqQ" base_Element="_sYyw8R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ1R6fEeaVEcfXx-aEqQ" base_Element="_sYyw8h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ1h6fEeaVEcfXx-aEqQ" base_Element="_sYyw8x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ1x6fEeaVEcfXx-aEqQ" base_Element="_sYyw9B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ2B6fEeaVEcfXx-aEqQ" base_Element="_sYyw9R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ2R6fEeaVEcfXx-aEqQ" base_Element="_sYyw9h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ2h6fEeaVEcfXx-aEqQ" base_Element="_sYyw9x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ2x6fEeaVEcfXx-aEqQ" base_Element="_sYyw-B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ3B6fEeaVEcfXx-aEqQ" base_Element="_sYyw-R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ3R6fEeaVEcfXx-aEqQ" base_Element="_sYyw-h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ3h6fEeaVEcfXx-aEqQ" base_Element="_sYyw-x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ3x6fEeaVEcfXx-aEqQ" base_Element="_sYyw_B3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ4B6fEeaVEcfXx-aEqQ" base_Element="_sYyw_R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ4R6fEeaVEcfXx-aEqQ" base_Element="_sYyw_h3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ4h6fEeaVEcfXx-aEqQ" base_Element="_sYyw_x3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ4x6fEeaVEcfXx-aEqQ" base_Element="_sYyxAB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ5B6fEeaVEcfXx-aEqQ" base_Element="_sYyxAR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ5R6fEeaVEcfXx-aEqQ" base_Element="_sYyxAh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ5h6fEeaVEcfXx-aEqQ" base_Element="_sYyxAx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ5x6fEeaVEcfXx-aEqQ" base_Element="_sYyxBB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ6B6fEeaVEcfXx-aEqQ" base_Element="_sYyxBR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ6R6fEeaVEcfXx-aEqQ" base_Element="_sYyxBh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ6h6fEeaVEcfXx-aEqQ" base_Element="_sYyxBx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ6x6fEeaVEcfXx-aEqQ" base_Element="_sYyxCB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ7B6fEeaVEcfXx-aEqQ" base_Element="_sYyxCR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ7R6fEeaVEcfXx-aEqQ" base_Element="_sYyxCh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ7h6fEeaVEcfXx-aEqQ" base_Element="_sYyxCx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ7x6fEeaVEcfXx-aEqQ" base_Element="_sYyxDB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ8B6fEeaVEcfXx-aEqQ" base_Element="_sYyxDR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ8R6fEeaVEcfXx-aEqQ" base_Element="_sYyxDh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ8h6fEeaVEcfXx-aEqQ" base_Element="_sYyxDx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ8x6fEeaVEcfXx-aEqQ" base_Element="_sYyxEB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ9B6fEeaVEcfXx-aEqQ" base_Element="_sYyxER3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ9R6fEeaVEcfXx-aEqQ" base_Element="_sYyxEh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ9h6fEeaVEcfXx-aEqQ" base_Element="_sYyxEx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ9x6fEeaVEcfXx-aEqQ" base_Element="_sYyxFB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ-B6fEeaVEcfXx-aEqQ" base_Element="_sYyxFR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ-R6fEeaVEcfXx-aEqQ" base_Element="_sYyxFh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ-h6fEeaVEcfXx-aEqQ" base_Element="_sYyxFx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ-x6fEeaVEcfXx-aEqQ" base_Element="_sYyxGB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ_B6fEeaVEcfXx-aEqQ" base_Element="_sYyxGR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ_R6fEeaVEcfXx-aEqQ" base_Element="_sYyxGh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ_h6fEeaVEcfXx-aEqQ" base_Element="_sYyxGx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKJ_x6fEeaVEcfXx-aEqQ" base_Element="_sYyxHB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKAB6fEeaVEcfXx-aEqQ" base_Element="_sYyxHR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKAR6fEeaVEcfXx-aEqQ" base_Element="_sYyxHh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKAh6fEeaVEcfXx-aEqQ" base_Element="_sYyxHx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKAx6fEeaVEcfXx-aEqQ" base_Element="_sYyxIB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKBB6fEeaVEcfXx-aEqQ" base_Element="_sYyxIR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKBR6fEeaVEcfXx-aEqQ" base_Element="_sYyxIh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKBh6fEeaVEcfXx-aEqQ" base_Element="_sYyxIx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKBx6fEeaVEcfXx-aEqQ" base_Element="_sYyxJB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKCB6fEeaVEcfXx-aEqQ" base_Element="_sYyxJR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKCR6fEeaVEcfXx-aEqQ" base_Element="_sYyxJh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKCh6fEeaVEcfXx-aEqQ" base_Element="_sYyxJx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKCx6fEeaVEcfXx-aEqQ" base_Element="_sYyxKB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKDB6fEeaVEcfXx-aEqQ" base_Element="_sYyxKR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKDR6fEeaVEcfXx-aEqQ" base_Element="_sYyxKh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKDh6fEeaVEcfXx-aEqQ" base_Element="_sYyxKx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKDx6fEeaVEcfXx-aEqQ" base_Element="_sYyxLB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKEB6fEeaVEcfXx-aEqQ" base_Element="_sYyxLR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKER6fEeaVEcfXx-aEqQ" base_Element="_sYyxLh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKEh6fEeaVEcfXx-aEqQ" base_Element="_sYyxLx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKEx6fEeaVEcfXx-aEqQ" base_Element="_sYyxMB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKFB6fEeaVEcfXx-aEqQ" base_Element="_sYyxMR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKFR6fEeaVEcfXx-aEqQ" base_Element="_sYyxMh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKKFh6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYyxMh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKFx6fEeaVEcfXx-aEqQ" base_Element="_sYyxMx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKGB6fEeaVEcfXx-aEqQ" base_Element="_sYyxNB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_2aKKGR6fEeaVEcfXx-aEqQ" base_StructuralFeature="_sYyxNB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKGh6fEeaVEcfXx-aEqQ" base_Element="_sYyxNR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKGx6fEeaVEcfXx-aEqQ" base_Element="_sYyxNh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKHB6fEeaVEcfXx-aEqQ" base_Element="_sYyxNx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKHR6fEeaVEcfXx-aEqQ" base_Element="_sYyxOB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKHh6fEeaVEcfXx-aEqQ" base_Element="_sYyxOR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKHx6fEeaVEcfXx-aEqQ" base_Element="_sYyxOh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKIB6fEeaVEcfXx-aEqQ" base_Element="_sYyxOx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKIR6fEeaVEcfXx-aEqQ" base_Element="_sYyxPB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKIh6fEeaVEcfXx-aEqQ" base_Element="_sYyxPR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKIx6fEeaVEcfXx-aEqQ" base_Element="_sYyxPh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKJB6fEeaVEcfXx-aEqQ" base_Element="_sYyxPx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKJR6fEeaVEcfXx-aEqQ" base_Element="_sYyxQB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKJh6fEeaVEcfXx-aEqQ" base_Element="_sYyxQR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKJx6fEeaVEcfXx-aEqQ" base_Element="_sYyxQh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKKB6fEeaVEcfXx-aEqQ" base_Element="_sYyxQx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKKR6fEeaVEcfXx-aEqQ" base_Element="_sYyxRB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKKh6fEeaVEcfXx-aEqQ" base_Element="_sYyxRR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKKx6fEeaVEcfXx-aEqQ" base_Element="_sYyxRh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKLB6fEeaVEcfXx-aEqQ" base_Element="_sYyxRx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKLR6fEeaVEcfXx-aEqQ" base_Element="_sYyxSB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKLh6fEeaVEcfXx-aEqQ" base_Element="_sYyxSR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKLx6fEeaVEcfXx-aEqQ" base_Element="_sYyxSh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKMB6fEeaVEcfXx-aEqQ" base_Element="_sYyxSx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKMR6fEeaVEcfXx-aEqQ" base_Element="_sYyxTB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKMh6fEeaVEcfXx-aEqQ" base_Element="_sYyxTR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKMx6fEeaVEcfXx-aEqQ" base_Element="_sYyxTh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKNB6fEeaVEcfXx-aEqQ" base_Element="_sYyxTx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKNR6fEeaVEcfXx-aEqQ" base_Element="_sYyxUB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKNh6fEeaVEcfXx-aEqQ" base_Element="_sYyxUR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKNx6fEeaVEcfXx-aEqQ" base_Element="_sYyxUh3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKOB6fEeaVEcfXx-aEqQ" base_Element="_sYyxUx3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKOR6fEeaVEcfXx-aEqQ" base_Element="_sYyxVB3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_2aKKOh6fEeaVEcfXx-aEqQ" base_Element="_2YFFoB6fEeaVEcfXx-aEqQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ZLDVUB6gEeaVEcfXx-aEqQ" base_Element="_ZJaWkB6gEeaVEcfXx-aEqQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_01JBUR6hEeaVEcfXx-aEqQ" base_Element="_01JBUB6hEeaVEcfXx-aEqQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_-akw4R6pEeaVEcfXx-aEqQ" base_Element="_-akw4B6pEeaVEcfXx-aEqQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_-aq3gR6pEeaVEcfXx-aEqQ" base_Element="_-aq3gB6pEeaVEcfXx-aEqQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_dZ3I0TIMEeaBg9FoTfINnA" base_Element="_dZ3I0DIMEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_CJrDMTIOEeaBg9FoTfINnA" base_Element="_CJrDMDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_CJrDMjIOEeaBg9FoTfINnA" base_Class="_CJrDMDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cOYiQTIOEeaBg9FoTfINnA" base_Element="_cOYiQDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cOYiRTIOEeaBg9FoTfINnA" base_Element="_cOYiRDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cOYiRjIOEeaBg9FoTfINnA" base_StructuralFeature="_cOYiRDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_cOYiSDIOEeaBg9FoTfINnA" base_Element="_cOYiRzIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cOYiSTIOEeaBg9FoTfINnA" base_StructuralFeature="_cOYiRzIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ez-EcDIOEeaBg9FoTfINnA" base_Element="_ez0TcDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ez-EcjIOEeaBg9FoTfINnA" base_Element="_ez-EcTIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WX4NITNnEea2QIuFbbE3OA" base_Element="_WX4NIDNnEea2QIuFbbE3OA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__8RGQjNnEea2QIuFbbE3OA" base_Element="__8RGQDNnEea2QIuFbbE3OA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__8RGQzNnEea2QIuFbbE3OA" base_StructuralFeature="__8RGQDNnEea2QIuFbbE3OA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__8RGRDNnEea2QIuFbbE3OA" base_Element="__8RGQTNnEea2QIuFbbE3OA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_JjnkgjQ4EeanX4TaGUWPQA" base_StructuralFeature="_JjnkgDQ4EeanX4TaGUWPQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_JjnkgzQ4EeanX4TaGUWPQA" base_Element="_JjnkgDQ4EeanX4TaGUWPQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_JjnkhDQ4EeanX4TaGUWPQA" base_Element="_JjnkgTQ4EeanX4TaGUWPQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_c1dVUUKhEea-2Meh9kw1kA" base_Element="_c1dVUEKhEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_pkaewEKiEea-2Meh9kw1kA" base_StructuralFeature="_JjnkgDQ4EeanX4TaGUWPQA"/>
+  <OpenModel_Profile:SpecReference xmi:id="_qtNS0EKiEea-2Meh9kw1kA" base_StructuralFeature="__8RGQDNnEea2QIuFbbE3OA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__VK1UkKiEea-2Meh9kw1kA" base_Element="__VK1UEKiEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__VUmUEKiEea-2Meh9kw1kA" base_StructuralFeature="__VK1UEKiEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="__VUmUUKiEea-2Meh9kw1kA" base_Element="__VK1UUKiEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NkIOYkKjEea-2Meh9kw1kA" base_Element="_NkIOYEKjEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_NkIOY0KjEea-2Meh9kw1kA" base_StructuralFeature="_NkIOYEKjEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NkIOZEKjEea-2Meh9kw1kA" base_Element="_NkIOYUKjEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_dq0IoUKkEea-2Meh9kw1kA" base_Element="_dq0IoEKkEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_dq0IokKkEea-2Meh9kw1kA" base_StructuralFeature="_dq0IoEKkEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_iK8r8UKkEea-2Meh9kw1kA" base_Element="_iK8r8EKkEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iK8r8kKkEea-2Meh9kw1kA" base_StructuralFeature="_iK8r8EKkEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_knm7oUKkEea-2Meh9kw1kA" base_Element="_knm7oEKkEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_knwsoEKkEea-2Meh9kw1kA" base_StructuralFeature="_knm7oEKkEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:SpecReference xmi:id="_cl8JAENZEeajnf5I7cki4A" base_StructuralFeature="__VK1UEKiEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_dvAp4ENZEeajnf5I7cki4A" base_StructuralFeature="_NkIOYEKjEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_y75GIEUAEead1bezhJG4aw" base_Association="_sYw7sR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_zyMcAEUAEead1bezhJG4aw" base_Association="_sYw7tR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_1XOgIEUAEead1bezhJG4aw" base_Association="_cOYiQDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_AGyaIUUBEead1bezhJG4aw" base_Element="_AGyaIEUBEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_AGyaI0UBEead1bezhJG4aw" base_Element="_AGyaIkUBEead1bezhJG4aw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_4mU1MEUHEead1bezhJG4aw" base_Element="_sYxi9R3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_5upIIEUHEead1bezhJG4aw" base_Element="_CJrDMDIOEeaBg9FoTfINnA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_7DBhIEUHEead1bezhJG4aw" base_Element="_sYxiwR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:Preliminary xmi:id="_9vOosEUHEead1bezhJG4aw" base_Element="_sYxjIR3BEea2UIYIpgn3Zw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_UoKjwUKhEea-2Meh9kw1kA" base_Element="_Um-Q8EKhEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_UoKjwEKhEea-2Meh9kw1kA" base_Class="_Um-Q8EKhEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:Preliminary xmi:id="_8c4QAEUHEead1bezhJG4aw" base_Element="_Um-Q8EKhEea-2Meh9kw1kA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NpgFEUWtEeaB8vMnkFQLXQ" base_Element="_NpgFEEWtEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NpgFE0WtEeaB8vMnkFQLXQ" base_Element="_NpgFEkWtEeaB8vMnkFQLXQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiPathComputation.uml
+++ b/xmi2yang tool-v2.0/project/TapiPathComputation.uml
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_Fk3e0DA5Eea4fKwSGMr6CA" name="TapiPathComputation">
+    <packagedElement xmi:type="uml:Package" xmi:id="_tqjuoC5zEea0_JngOlSKcA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_f8XbAC2cEeair-8ZDvf8jw" name="PathCompSvcHasServicePorts" memberEnd="_f8XbBC2cEeair-8ZDvf8jw _f8XbBy2cEeair-8ZDvf8jw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_f8XbAi2cEeair-8ZDvf8jw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_f8XbAy2cEeair-8ZDvf8jw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_f8XbBy2cEeair-8ZDvf8jw" name="_service" type="_IUF7cC2XEeair-8ZDvf8jw" association="_f8XbAC2cEeair-8ZDvf8jw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_iuK74O_xEeWLlrwIF3w0vA" name="PathHasRoutingConstraints" memberEnd="_iuK74-_xEeWLlrwIF3w0vA _iuK75e_xEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iuK74e_xEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iuK74u_xEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_iuK75e_xEeWLlrwIF3w0vA" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" association="_iuK74O_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_jUIIoO_xEeWLlrwIF3w0vA" name="PathSvcHasObjectiveFunction" memberEnd="_jUIIo-_xEeWLlrwIF3w0vA _jUIIpe_xEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jUIIoe_xEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jUIIou_xEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_jUIIpe_xEeWLlrwIF3w0vA" name="_path" type="_IUF7cC2XEeair-8ZDvf8jw" association="_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_jyVHkO_xEeWLlrwIF3w0vA" name="PathSvcHasOptimizationConstraints" memberEnd="_jyVHk-_xEeWLlrwIF3w0vA _jyVHle_xEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jyVHke_xEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jyVHku_xEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_jyVHle_xEeWLlrwIF3w0vA" name="_path" type="_IUF7cC2XEeair-8ZDvf8jw" association="_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_7s7p0C2aEeair-8ZDvf8jw" name="PathSvcHasRoutingConstraints" memberEnd="_7tFa0i2aEeair-8ZDvf8jw _7tFa1S2aEeair-8ZDvf8jw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7tFa0C2aEeair-8ZDvf8jw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7tFa0S2aEeair-8ZDvf8jw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_7tFa1S2aEeair-8ZDvf8jw" name="_pathService" type="_IUF7cC2XEeair-8ZDvf8jw" association="_7s7p0C2aEeair-8ZDvf8jw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_1EaBMC2bEeair-8ZDvf8jw" name="PathCompSvcHasComputedPath" memberEnd="_1EaBNC2bEeair-8ZDvf8jw _1EjyMC2bEeair-8ZDvf8jw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1EaBMi2bEeair-8ZDvf8jw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1EaBMy2bEeair-8ZDvf8jw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_1EjyMC2bEeair-8ZDvf8jw" name="_pathService" type="_IUF7cC2XEeair-8ZDvf8jw" association="_1EaBMC2bEeair-8ZDvf8jw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_eMpiAN6ZEeWd9KDn6x5Skg" name="PathHasTeLinks" memberEnd="_eMyr8t6ZEeWd9KDn6x5Skg _eMyr9N6ZEeWd9KDn6x5Skg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_eMyr8N6ZEeWd9KDn6x5Skg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_eMyr8d6ZEeWd9KDn6x5Skg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_eMyr9N6ZEeWd9KDn6x5Skg" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" association="_eMpiAN6ZEeWd9KDn6x5Skg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_YEuIUC2nEeair-8ZDvf8jw" name="PathSvcPortTerminatesOnServiceEP" memberEnd="_YEuIVC2nEeair-8ZDvf8jw _YEuIVy2nEeair-8ZDvf8jw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_YEuIUi2nEeair-8ZDvf8jw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_YEuIUy2nEeair-8ZDvf8jw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_YEuIVy2nEeair-8ZDvf8jw" name="_pathServicePort" type="_yYDusC2mEeair-8ZDvf8jw" association="_YEuIUC2nEeair-8ZDvf8jw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uxrocC2nEeair-8ZDvf8jw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uxroci2nEeair-8ZDvf8jw" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_111xADM0EeaULOmJRJKM0Q" name="RouteConstrHasExcludePath" memberEnd="_111xBDM0EeaULOmJRJKM0Q _11_iATM0EeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_111xAjM0EeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_111xAzM0EeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_11_iATM0EeaULOmJRJKM0Q" name="routingconstraint" type="_qXAPsDJDEeamvfKYyWmELQ" association="_111xADM0EeaULOmJRJKM0Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_zJVugDM0EeaULOmJRJKM0Q" name="RouteConstrHasIncludePath" memberEnd="_zJVuhDM0EeaULOmJRJKM0Q _zJVuhzM0EeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_zJVugjM0EeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_zJVugzM0EeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_zJVuhzM0EeaULOmJRJKM0Q" name="routingconstraint" type="_qXAPsDJDEeamvfKYyWmELQ" association="_zJVugDM0EeaULOmJRJKM0Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_ObYjYDM1EeaULOmJRJKM0Q" name="RouteConstrHasAvoidTopology" memberEnd="_ObiUYjM1EeaULOmJRJKM0Q _ObiUZTM1EeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ObiUYDM1EeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ObiUYTM1EeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ObiUZTM1EeaULOmJRJKM0Q" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" association="_ObYjYDM1EeaULOmJRJKM0Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_MnHJYDM1EeaULOmJRJKM0Q" name="RouteConstrHasIncludeTopology" memberEnd="_MnHJZDM1EeaULOmJRJKM0Q _MnHJZzM1EeaULOmJRJKM0Q">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MnHJYjM1EeaULOmJRJKM0Q" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MnHJYzM1EeaULOmJRJKM0Q" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MnHJZzM1EeaULOmJRJKM0Q" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" association="_MnHJYDM1EeaULOmJRJKM0Q"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_rZmYoC5zEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_pNcqIC5zEea0_JngOlSKcA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_c2J9kDBFEeam35bpdXJzEw">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_MnGvIDKBEeapu9k56t8ZKQ">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_qaqEIC5zEea0_JngOlSKcA" name="Interfaces">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_5ASPgN6MEeWd9KDn6x5Skg" name="PathComputationService" isLeaf="true">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_5ASPmt6MEeWd9KDn6x5Skg" name="computeP2PPath" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_LxwagC2qEeair-8ZDvf8jw" name="servicePort" type="_yYDusC2mEeair-8ZDvf8jw" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_NKeg8C2qEeair-8ZDvf8jw" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_NKeg8i2qEeair-8ZDvf8jw" value="2"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPn96MEeWd9KDn6x5Skg" name="routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_8XQOgN6QEeWd9KDn6x5Skg" name="objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_zhR6MC2eEeair-8ZDvf8jw" name="pathCompService" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_5ASPqN6MEeWd9KDn6x5Skg" name="optimizeP2PPath" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPqt6MEeWd9KDn6x5Skg" name="pathIdOrName" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_pPFOUN6REeWd9KDn6x5Skg" name="routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_tj9j4N6REeWd9KDn6x5Skg" name="optimizationConstraint" type="_PK97QO-fEeWLlrwIF3w0vA" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_wQie4N6REeWd9KDn6x5Skg" name="objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_tH7ygC2eEeair-8ZDvf8jw" name="pathCompService" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out" effect="update"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_Z9I7IC2qEeair-8ZDvf8jw" name="deleteP2PPath" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Z9I7IS2qEeair-8ZDvf8jw" name="pathIdOrName" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_Z9I7JS2qEeair-8ZDvf8jw" name="pathCompService" type="_IUF7cC2XEeair-8ZDvf8jw" direction="out" effect="delete"/>
+        </ownedOperation>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_so3BEC5zEea0_JngOlSKcA" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_aMQ88N5xEeWd9KDn6x5Skg" name="Path" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_aMQ88d5xEeWd9KDn6x5Skg" annotatedElement="_aMQ88N5xEeWd9KDn6x5Skg">
+          <body>Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_WKDJcO_wEeWLlrwIF3w0vA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_h65Q0ETgEead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_h65Q0UTgEead1bezhJG4aw" value="/TapiPathComputation:Path"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_prXjgETgEead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_prXjgUTgEead1bezhJG4aw" value="/Tapi:Context/Tapi:_path"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_eMyr8t6ZEeWd9KDn6x5Skg" name="_telink" isReadOnly="true" aggregation="composite" association="_eMpiAN6ZEeWd9KDn6x5Skg">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rNMnMN6ZEeWd9KDn6x5Skg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNMnMd6ZEeWd9KDn6x5Skg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iuK74-_xEeWLlrwIF3w0vA" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" isReadOnly="true" aggregation="composite" association="_iuK74O_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_yYDusC2mEeair-8ZDvf8jw" name="PathCompServicePort" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_yYDusS2mEeair-8ZDvf8jw" annotatedElement="_yYDusC2mEeair-8ZDvf8jw">
+          <body>The association of the FC to LTPs is made via EndPoints.&#xD;
+The EndPoint (EP) object class models the access to the FC function. &#xD;
+The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  &#xD;
+In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. &#xD;
+It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.&#xD;
+The EP replaces the Protection Unit of a traditional protection model. &#xD;
+The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_yYDusi2mEeair-8ZDvf8jw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YEuIVC2nEeair-8ZDvf8jw" name="_serviceEndPoint" isReadOnly="true" association="_YEuIUC2nEeair-8ZDvf8jw">
+          <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yYDutC2mEeair-8ZDvf8jw" name="role" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yYDutS2mEeair-8ZDvf8jw" annotatedElement="_yYDutC2mEeair-8ZDvf8jw">
+            <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYDuti2mEeair-8ZDvf8jw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYDuty2mEeair-8ZDvf8jw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yYDuuC2mEeair-8ZDvf8jw" name="direction" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yYDuuS2mEeair-8ZDvf8jw" annotatedElement="_yYDuuC2mEeair-8ZDvf8jw">
+            <body>The orientation of defined flow at the EndPoint.</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYDuui2mEeair-8ZDvf8jw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYDuuy2mEeair-8ZDvf8jw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yYDuvC2mEeair-8ZDvf8jw" name="serviceLayer" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yYDuvS2mEeair-8ZDvf8jw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yYDuvi2mEeair-8ZDvf8jw" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_IUF7cC2XEeair-8ZDvf8jw" name="PathComputationService">
+        <generalization xmi:type="uml:Generalization" xmi:id="_IUF7cS2XEeair-8ZDvf8jw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_D3E34ETgEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_D3E34UTgEead1bezhJG4aw" value="/TapiPathComputation:PathComputationService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_36HEED3jEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LHJMMETgEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_LHJMMUTgEead1bezhJG4aw" value="/Tapi:Context/Tapi:_pathCompService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_4oopgEJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1EaBNC2bEeair-8ZDvf8jw" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" isReadOnly="true" aggregation="composite" association="_1EaBMC2bEeair-8ZDvf8jw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_51qJsC2bEeair-8ZDvf8jw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_51qJsi2bEeair-8ZDvf8jw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_f8XbBC2cEeair-8ZDvf8jw" name="_servicePort" type="_yYDusC2mEeair-8ZDvf8jw" aggregation="composite" association="_f8XbAC2cEeair-8ZDvf8jw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_nArLQC2cEeair-8ZDvf8jw" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_nArLQi2cEeair-8ZDvf8jw" value="2"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7tFa0i2aEeair-8ZDvf8jw" name="_routingConstraint" type="_qXAPsDJDEeamvfKYyWmELQ" aggregation="composite" association="_7s7p0C2aEeair-8ZDvf8jw"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jUIIo-_xEeWLlrwIF3w0vA" name="_objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" aggregation="composite" association="_jUIIoO_xEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jyVHk-_xEeWLlrwIF3w0vA" name="_optimizationConstraint" type="_PK97QO-fEeWLlrwIF3w0vA" aggregation="composite" association="_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_kJjOAO-fEeWLlrwIF3w0vA" name="PathObjectiveFunction">
+        <generalization xmi:type="uml:Generalization" xmi:id="_iZt2YD4zEea-1_BGg-qcjQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PSJDoN5vEeWd9KDn6x5Skg" name="bandwidthOptimization" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9OvWUN5zEeWd9KDn6x5Skg" name="concurrentPaths" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_OHiZEN5sEeWd9KDn6x5Skg" name="costOptimization" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YQ35MN5vEeWd9KDn6x5Skg" name="linkUtilization" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BS_lAN5rEeWd9KDn6x5Skg" name="resourceSharing" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_PK97QO-fEeWLlrwIF3w0vA" name="PathOptimizationConstraint" isLeaf="true">
+        <generalization xmi:type="uml:Generalization" xmi:id="_hUGSID4zEea-1_BGg-qcjQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_H7MS8N5pEeWd9KDn6x5Skg" name="trafficInterruption" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_pGsZEN5qEeWd9KDn6x5Skg"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_qXAPsDJDEeamvfKYyWmELQ" name="RoutingConstraint">
+        <generalization xmi:type="uml:Generalization" xmi:id="_gvfwQD4zEea-1_BGg-qcjQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPuTJDEeamvfKYyWmELQ" name="requestedCapacity" isReadOnly="true">
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPsjJDEeamvfKYyWmELQ" name="serviceLevel" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qXAPszJDEeamvfKYyWmELQ">
+            <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPtDJDEeamvfKYyWmELQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPtTJDEeamvfKYyWmELQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPtjJDEeamvfKYyWmELQ" name="pathLayer" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPtzJDEeamvfKYyWmELQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPuDJDEeamvfKYyWmELQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPujJDEeamvfKYyWmELQ" name="costCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qXAPuzJDEeamvfKYyWmELQ" annotatedElement="_qXAPujJDEeamvfKYyWmELQ">
+            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPvDJDEeamvfKYyWmELQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPvTJDEeamvfKYyWmELQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qXAPwjJDEeamvfKYyWmELQ" name="latencyCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_qXAPwzJDEeamvfKYyWmELQ" annotatedElement="_qXAPwjJDEeamvfKYyWmELQ">
+            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_qXAPxDJDEeamvfKYyWmELQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_qXAPxTJDEeamvfKYyWmELQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MnHJZDM1EeaULOmJRJKM0Q" name="_includeTopology" isReadOnly="true" association="_MnHJYDM1EeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_leUTgDM1EeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_leUTgjM1EeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ObiUYjM1EeaULOmJRJKM0Q" name="_avoidTopology" isReadOnly="true" association="_ObYjYDM1EeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s0hsEDM1EeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s0hsEjM1EeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zJVuhDM0EeaULOmJRJKM0Q" name="_includePath" isReadOnly="true" aggregation="composite" association="_zJVugDM0EeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_a2GXoDM1EeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_a2PhkDM1EeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_111xBDM0EeaULOmJRJKM0Q" name="_excludePath" isReadOnly="true" aggregation="composite" association="_111xADM0EeaULOmJRJKM0Q">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ftiAoDM1EeaULOmJRJKM0Q"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ftiAojM1EeaULOmJRJKM0Q" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_F8O2dDA5Eea4fKwSGMr6CA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_SlS7QDOGEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SlS7QTOGEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SlS7QjOGEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SlS7QzOGEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SlS7RDOGEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_SlS7RTOGEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_F8O2dTA5Eea4fKwSGMr6CA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F9kSsDA5Eea4fKwSGMr6CA" base_Element="_Fk3e0DA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_F9kSsTA5Eea4fKwSGMr6CA" base_Element="_F8O2dDA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_H7MS8d5pEeWd9KDn6x5Skg" base_StructuralFeature="_H7MS8N5pEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BS_lAd5rEeWd9KDn6x5Skg" base_StructuralFeature="_BS_lAN5rEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_OHiZEd5sEeWd9KDn6x5Skg" base_StructuralFeature="_OHiZEN5sEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PSJDod5vEeWd9KDn6x5Skg" base_StructuralFeature="_PSJDoN5vEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YQ35Md5vEeWd9KDn6x5Skg" base_StructuralFeature="_YQ35MN5vEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9OvWUd5zEeWd9KDn6x5Skg" base_StructuralFeature="_9OvWUN5zEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelInterface xmi:id="_5ASPrN6MEeWd9KDn6x5Skg" base_Interface="_5ASPgN6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_5AcAid6MEeWd9KDn6x5Skg" base_Parameter="_5ASPn96MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_5AcAlN6MEeWd9KDn6x5Skg" base_Parameter="_5ASPqt6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_8XQOgd6QEeWd9KDn6x5Skg" base_Parameter="_8XQOgN6QEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_pPFOUd6REeWd9KDn6x5Skg" base_Parameter="_pPFOUN6REeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_tj9j4d6REeWd9KDn6x5Skg" base_Parameter="_tj9j4N6REeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_wQie4d6REeWd9KDn6x5Skg" base_Parameter="_wQie4N6REeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eMyr896ZEeWd9KDn6x5Skg" base_StructuralFeature="_eMyr8t6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_eMyr9d6ZEeWd9KDn6x5Skg" base_StructuralFeature="_eMyr9N6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iuK75O_xEeWLlrwIF3w0vA" base_StructuralFeature="_iuK74-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iuK75u_xEeWLlrwIF3w0vA" base_StructuralFeature="_iuK75e_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jUIIpO_xEeWLlrwIF3w0vA" base_StructuralFeature="_jUIIo-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jUIIpu_xEeWLlrwIF3w0vA" base_StructuralFeature="_jUIIpe_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jyVHlO_xEeWLlrwIF3w0vA" base_StructuralFeature="_jyVHk-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jyVHlu_xEeWLlrwIF3w0vA" base_StructuralFeature="_jyVHle_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vWR31EeaVEcfXx-aEqQ" base_Element="_aMQ88d5xEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vWh31EeaVEcfXx-aEqQ" base_Element="_WKDJcO_wEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vWx31EeaVEcfXx-aEqQ" base_Element="_eMyr8t6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vXB31EeaVEcfXx-aEqQ" base_Element="_rNMnMN6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vXR31EeaVEcfXx-aEqQ" base_Element="_rNMnMd6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vXh31EeaVEcfXx-aEqQ" base_Element="_iuK74-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5QB31EeaVEcfXx-aEqQ" base_Element="_jyVHk-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwB5QR31EeaVEcfXx-aEqQ" base_Element="_jUIIo-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqbx31EeaVEcfXx-aEqQ" base_Element="_H7MS8N5pEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqcR31EeaVEcfXx-aEqQ" base_Element="_PSJDoN5vEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqch31EeaVEcfXx-aEqQ" base_Element="_9OvWUN5zEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqcx31EeaVEcfXx-aEqQ" base_Element="_OHiZEN5sEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqdB31EeaVEcfXx-aEqQ" base_Element="_YQ35MN5vEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqdR31EeaVEcfXx-aEqQ" base_Element="_BS_lAN5rEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgax31EeaVEcfXx-aEqQ" base_Element="_eMpiAN6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgbB31EeaVEcfXx-aEqQ" base_Element="_eMyr9N6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RLB31EeaVEcfXx-aEqQ" base_Element="_iuK75e_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RLh31EeaVEcfXx-aEqQ" base_Element="_jUIIpe_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RMB31EeaVEcfXx-aEqQ" base_Element="_jyVHle_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCIB31EeaVEcfXx-aEqQ" base_Element="_5ASPgN6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCJR31EeaVEcfXx-aEqQ" base_Element="_5ASPn96MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCJh31EeaVEcfXx-aEqQ" base_Element="_8XQOgN6QEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCKx31EeaVEcfXx-aEqQ" base_Element="_5ASPqt6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCLB31EeaVEcfXx-aEqQ" base_Element="_pPFOUN6REeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCLR31EeaVEcfXx-aEqQ" base_Element="_tj9j4N6REeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCLh31EeaVEcfXx-aEqQ" base_Element="_wQie4N6REeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IVbYMi2XEeair-8ZDvf8jw" base_Element="_IUF7cS2XEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7s7p0S2aEeair-8ZDvf8jw" base_Element="_7s7p0C2aEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7tFa0y2aEeair-8ZDvf8jw" base_StructuralFeature="_7tFa0i2aEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7tFa1C2aEeair-8ZDvf8jw" base_Element="_7tFa0i2aEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7tFa1i2aEeair-8ZDvf8jw" base_StructuralFeature="_7tFa1S2aEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7tFa1y2aEeair-8ZDvf8jw" base_Element="_7tFa1S2aEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_cWeu4C2bEeair-8ZDvf8jw" base_Association="_7s7p0C2aEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1EaBMS2bEeair-8ZDvf8jw" base_Element="_1EaBMC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1EaBNS2bEeair-8ZDvf8jw" base_StructuralFeature="_1EaBNC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1EaBNi2bEeair-8ZDvf8jw" base_Element="_1EaBNC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_1EjyMS2bEeair-8ZDvf8jw" base_StructuralFeature="_1EjyMC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1EjyMi2bEeair-8ZDvf8jw" base_Element="_1EjyMC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_51qJsS2bEeair-8ZDvf8jw" base_Element="_51qJsC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_51qJsy2bEeair-8ZDvf8jw" base_Element="_51qJsi2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_f8XbAS2cEeair-8ZDvf8jw" base_Element="_f8XbAC2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_f8XbBS2cEeair-8ZDvf8jw" base_StructuralFeature="_f8XbBC2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_f8XbBi2cEeair-8ZDvf8jw" base_Element="_f8XbBC2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_f8XbCC2cEeair-8ZDvf8jw" base_StructuralFeature="_f8XbBy2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_f8XbCS2cEeair-8ZDvf8jw" base_Element="_f8XbBy2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_nArLQS2cEeair-8ZDvf8jw" base_Element="_nArLQC2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_nArLQy2cEeair-8ZDvf8jw" base_Element="_nArLQi2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_tH7ygS2eEeair-8ZDvf8jw" base_Parameter="_tH7ygC2eEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_tH7ygi2eEeair-8ZDvf8jw" base_Element="_tH7ygC2eEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_zhR6MS2eEeair-8ZDvf8jw" base_Parameter="_zhR6MC2eEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zhR6Mi2eEeair-8ZDvf8jw" base_Element="_zhR6MC2eEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8ci2mEeair-8ZDvf8jw" base_Element="_yYDusS2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8cy2mEeair-8ZDvf8jw" base_Element="_yYDusi2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yZi8di2mEeair-8ZDvf8jw" base_StructuralFeature="_yYDutC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8dy2mEeair-8ZDvf8jw" base_Element="_yYDutC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8eC2mEeair-8ZDvf8jw" base_Element="_yYDutS2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8eS2mEeair-8ZDvf8jw" base_Element="_yYDuti2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8ei2mEeair-8ZDvf8jw" base_Element="_yYDuty2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yZi8ey2mEeair-8ZDvf8jw" base_StructuralFeature="_yYDuuC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8fC2mEeair-8ZDvf8jw" base_Element="_yYDuuC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8fS2mEeair-8ZDvf8jw" base_Element="_yYDuuS2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8fi2mEeair-8ZDvf8jw" base_Element="_yYDuui2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8fy2mEeair-8ZDvf8jw" base_Element="_yYDuuy2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yZi8gC2mEeair-8ZDvf8jw" base_StructuralFeature="_yYDuvC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8gS2mEeair-8ZDvf8jw" base_Element="_yYDuvC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8gi2mEeair-8ZDvf8jw" base_Element="_yYDuvS2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8gy2mEeair-8ZDvf8jw" base_Element="_yYDuvi2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_IdwagC2nEeair-8ZDvf8jw" base_Association="_f8XbAC2cEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YEuIUS2nEeair-8ZDvf8jw" base_Element="_YEuIUC2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YEuIVS2nEeair-8ZDvf8jw" base_StructuralFeature="_YEuIVC2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YEuIVi2nEeair-8ZDvf8jw" base_Element="_YEuIVC2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_YEuIWC2nEeair-8ZDvf8jw" base_StructuralFeature="_YEuIVy2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YEuIWS2nEeair-8ZDvf8jw" base_Element="_YEuIVy2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_uxrocS2nEeair-8ZDvf8jw" base_Element="_uxrocC2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_uxrocy2nEeair-8ZDvf8jw" base_Element="_uxroci2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="__s_6EC2nEeair-8ZDvf8jw" base_StructuralFeature="_YEuIVC2nEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RKx31EeaVEcfXx-aEqQ" base_Element="_iuK74O_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_9zKzQO_xEeWLlrwIF3w0vA" base_Association="_iuK74O_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RLx31EeaVEcfXx-aEqQ" base_Element="_jyVHkO_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_ATIOkO_yEeWLlrwIF3w0vA" base_Association="_jyVHkO_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RLR31EeaVEcfXx-aEqQ" base_Element="_jUIIoO_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Aw49kPEvEeWIT-EHROE-tg" base_Association="_jUIIoO_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IVbYMS2XEeair-8ZDvf8jw" base_Element="_IUF7cC2XEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_IVbYMC2XEeair-8ZDvf8jw" base_Class="_IUF7cC2XEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqcB31EeaVEcfXx-aEqQ" base_Element="_kJjOAO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_kJjOAu-fEeWLlrwIF3w0vA" base_Class="_kJjOAO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqbh31EeaVEcfXx-aEqQ" base_Element="_PK97QO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_PMwrAO-fEeWLlrwIF3w0vA" base_Class="_PK97QO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vWB31EeaVEcfXx-aEqQ" base_Element="_aMQ88N5xEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_aMQ8-d5xEeWd9KDn6x5Skg" base_Class="_aMQ88N5xEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yZi8cS2mEeair-8ZDvf8jw" base_Element="_yYDusC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_yZi8cC2mEeair-8ZDvf8jw" base_Class="_yYDusC2mEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_LxwagS2qEeair-8ZDvf8jw" base_Parameter="_LxwagC2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Lxwagi2qEeair-8ZDvf8jw" base_Element="_LxwagC2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NKeg8S2qEeair-8ZDvf8jw" base_Element="_NKeg8C2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NKeg8y2qEeair-8ZDvf8jw" base_Element="_NKeg8i2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Z-e-8C2qEeair-8ZDvf8jw" base_Element="_Z9I7IC2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_Z-e-8S2qEeair-8ZDvf8jw" base_Operation="_Z9I7IC2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Z-e-8i2qEeair-8ZDvf8jw" base_Parameter="_Z9I7IS2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Z-e-8y2qEeair-8ZDvf8jw" base_Element="_Z9I7IS2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Z-e--i2qEeair-8ZDvf8jw" base_Parameter="_Z9I7JS2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Z-e--y2qEeair-8ZDvf8jw" base_Element="_Z9I7JS2qEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCIR31EeaVEcfXx-aEqQ" base_Element="_5ASPmt6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_5AcAht6MEeWd9KDn6x5Skg" base_Operation="_5ASPmt6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCKh31EeaVEcfXx-aEqQ" base_Element="_5ASPqN6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_5AcAkt6MEeWd9KDn6x5Skg" base_Operation="_5ASPqN6MEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_pNdRMC5zEea0_JngOlSKcA" base_Element="_pNcqIC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qaqEIS5zEea0_JngOlSKcA" base_Element="_qaqEIC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_rZm_sC5zEea0_JngOlSKcA" base_Element="_rZmYoC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_so3oIC5zEea0_JngOlSKcA" base_Element="_so3BEC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_tqjuoS5zEea0_JngOlSKcA" base_Element="_tqjuoC5zEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_c2J9kTBFEeam35bpdXJzEw" base_Element="_c2J9kDBFEeam35bpdXJzEw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_qXAPxjJDEeamvfKYyWmELQ" base_Class="_qXAPsDJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAPxzJDEeamvfKYyWmELQ" base_Element="_qXAPsDJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAPyjJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPsjJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAPyzJDEeamvfKYyWmELQ" base_Element="_qXAPsjJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAPzDJDEeamvfKYyWmELQ" base_Element="_qXAPszJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAPzTJDEeamvfKYyWmELQ" base_Element="_qXAPtDJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAPzjJDEeamvfKYyWmELQ" base_Element="_qXAPtTJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAPzzJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPtjJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP0DJDEeamvfKYyWmELQ" base_Element="_qXAPtjJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP0TJDEeamvfKYyWmELQ" base_Element="_qXAPtzJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP0jJDEeamvfKYyWmELQ" base_Element="_qXAPuDJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAP0zJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPuTJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP1DJDEeamvfKYyWmELQ" base_Element="_qXAPuTJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAP1TJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPujJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP1jJDEeamvfKYyWmELQ" base_Element="_qXAPujJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP1zJDEeamvfKYyWmELQ" base_Element="_qXAPuzJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP2DJDEeamvfKYyWmELQ" base_Element="_qXAPvDJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXAP2TJDEeamvfKYyWmELQ" base_Element="_qXAPvTJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_qXAP3zJDEeamvfKYyWmELQ" base_StructuralFeature="_qXAPwjJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXKAsDJDEeamvfKYyWmELQ" base_Element="_qXAPwjJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXKAsTJDEeamvfKYyWmELQ" base_Element="_qXAPwzJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXKAsjJDEeamvfKYyWmELQ" base_Element="_qXAPxDJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_qXKAszJDEeamvfKYyWmELQ" base_Element="_qXAPxTJDEeamvfKYyWmELQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MnGvITKBEeapu9k56t8ZKQ" base_Element="_MnGvIDKBEeapu9k56t8ZKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zJVugTM0EeaULOmJRJKM0Q" base_Element="_zJVugDM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zJVuhTM0EeaULOmJRJKM0Q" base_StructuralFeature="_zJVuhDM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zJVuhjM0EeaULOmJRJKM0Q" base_Element="_zJVuhDM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_111xATM0EeaULOmJRJKM0Q" base_Element="_111xADM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_111xBTM0EeaULOmJRJKM0Q" base_StructuralFeature="_111xBDM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_11_iADM0EeaULOmJRJKM0Q" base_Element="_111xBDM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MnHJYTM1EeaULOmJRJKM0Q" base_Element="_MnHJYDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MnHJZTM1EeaULOmJRJKM0Q" base_StructuralFeature="_MnHJZDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MnHJZjM1EeaULOmJRJKM0Q" base_Element="_MnHJZDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ObYjYTM1EeaULOmJRJKM0Q" base_Element="_ObYjYDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ObiUYzM1EeaULOmJRJKM0Q" base_StructuralFeature="_ObiUYjM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ObiUZDM1EeaULOmJRJKM0Q" base_Element="_ObiUYjM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_a2GXoTM1EeaULOmJRJKM0Q" base_Element="_a2GXoDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_a2PhkTM1EeaULOmJRJKM0Q" base_Element="_a2PhkDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ftiAoTM1EeaULOmJRJKM0Q" base_Element="_ftiAoDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ftiAozM1EeaULOmJRJKM0Q" base_Element="_ftiAojM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_leUTgTM1EeaULOmJRJKM0Q" base_Element="_leUTgDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_leUTgzM1EeaULOmJRJKM0Q" base_Element="_leUTgjM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_s0hsETM1EeaULOmJRJKM0Q" base_Element="_s0hsEDM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_s0hsEzM1EeaULOmJRJKM0Q" base_Element="_s0hsEjM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zJVuiDM0EeaULOmJRJKM0Q" base_StructuralFeature="_zJVuhzM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zrEikDM0EeaULOmJRJKM0Q" base_Element="_zJVuhzM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_11_iAjM0EeaULOmJRJKM0Q" base_StructuralFeature="_11_iATM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_11_iAzM0EeaULOmJRJKM0Q" base_Element="_11_iATM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MnHJaDM1EeaULOmJRJKM0Q" base_StructuralFeature="_MnHJZzM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MnHJaTM1EeaULOmJRJKM0Q" base_Element="_MnHJZzM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ObiUZjM1EeaULOmJRJKM0Q" base_StructuralFeature="_ObiUZTM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ObiUZzM1EeaULOmJRJKM0Q" base_Element="_ObiUZTM1EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_wwfZEDM6EeaULOmJRJKM0Q" base_Association="_1EaBMC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_8jQcgDM6EeaULOmJRJKM0Q" base_Association="_eMpiAN6ZEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_vfPEgD4aEea-1_BGg-qcjQ" base_StructuralFeature="_1EaBNC2bEeair-8ZDvf8jw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_gvfwQT4zEea-1_BGg-qcjQ" base_Element="_gvfwQD4zEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_hUGSIT4zEea-1_BGg-qcjQ" base_Element="_hUGSID4zEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_iZt2YT4zEea-1_BGg-qcjQ" base_Element="_iZt2YD4zEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_Nge2UD42Eea-1_BGg-qcjQ" base_Association="_zJVugDM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_O2xT0D42Eea-1_BGg-qcjQ" base_Association="_111xADM0EeaULOmJRJKM0Q"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_D3E34kTgEead1bezhJG4aw" base_StructuralFeature="_D3E34ETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_D3E340TgEead1bezhJG4aw" base_Element="_D3E34ETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_D3E35ETgEead1bezhJG4aw" base_Element="_D3E34UTgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LHJMMkTgEead1bezhJG4aw" base_StructuralFeature="_LHJMMETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LHJMM0TgEead1bezhJG4aw" base_Element="_LHJMMETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LHJMNETgEead1bezhJG4aw" base_Element="_LHJMMUTgEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_RTq_4ETgEead1bezhJG4aw" base_StructuralFeature="_D3E34ETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_THEQIETgEead1bezhJG4aw" base_StructuralFeature="_LHJMMETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_h65Q0kTgEead1bezhJG4aw" base_StructuralFeature="_h65Q0ETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_h65Q00TgEead1bezhJG4aw" base_Element="_h65Q0ETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_h65Q1ETgEead1bezhJG4aw" base_Element="_h65Q0UTgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_prXjgkTgEead1bezhJG4aw" base_StructuralFeature="_prXjgETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_prXjg0TgEead1bezhJG4aw" base_Element="_prXjgETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_prXjhETgEead1bezhJG4aw" base_Element="_prXjgUTgEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_rdLfYETgEead1bezhJG4aw" base_StructuralFeature="_h65Q0ETgEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_s-p5METgEead1bezhJG4aw" base_StructuralFeature="_prXjgETgEead1bezhJG4aw"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiTopology.uml
+++ b/xmi2yang tool-v2.0/project/TapiTopology.uml
@@ -1,0 +1,1566 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_nbYiwDA4Eea4fKwSGMr6CA" name="TapiTopology">
+    <packagedElement xmi:type="uml:Package" xmi:id="_RPB0EC5xEea0_JngOlSKcA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_STzYAO_tEeWLlrwIF3w0vA" name="NodeEPHasStatePac" memberEnd="_STzYA-_tEeWLlrwIF3w0vA _STzYBe_tEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_STzYAe_tEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_STzYAu_tEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_STzYBe_tEeWLlrwIF3w0vA" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_STzYAO_tEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_WSiGUN71EeW-BtRsuJPbqg" name="LinkHasCapacityPac" memberEnd="_WSiGU971EeW-BtRsuJPbqg _WSiGVd71EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WSiGUd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WSiGUt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_WSiGVd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_WSiGUN71EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_cQkyEN71EeW-BtRsuJPbqg" name="LinkHasCostPac" memberEnd="_cQkyE971EeW-BtRsuJPbqg _cQujEN71EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cQkyEd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cQkyEt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_cQujEN71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_cQkyEN71EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_gJx4QN71EeW-BtRsuJPbqg" name="LinkHasIntegrityPac" memberEnd="_gJx4Q971EeW-BtRsuJPbqg _gJx4Rd71EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gJx4Qd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gJx4Qt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_gJx4Rd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_gJx4QN71EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_LGsOIGkDEeWZEqTYAF8eqA" name="LinkHasLinkPorts" memberEnd="_LGsOI2kDEeWZEqTYAF8eqA _LG1_IWkDEeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LGsOIWkDEeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_LGsOImkDEeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_LG1_IWkDEeWZEqTYAF8eqA" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_LGsOIGkDEeWZEqTYAF8eqA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_rJUvAN71EeW-BtRsuJPbqg" name="LinkHasRiskPac" memberEnd="_rJUvA971EeW-BtRsuJPbqg _rJUvBd71EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rJUvAd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rJUvAt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_rJUvBd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_rJUvAN71EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_IZggAN8AEeW-BtRsuJPbqg" name="LinkHasStatePac" memberEnd="_IZggA98AEeW-BtRsuJPbqg _IZpp8N8AEeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IZggAd8AEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IZggAt8AEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_IZpp8N8AEeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_IZggAN8AEeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_kZ4bgN71EeW-BtRsuJPbqg" name="LinkHasTimingPac" memberEnd="_kZ4bg971EeW-BtRsuJPbqg _kZ4bhd71EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_kZ4bgd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_kZ4bgt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_kZ4bhd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_kZ4bgN71EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_CM28EN72EeW-BtRsuJPbqg" name="LinkHasTransitionPac" memberEnd="_CM28E972EeW-BtRsuJPbqg _CM28Fd72EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CM28Ed72EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CM28Et72EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_CM28Fd72EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_CM28EN72EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="__ET2wN71EeW-BtRsuJPbqg" name="LinkHasValidationPac" memberEnd="__ET2w971EeW-BtRsuJPbqg __EdnwN71EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__ET2wd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__ET2wt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="__EdnwN71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="__ET2wN71EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_0rPocNnXEeWIOYiRCk5bbQ" name="NodeEPIncludesLP" memberEnd="_0rYyYtnXEeWIOYiRCk5bbQ _0rYyZNnXEeWIOYiRCk5bbQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_0rYyYNnXEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_0rYyYdnXEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_0rYyZNnXEeWIOYiRCk5bbQ" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_0rPocNnXEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_tOFAkN7rEeW-BtRsuJPbqg" name="NodeHasCapacityPac" memberEnd="_tOFAk97rEeW-BtRsuJPbqg _tOFAld7rEeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tOFAkd7rEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tOFAkt7rEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_tOFAld7rEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_tOFAkN7rEeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_7DdfMN7vEeW-BtRsuJPbqg" name="NodeHasCostPac" memberEnd="_7DdfM97vEeW-BtRsuJPbqg _7DmpIN7vEeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7DdfMd7vEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7DdfMt7vEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_7DmpIN7vEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_7DdfMN7vEeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_lqLYAN7wEeW-BtRsuJPbqg" name="NodeHasIntegrityPac" memberEnd="_lqLYA97wEeW-BtRsuJPbqg _lqLYBd7wEeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lqLYAd7wEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_lqLYAt7wEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_lqLYBd7wEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_lqLYAN7wEeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_W9zh0N7-EeW-BtRsuJPbqg" name="NodeHasStatePac" memberEnd="_W9zh097-EeW-BtRsuJPbqg _W9zh1d7-EeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_W9zh0d7-EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W9zh0t7-EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_W9zh1d7-EeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_W9zh0N7-EeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_kTBiYN7xEeW-BtRsuJPbqg" name="NodeHasTimingPac" memberEnd="_kTBiY97xEeW-BtRsuJPbqg _kTBiZd7xEeW-BtRsuJPbqg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_kTBiYd7xEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_kTBiYt7xEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_kTBiZd7xEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_kTBiYN7xEeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_IzuHYKf4EeW6jfwWQNiYcg" name="BottomMostNodeOwnsNodeEP" memberEnd="_Iz0OAKf4EeW6jfwWQNiYcg _Iz6UoKf4EeW6jfwWQNiYcg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IzuHYaf4EeW6jfwWQNiYcg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IzuHYqf4EeW6jfwWQNiYcg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Iz6UoKf4EeW6jfwWQNiYcg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_IzuHYKf4EeW6jfwWQNiYcg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_N1sMcKf4EeW6jfwWQNiYcg" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_N1sMcaf4EeW6jfwWQNiYcg" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_8VTUQD-_EeWNAdBR30aJhw" name="LinkHasAsociatedNodes" memberEnd="_8VW-oD-_EeWNAdBR30aJhw _8VYMwD-_EeWNAdBR30aJhw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8VVJcD-_EeWNAdBR30aJhw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8VVwgD-_EeWNAdBR30aJhw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_8VYMwD-_EeWNAdBR30aJhw" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_8VTUQD-_EeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GSZ2kD_AEeWNAdBR30aJhw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GScS0D_AEeWNAdBR30aJhw" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_tQQ4UGj_EeWZEqTYAF8eqA" name="LinkPortTerminatesOnNodeEP" memberEnd="_tQQ4U2j_EeWZEqTYAF8eqA _tQQ4VWj_EeWZEqTYAF8eqA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tQQ4UWj_EeWZEqTYAF8eqA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tQQ4Umj_EeWZEqTYAF8eqA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_tQQ4VWj_EeWZEqTYAF8eqA" name="_linkPort" type="_7vdU8Gh_EeWZEqTYAF8eqA" association="_tQQ4UGj_EeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_VEfbYGkAEeWZEqTYAF8eqA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_VEfbYWkAEeWZEqTYAF8eqA" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_T3T6ID_NEeWNAdBR30aJhw" name="NodeAggregatesNodeEP" memberEnd="_T3VIQT_NEeWNAdBR30aJhw _T3W9cD_NEeWNAdBR30aJhw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_T3UhMD_NEeWNAdBR30aJhw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_T3VIQD_NEeWNAdBR30aJhw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_T3W9cD_NEeWNAdBR30aJhw" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_T3T6ID_NEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8J_TwD_NEeWNAdBR30aJhw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8KCXED_NEeWNAdBR30aJhw" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_T7gvkD_LEeWNAdBR30aJhw" name="NodeEncapsulatesTopology" memberEnd="_T7gvkz_LEeWNAdBR30aJhw _T7hWoD_LEeWNAdBR30aJhw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_T7gvkT_LEeWNAdBR30aJhw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_T7gvkj_LEeWNAdBR30aJhw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_T7hWoD_LEeWNAdBR30aJhw" name="_forwardingDomain" type="_xImb0OK4EeSq5fATALSQkQ" association="_T7gvkD_LEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XgIs4D_LEeWNAdBR30aJhw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XgJ7AD_LEeWNAdBR30aJhw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_GkchcD_DEeWNAdBR30aJhw" name="TopologyEncompassesLinks" memberEnd="_Gkdvkj_DEeWNAdBR30aJhw _GkfkwD_DEeWNAdBR30aJhw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_GkdvkD_DEeWNAdBR30aJhw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_GkdvkT_DEeWNAdBR30aJhw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_GkfkwD_DEeWNAdBR30aJhw" name="_forwardingDomain" type="_ejyEgOKyEeSq5fATALSQkQ" association="_GkchcD_DEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jcBwwD_DEeWNAdBR30aJhw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jcC-4D_DEeWNAdBR30aJhw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_9-A9gD_KEeWNAdBR30aJhw" name="TopologyEncompassesNodes" memberEnd="_9-Bkkj_KEeWNAdBR30aJhw _9-CysD_KEeWNAdBR30aJhw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_9-BkkD_KEeWNAdBR30aJhw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9-BkkT_KEeWNAdBR30aJhw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_9-CysD_KEeWNAdBR30aJhw" name="_upperLevelFd" type="_ejyEgOKyEeSq5fATALSQkQ" association="_9-A9gD_KEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GAXDUD_LEeWNAdBR30aJhw" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GAZfkD_LEeWNAdBR30aJhw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_FVQ-0LpUEeWadf5Yweab7g" name="BottomMostNodeOwnsNodeEP" client="_IzuHYKf4EeW6jfwWQNiYcg">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_2EZj8FYkEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_EsX40LoSEeWgnN4av0rtYw" name="Link" client="_37fFQOMCEeSdZOEXoN8VDQ">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGqnjVLNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_crfNQLomEeWadf5Yweab7g" name="LinkHasAssociatedNodes" client="_8VTUQD-_EeWNAdBR30aJhw">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_oGqnu1LNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_H1WLwJ1REeWJ0fWjnLbawA" name="LinkHasLinkPorts" client="_LGsOIGkDEeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_oGqnwVLNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_UKHxgLoYEeWgnN4av0rtYw" name="LinkPort" client="_7vdU8Gh_EeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_H7c0oIgjEeOIkJV2fkx5ZA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_VMDHIJ1REeWJ0fWjnLbawA" name="LinkPortTerminatesOnNodeEP" client="_tQQ4UGj_EeWZEqTYAF8eqA">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_buzL4BNjEeS1heseQTA6lw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_O7ctMLoYEeWgnN4av0rtYw" name="Node" client="_xImb0OK4EeSq5fATALSQkQ">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGql-FLNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_Gt08wLoeEeWgnN4av0rtYw" name="NodeAggregatesNodeEP" client="_T3T6ID_NEeWNAdBR30aJhw">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_2EZj8FYkEeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_bv0XkLoYEeWgnN4av0rtYw" name="NodeEdgePoint" client="_i1UzkD-3EeWNAdBR30aJhw">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_eEpDMFX4EeOVGaP4lO41SQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_BeLPwLoYEeWgnN4av0rtYw" name="Topology">
+        <client xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGql-FLNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_WMH9ILomEeWadf5Yweab7g" name="TopologyEncompassesLinks" client="_GkchcD_DEeWNAdBR30aJhw">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_dnWM0BiQEeSh8KVgZCMyDw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_kAwnILolEeWadf5Yweab7g" name="TopologyEncompassesNodes" client="_9-A9gD_KEeWNAdBR30aJhw">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_oGqoD1LNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_G1pfMNnfEeWIOYiRCk5bbQ" name="NodeEPHasClientNodeEPs" memberEnd="_G1pfM9nfEeWIOYiRCk5bbQ _G1pfNdnfEeWIOYiRCk5bbQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_G1pfMdnfEeWIOYiRCk5bbQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_G1pfMtnfEeWIOYiRCk5bbQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_G1pfNdnfEeWIOYiRCk5bbQ" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_G1pfMNnfEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_FNLlMLolEeWadf5Yweab7g" name="NodeEncapsulatesTopology" client="_T7gvkD_LEeWNAdBR30aJhw">
+        <supplier xmi:type="uml:Class" href="CoreModel.uml#_oGql-FLNEeO75dO39GbF8Q"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_-NFDgN6XEeWd9KDn6x5Skg" name="TeLinkRefersToNodeEP" memberEnd="_-NONcN6XEeWd9KDn6x5Skg _-NONct6XEeWd9KDn6x5Skg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_-NFDgd6XEeWd9KDn6x5Skg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_-NFDgt6XEeWd9KDn6x5Skg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_-NONct6XEeWd9KDn6x5Skg" name="_telink" type="_BnjHcN5lEeWd9KDn6x5Skg" association="_-NFDgN6XEeWd9KDn6x5Skg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JNPzcN7nEeW-BtRsuJPbqg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JNZkcN7nEeW-BtRsuJPbqg" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_iDpeMN6YEeWd9KDn6x5Skg" name="TeLinkRefersToNode" memberEnd="_iDpeM96YEeWd9KDn6x5Skg _iDpeNd6YEeWd9KDn6x5Skg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iDpeMd6YEeWd9KDn6x5Skg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iDpeMt6YEeWd9KDn6x5Skg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_iDpeNd6YEeWd9KDn6x5Skg" name="_telink" type="_BnjHcN5lEeWd9KDn6x5Skg" association="_iDpeMN6YEeWd9KDn6x5Skg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_LyFuwN7nEeW-BtRsuJPbqg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_LyFuwd7nEeW-BtRsuJPbqg" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_v4NNUETtEead1bezhJG4aw" name="NwTopologyServiceHasTopology" memberEnd="_v4NNVETtEead1bezhJG4aw _v4W-UETtEead1bezhJG4aw">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_v4NNUkTtEead1bezhJG4aw" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_v4NNU0TtEead1bezhJG4aw" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_v4W-UETtEead1bezhJG4aw" name="_nwTopologyService" type="_oCmjAETtEead1bezhJG4aw" association="_v4NNUETtEead1bezhJG4aw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9aQdEETtEead1bezhJG4aw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9aQdEkTtEead1bezhJG4aw" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_MM4s4EHBEeWqPKyD1j6LMg" name="NodeEPRelatesToServiceEP" memberEnd="_MM6iEEHBEeWqPKyD1j6LMg _MM7wMEHBEeWqPKyD1j6LMg">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MM57AEHBEeWqPKyD1j6LMg" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MM57AUHBEeWqPKyD1j6LMg" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MM7wMEHBEeWqPKyD1j6LMg" name="_mappedNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" association="_MM4s4EHBEeWqPKyD1j6LMg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_euOhIEHBEeWqPKyD1j6LMg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_euQ9YEHBEeWqPKyD1j6LMg" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Realization" xmi:id="_ek0W4J1dEeWAQercC81WNA" name="NodeEPRelatesToServiceEP" client="_MM4s4EHBEeWqPKyD1j6LMg">
+        <supplier xmi:type="uml:Association" href="CoreModel.uml#_vrCogBigEeSh8KVgZCMyDw"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_SXc0sC5xEea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_QOoHAC5xEea0_JngOlSKcA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_LArf4DA8Eea4fKwSGMr6CA">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_UWAzIC5xEea0_JngOlSKcA" name="Interfaces">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_-ht5oPMtEeSb-q8_djA2ng" name="TopologyService" isLeaf="true">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_taDjMPMvEeSb-q8_djA2ng" name="getTopologyDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_0HRXMPMxEeSb-q8_djA2ng" name="topologyIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <defaultValue xmi:type="uml:LiteralNull" xmi:id="_0HRXMfMxEeSb-q8_djA2ng"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_l8oKkEpeEeW7b92SEnwDVg" name="topology" type="_ejyEgOKyEeSq5fATALSQkQ" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_N-W74PMwEeSb-q8_djA2ng" name="getNodeDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qRQggLsEEeWYrqoqXLgguw" name="topologyIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_B2HeEPM4EeSb-q8_djA2ng" name="nodeIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_FmxFMPM4EeSb-q8_djA2ng" name="node" type="_xImb0OK4EeSq5fATALSQkQ" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_dACyYPMwEeSb-q8_djA2ng" name="getNodeEdgePointDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_mNsdwN6NEeWd9KDn6x5Skg" name="topologyIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_2nCKYLsEEeWYrqoqXLgguw" name="nodeIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_QDy9YPM7EeSb-q8_djA2ng" name="epIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_bH8AQPM7EeSb-q8_djA2ng" name="nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_AgHtkFJFEeWDQNzGZgIgfQ" name="getLinkDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_yctfALsEEeWYrqoqXLgguw" name="topologyIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_AgHtkVJFEeWDQNzGZgIgfQ" name="linkIdOrName" effect="read">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_AgHtklJFEeWDQNzGZgIgfQ" name="link" type="_37fFQOMCEeSdZOEXoN8VDQ" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_M2tAQPVKEeWQB8HQFBfkJQ" name="getTopologyList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_M2tAQ_VKEeWQB8HQFBfkJQ" name="topology" type="_ejyEgOKyEeSq5fATALSQkQ" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QCEJAPVKEeWQB8HQFBfkJQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QCEJAfVKEeWQB8HQFBfkJQ" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_3Qgr4Em0EeaKuvClDq6rqA" name="OperatesOn" client="_-ht5oPMtEeSb-q8_djA2ng" supplier="_oCmjAETtEead1bezhJG4aw"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_dT_qEEm1EeaKuvClDq6rqA" name="Retrieves" client="_SXc0sC5xEea0_JngOlSKcA" supplier="_ejyEgOKyEeSq5fATALSQkQ"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_WC-EMC5xEea0_JngOlSKcA" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_37fFQOMCEeSdZOEXoN8VDQ" name="Link" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_37fFQeMCEeSdZOEXoN8VDQ">
+          <body>The Link object class models effective adjacency between two or more ForwardingDomains (FD). </body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_kS1h4N8BEeW-BtRsuJPbqg">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LErsEET2Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_LErsEUT2Eead1bezhJG4aw" value="/TapiTopology:Link"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_V5vxIET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_V5vxIUT2Eead1bezhJG4aw" value=""/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_LGsOI2kDEeWZEqTYAF8eqA" name="_linkPort" type="_7vdU8Gh_EeWZEqTYAF8eqA" isReadOnly="true" aggregation="composite" association="_LGsOIGkDEeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_S0GlwGkDEeWZEqTYAF8eqA" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_S0PvsGkDEeWZEqTYAF8eqA" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8VW-oD-_EeWNAdBR30aJhw" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" isReadOnly="true" association="_8VTUQD-_EeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TiWCoD_AEeWNAdBR30aJhw" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TiZtAD_AEeWNAdBR30aJhw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IZggA98AEeW-BtRsuJPbqg" name="_state" isReadOnly="true" aggregation="composite" association="_IZggAN8AEeW-BtRsuJPbqg">
+          <type xmi:type="uml:Class" href="Tapi.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WSiGU971EeW-BtRsuJPbqg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_WSiGUN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cQkyE971EeW-BtRsuJPbqg" name="_transferCost" type="_KjZW8dyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_cQkyEN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gJx4Q971EeW-BtRsuJPbqg" name="_transferIntegrity" type="_KjZXGdyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_gJx4QN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kZ4bg971EeW-BtRsuJPbqg" name="_transferTiming" type="_KjZXB9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_kZ4bgN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rJUvA971EeW-BtRsuJPbqg" name="_riskParameter" type="_KjZW99yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_rJUvAN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__ET2w971EeW-BtRsuJPbqg" name="_validation" type="_KjZXXNyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="__ET2wN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_CM28E972EeW-BtRsuJPbqg" name="_lpTransition" type="_KjZW_dyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_CM28EN72EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_37fFROMCEeSdZOEXoN8VDQ" name="layerProtocolName" visibility="public" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_37fFReMCEeSdZOEXoN8VDQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_37fFRuMCEeSdZOEXoN8VDQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_QpQJIINtEeW35P6IpRw6Dg" name="direction" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_QpQJIYNtEeW35P6IpRw6Dg" annotatedElement="_QpQJIINtEeW35P6IpRw6Dg">
+            <body>The directionality of the Link. &#xD;
+Is applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). &#xD;
+Is not present in more complex cases.</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_PvuhcNnjEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QpQJIoNtEeW35P6IpRw6Dg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QpQJI4NtEeW35P6IpRw6Dg" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_xImb0OK4EeSq5fATALSQkQ" name="Node" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_xImb0eK4EeSq5fATALSQkQ" annotatedElement="_xImb0OK4EeSq5fATALSQkQ">
+          <body>The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. &#xD;
+At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). </body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_W9J6MN8BEeW-BtRsuJPbqg">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7GUK4ET1Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_7GUK4UT1Eead1bezhJG4aw" value="/TapiTopology:Node"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BCToMET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_BCToMUT2Eead1bezhJG4aw" value=""/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Iz0OAKf4EeW6jfwWQNiYcg" name="_ownedNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" aggregation="composite" association="_IzuHYKf4EeW6jfwWQNiYcg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QXEkEKf4EeW6jfwWQNiYcg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QXEkEaf4EeW6jfwWQNiYcg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_T3VIQT_NEeWNAdBR30aJhw" name="_aggregatedNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" aggregation="shared" association="_T3T6ID_NEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_aQ8VsD_NEeWNAdBR30aJhw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_aQ9j0D_NEeWNAdBR30aJhw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_T7gvkz_LEeWNAdBR30aJhw" name="_encapTopology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_T7gvkD_LEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cNt2UD_LEeWNAdBR30aJhw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cNvrgD_LEeWNAdBR30aJhw" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_W9zh097-EeW-BtRsuJPbqg" name="_state" isReadOnly="true" aggregation="composite" association="_W9zh0N7-EeW-BtRsuJPbqg">
+          <type xmi:type="uml:Class" href="Tapi.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tOFAk97rEeW-BtRsuJPbqg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_tOFAkN7rEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7DdfM97vEeW-BtRsuJPbqg" name="_transferCost" type="_KjZW8dyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_7DdfMN7vEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lqLYA97wEeW-BtRsuJPbqg" name="_transferIntegrity" type="_KjZXGdyKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_lqLYAN7wEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kTBiY97xEeW-BtRsuJPbqg" name="_transferTiming" type="_KjZXB9yKEeWXdJnxZxtFYA" isReadOnly="true" aggregation="composite" association="_kTBiYN7xEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_xImb1OK4EeSq5fATALSQkQ" name="layerProtocolName" visibility="public" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xImb1eK4EeSq5fATALSQkQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xImb1uK4EeSq5fATALSQkQ" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_ejyEgOKyEeSq5fATALSQkQ" name="Topology" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_ejyEgeKyEeSq5fATALSQkQ" annotatedElement="_ejyEgOKyEeSq5fATALSQkQ">
+          <body>The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. &#xD;
+At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). </body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_5ybxcO_gEeWLlrwIF3w0vA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rS5u4ENoEeaF1NC7HRCQgw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_rS5u4UNoEeaF1NC7HRCQgw" value="/TapiTopology:Topology"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ywQ4UENoEeaF1NC7HRCQgw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_6v0v4ENoEeaF1NC7HRCQgw" value="/Tapi:Context/Tapi:_topology"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9-Bkkj_KEeWNAdBR30aJhw" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_9-A9gD_KEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JhtDID_LEeWNAdBR30aJhw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Jhu4UD_LEeWNAdBR30aJhw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Gkdvkj_DEeWNAdBR30aJhw" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" isReadOnly="true" aggregation="composite" association="_GkchcD_DEeWNAdBR30aJhw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kX5jID_DEeWNAdBR30aJhw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kX7YUD_DEeWNAdBR30aJhw" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ejyEhOKyEeSq5fATALSQkQ" name="layerProtocolName" visibility="public" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ejyEheKyEeSq5fATALSQkQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ejyEhuKyEeSq5fATALSQkQ" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW_dyKEeWXdJnxZxtFYA" name="LayerProtocolTransitionPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW_tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW_dyKEeWXdJnxZxtFYA">
+          <body>Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. &#xD;
+This abstraction is relevant when considering multi-layer routing. &#xD;
+The layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.&#xD;
+This Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.&#xD;
+Links that included details in this Pac are often referred to as Transitional Links.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZW_9yKEeWXdJnxZxtFYA" name="transitionedLayerProtocolName" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXANyKEeWXdJnxZxtFYA" annotatedElement="_KjZW_9yKEeWXdJnxZxtFYA">
+            <body>Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXAdyKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXAtyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXA9yKEeWXdJnxZxtFYA" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXBNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXA9yKEeWXdJnxZxtFYA">
+            <body>Lists the LTPs that define the layer protocol transition of the transitional link.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXBdyKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXBtyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_7vdU8Gh_EeWZEqTYAF8eqA" name="LinkPort" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_7vdU8Wh_EeWZEqTYAF8eqA" annotatedElement="_7vdU8Gh_EeWZEqTYAF8eqA">
+          <body>The association of the Link to LTPs is made via LinkEnd.&#xD;
+The LinkEnd object class models the access to the Link function. &#xD;
+The traffic forwarding between the associated LinkEnds of the Link depends upon the type of Link.  &#xD;
+In cases where there is resilience the LinkEnd may convey the resilience role of the access to the Link. &#xD;
+The Link can be considered as a component and the LinkEnd as a Port on that component</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_V5Y-AN8rEeWT9tG0gGLRFw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tQQ4U2j_EeWZEqTYAF8eqA" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" association="_tQQ4UGj_EeWZEqTYAF8eqA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_QK-uwGkAEeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QK-uwWkAEeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7vdU-2h_EeWZEqTYAF8eqA" name="role" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7vdU_Gh_EeWZEqTYAF8eqA" annotatedElement="_7vdU-2h_EeWZEqTYAF8eqA">
+            <body>Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. </body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7vdU_Wh_EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7vdU_mh_EeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7vdVA2h_EeWZEqTYAF8eqA" name="direction" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_7vdVBGh_EeWZEqTYAF8eqA" annotatedElement="_7vdVA2h_EeWZEqTYAF8eqA">
+            <body>The orientation of defined flow at the LinkEnd.</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_7vdVBWh_EeWZEqTYAF8eqA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7vdVBmh_EeWZEqTYAF8eqA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_i1UzkD-3EeWNAdBR30aJhw" name="NodeEdgePoint" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_i1UzkT-3EeWNAdBR30aJhw" annotatedElement="_i1UzkD-3EeWNAdBR30aJhw">
+          <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
+The structure of LTP supports all transport protocols including circuit and packet forms.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_3vF8gO_nEeWLlrwIF3w0vA">
+          <general xmi:type="uml:Class" href="Tapi.uml#_tjWBYD3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_fJEncET2Eead1bezhJG4aw" name="resourceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_fJEncUT2Eead1bezhJG4aw" value="/TapiTopology:NodeEdgePoint"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_WjwG4D3kEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jW1BUET2Eead1bezhJG4aw" name="resourceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_jW1BUUT2Eead1bezhJG4aw" value=""/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_-nYf4EJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_0rYyYtnXEeWIOYiRCk5bbQ" name="_layerProtocol" isReadOnly="true" aggregation="composite" association="_0rPocNnXEeWIOYiRCk5bbQ">
+          <type xmi:type="uml:Class" href="Tapi.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OlnfwNnYEeWIOYiRCk5bbQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OlnfwdnYEeWIOYiRCk5bbQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_G1pfM9nfEeWIOYiRCk5bbQ" name="_clientNodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" aggregation="shared" association="_G1pfMNnfEeWIOYiRCk5bbQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UMztkNnfEeWIOYiRCk5bbQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UMztkdnfEeWIOYiRCk5bbQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MM6iEEHBEeWqPKyD1j6LMg" name="_mappedServiceEndPoint" association="_MM4s4EHBEeWqPKyD1j6LMg">
+          <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_eKdFsEHBEeWqPKyD1j6LMg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eKfh8EHBEeWqPKyD1j6LMg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_STzYA-_tEeWLlrwIF3w0vA" name="_state" isReadOnly="true" aggregation="composite" association="_STzYAO_tEeWLlrwIF3w0vA">
+          <type xmi:type="uml:Class" href="Tapi.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_093zYKU7EeWkWNPM1BHzGA" name="direction" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_Ydx2sNnjEeWIOYiRCk5bbQ"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW99yKEeWXdJnxZxtFYA" name="RiskParameterPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW-NyKEeWXdJnxZxtFYA" annotatedElement="_KjZW99yKEeWXdJnxZxtFYA">
+          <body>The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. &#xD;
+The risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.&#xD;
+A TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.&#xD;
+The realization can be partitioned into segments which have some relevant common failure modes.&#xD;
+There is a risk of failure/degradation of each segment of the underlying realization.&#xD;
+Each segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).&#xD;
+Disruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.&#xD;
+Any TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.&#xD;
+The identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.&#xD;
+A segment has one or more risk characteristic.&#xD;
+Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.&#xD;
+Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZW-dyKEeWXdJnxZxtFYA" name="riskCharacteristic" visibility="public" type="_8ZRqz9v-EeWowYqZXEhn3A" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW-tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW-dyKEeWXdJnxZxtFYA">
+            <body>A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZW-9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW_NyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="TransferCapacityPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXM9yKEeWXdJnxZxtFYA">
+          <body>The TopologicalEntity derives capacity from the underlying realization. &#xD;
+A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.&#xD;
+A TopologicalEntity may be directly used in the view or may be assigned to another view for use.&#xD;
+The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.&#xD;
+Represents the capacity available to user (client) along with client interaction and usage. &#xD;
+A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXNdyKEeWXdJnxZxtFYA" name="totalPotentialCapacity" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXNdyKEeWXdJnxZxtFYA">
+            <body>An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXN9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXONyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXOdyKEeWXdJnxZxtFYA" name="availableCapacity" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXOtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXOdyKEeWXdJnxZxtFYA">
+            <body>Capacity available to be assigned.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXO9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXPNyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXPdyKEeWXdJnxZxtFYA" name="capacityAssignedToUserView" visibility="public" type="_rNbewL1-EeWdore3Cxez9g" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXPtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXPdyKEeWXdJnxZxtFYA">
+            <body>Capacity already assigned</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXP9yKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXQNyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXQdyKEeWXdJnxZxtFYA" name="capacityInteractionAlgorithm" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXQtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXQdyKEeWXdJnxZxtFYA">
+            <body>A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXQ9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXRNyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW8dyKEeWXdJnxZxtFYA" name="TransferCostPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW8tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW8dyKEeWXdJnxZxtFYA">
+          <body>The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. &#xD;
+They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity&#xD;
+There may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. &#xD;
+Using an entity will incur a cost. </body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZW89yKEeWXdJnxZxtFYA" name="costCharacteristic" visibility="public" type="_8ZRqwdv-EeWowYqZXEhn3A" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW9NyKEeWXdJnxZxtFYA" annotatedElement="_KjZW89yKEeWXdJnxZxtFYA">
+            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZW9dyKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW9tyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXGdyKEeWXdJnxZxtFYA" name="TransferIntegrityPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXGtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXGdyKEeWXdJnxZxtFYA">
+          <body>Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.&#xD;
+It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.&#xD;
+Note that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXG9yKEeWXdJnxZxtFYA" name="errorCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXHNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXG9yKEeWXdJnxZxtFYA">
+            <body>Describes the degree to which the signal propagated can be errored. &#xD;
+Applies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXHdyKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXHtyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXH9yKEeWXdJnxZxtFYA" name="lossCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXINyKEeWXdJnxZxtFYA" annotatedElement="_KjZXH9yKEeWXdJnxZxtFYA">
+            <body>Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.&#xD;
+Applies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXIdyKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXItyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXI9yKEeWXdJnxZxtFYA" name="repeatDeliveryCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXJNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXI9yKEeWXdJnxZxtFYA">
+            <body>Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). &#xD;
+It can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXJdyKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXJtyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXJ9yKEeWXdJnxZxtFYA" name="deliveryOrderCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXKNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXJ9yKEeWXdJnxZxtFYA">
+            <body>Describes the degree to which packets will be delivered out of sequence.&#xD;
+Does not apply to TDM as the TDM protocols maintain strict order.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXKdyKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXKtyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXK9yKEeWXdJnxZxtFYA" name="unavailableTimeCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXLNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXK9yKEeWXdJnxZxtFYA">
+            <body>Describes the duration for which there may be no valid signal propagated.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXLdyKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXLtyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXL9yKEeWXdJnxZxtFYA" name="serverIntegrityProcessCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXMNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXL9yKEeWXdJnxZxtFYA">
+            <body>Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXMdyKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXMtyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXB9yKEeWXdJnxZxtFYA" name="TransferTimingPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXCNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXB9yKEeWXdJnxZxtFYA">
+          <body>A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXFdyKEeWXdJnxZxtFYA" name="latencyCharacteristic" visibility="public" type="_8ZRq-dv-EeWowYqZXEhn3A" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXFtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXFdyKEeWXdJnxZxtFYA">
+            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXF9yKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXGNyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXXNyKEeWXdJnxZxtFYA" name="ValidationPac">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXXdyKEeWXdJnxZxtFYA" annotatedElement="_KjZXXNyKEeWXdJnxZxtFYA">
+          <body>Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXXtyKEeWXdJnxZxtFYA" name="validationMechanism" visibility="public" type="_8ZRq69v-EeWowYqZXEhn3A" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXX9yKEeWXdJnxZxtFYA" annotatedElement="_KjZXXtyKEeWXdJnxZxtFYA">
+            <body>Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXYNyKEeWXdJnxZxtFYA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXYdyKEeWXdJnxZxtFYA" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_BnjHcN5lEeWd9KDn6x5Skg" name="TeLink" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_BnjHcd5lEeWd9KDn6x5Skg">
+          <body>The Link object class models effective adjacency between two or more ForwardingDomains (FD). </body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_VMSncN8rEeWT9tG0gGLRFw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iDpeM96YEeWd9KDn6x5Skg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" isReadOnly="true" association="_iDpeMN6YEeWd9KDn6x5Skg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_uRUU8N6YEeWd9KDn6x5Skg" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_uRUU8d6YEeWd9KDn6x5Skg" value="2"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-NONcN6XEeWd9KDn6x5Skg" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" isReadOnly="true" association="_-NFDgN6XEeWd9KDn6x5Skg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_R-HlEN6YEeWd9KDn6x5Skg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_R-HlEd6YEeWd9KDn6x5Skg" value="2"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_oCmjAETtEead1bezhJG4aw" name="NetworkTopologyService">
+        <generalization xmi:type="uml:Generalization" xmi:id="_uF7-cETtEead1bezhJG4aw">
+          <general xmi:type="uml:Class" href="Tapi.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ko4_wETuEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_ko4_wUTuEead1bezhJG4aw" value="/TapiTopology:NetworkTopologyService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_36HEED3jEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_yEfCMETuEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_yEfCMUTuEead1bezhJG4aw" value="/Tapi:Context/Tapi:_nwTopologyService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_4oopgEJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_v4NNVETtEead1bezhJG4aw" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" isReadOnly="true" aggregation="composite" association="_v4NNUETtEead1bezhJG4aw">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1QQQEETtEead1bezhJG4aw"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1QaBEETtEead1bezhJG4aw" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_TTPukC5xEea0_JngOlSKcA" name="TypeDefinitions">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_rNbewL1-EeWdore3Cxez9g" name="Capacity" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_rNbewb1-EeWdore3Cxez9g" annotatedElement="_rNbewL1-EeWdore3Cxez9g">
+          <body>Information on capacity of a particular TopologicalEntity.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rNbewr1-EeWdore3Cxez9g" name="totalSize" visibility="public" type="_smkSYL1yEeWdore3Cxez9g">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_rNbew71-EeWdore3Cxez9g" annotatedElement="_rNbewr1-EeWdore3Cxez9g">
+            <body>Total capacity of the TopologicalEntity in MB/s</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rNbexL1-EeWdore3Cxez9g" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNbexb1-EeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_zB_30D6iEeai_egNtQKqQA" name="packetBwProfileType" type="_EuZIcD6gEeai_egNtQKqQA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_FKRr0D6jEeai_egNtQKqQA" name="committedInformationRate">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_HJt0AD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_HJt0Aj6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_VJ4jID6jEeai_egNtQKqQA" name="committedBurstSize">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_WDdPcD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WDdPcj6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_aMoEQD6jEeai_egNtQKqQA" name="peakInformationRate">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_btxt8D6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bt634D6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_g9oeAD6jEeai_egNtQKqQA" name="peakBurstSize">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_iAAhAD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_iAAhAj6jEeai_egNtQKqQA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_or7mcD6jEeai_egNtQKqQA" name="colorAware">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wk4fsD6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wlCQsT6jEeai_egNtQKqQA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_or7mcT6jEeai_egNtQKqQA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_u_PXkD6jEeai_egNtQKqQA" name="couplingFlag">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xq1bID6jEeai_egNtQKqQA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xq1bIj6jEeai_egNtQKqQA" value="1"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_u_PXkT6jEeai_egNtQKqQA"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqwdv-EeWowYqZXEhn3A" name="CostCharacteristic" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRqwtv-EeWowYqZXEhn3A" annotatedElement="_8ZRqwdv-EeWowYqZXEhn3A">
+          <body>The information for a particular cost characteristic.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRqw9v-EeWowYqZXEhn3A" name="costName" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRqxNv-EeWowYqZXEhn3A" annotatedElement="_8ZRqw9v-EeWowYqZXEhn3A">
+            <body>The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRqxdv-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRqxtv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRqx9v-EeWowYqZXEhn3A" name="costValue" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRqyNv-EeWowYqZXEhn3A" annotatedElement="_8ZRqx9v-EeWowYqZXEhn3A">
+            <body>The specific cost.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRqydv-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRqytv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRqy9v-EeWowYqZXEhn3A" name="costAlgorithm" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRqzNv-EeWowYqZXEhn3A" annotatedElement="_8ZRqy9v-EeWowYqZXEhn3A">
+            <body>The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRqzdv-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRqztv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_smkSYL1yEeWdore3Cxez9g" name="FixedCapacityValue" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_UEqsALvUEeWYrqoqXLgguw">
+          <body>The Capacity (Bandwidth) values that are applicable for digital layers. </body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_HBQVkL2AEeWdore3Cxez9g" name="NOT_APPLICABLE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1YyV8L1yEeWdore3Cxez9g" name="10MBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_z7f4kL1yEeWdore3Cxez9g" name="100MBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_7cCR0L1yEeWdore3Cxez9g" name="1GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_gyYdML1zEeWdore3Cxez9g" name="2.4GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Ye91gL1zEeWdore3Cxez9g" name="10GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_bhtNwL1zEeWdore3Cxez9g" name="40GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_x85d4L1yEeWdore3Cxez9g" name="100GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oRItwL1zEeWdore3Cxez9g" name="200GBPS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mXlyML1zEeWdore3Cxez9g" name="400GBPS"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq-dv-EeWowYqZXEhn3A" name="LatencyCharacteristic" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq-tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq-dv-EeWowYqZXEhn3A">
+          <body>Provides information on latency characteristic for a particular stated trafficProperty.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXCdyKEeWXdJnxZxtFYA" name="fixedLatencyCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXCtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXCdyKEeWXdJnxZxtFYA">
+            <body>A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXC9yKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXDNyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXDdyKEeWXdJnxZxtFYA" name="jitterCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXDtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXDdyKEeWXdJnxZxtFYA">
+            <body>High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.&#xD;
+Applies to TDM systems (and not packet).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXD9yKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXENyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KjZXEdyKEeWXdJnxZxtFYA" name="wanderCharacteristic" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXEtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXEdyKEeWXdJnxZxtFYA">
+            <body>Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.&#xD;
+Applies to TDM systems (and not packet).</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KjZXE9yKEeWXdJnxZxtFYA"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXFNyKEeWXdJnxZxtFYA" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq-9v-EeWowYqZXEhn3A" name="trafficPropertyName" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq_Nv-EeWowYqZXEhn3A" annotatedElement="_8ZRq-9v-EeWowYqZXEhn3A">
+            <body>The identifier of the specific traffic property to which the queuing latency applies.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRq_dv-EeWowYqZXEhn3A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq_tv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq_9v-EeWowYqZXEhn3A" name="trafficPropertyQueingLatency" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRrANv-EeWowYqZXEhn3A" annotatedElement="_8ZRq_9v-EeWowYqZXEhn3A">
+            <body>The specific queuing latency for the traffic property.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRrAdv-EeWowYqZXEhn3A"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRrAtv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqz9v-EeWowYqZXEhn3A" name="RiskCharacteristic" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq0Nv-EeWowYqZXEhn3A" annotatedElement="_8ZRqz9v-EeWowYqZXEhn3A">
+          <body>The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq0dv-EeWowYqZXEhn3A" name="riskCharacteristicName" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq0tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq0dv-EeWowYqZXEhn3A">
+            <body>The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. &#xD;
+For example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).&#xD;
+Depending upon the importance of the traffic being routed different risk characteristics will be evaluated.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRq09v-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq1Nv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq1dv-EeWowYqZXEhn3A" name="riskIdentifierList" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq1tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq1dv-EeWowYqZXEhn3A">
+            <body>A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRq19v-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq2Nv-EeWowYqZXEhn3A" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq69v-EeWowYqZXEhn3A" name="ValidationMechanism" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq7Nv-EeWowYqZXEhn3A" annotatedElement="_8ZRq69v-EeWowYqZXEhn3A">
+          <body>Identifies the validation mechanism and describes the characteristics of that mechanism</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq7dv-EeWowYqZXEhn3A" name="validationMechanism" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq7tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq7dv-EeWowYqZXEhn3A">
+            <body>Name of mechanism used to validate adjacency</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRq79v-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq8Nv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq8dv-EeWowYqZXEhn3A" name="layerProtocolAdjacencyValidated" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq8tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq8dv-EeWowYqZXEhn3A">
+            <body>State of validatiion</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRq89v-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq9Nv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_8ZRq9dv-EeWowYqZXEhn3A" name="validationRobustness" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq9tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq9dv-EeWowYqZXEhn3A">
+            <body>Quality of validation (i.e. how likely is the stated validation to be invalid)</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8ZRq99v-EeWowYqZXEhn3A" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq-Nv-EeWowYqZXEhn3A" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EuZIcD6gEeai_egNtQKqQA" name="BandwidthProfileType">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Lrs40D6gEeai_egNtQKqQA" name="NOT_APPLICABLE"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_PYdMgD6iEeai_egNtQKqQA" name="MEF_10.x"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_R0GvkD6iEeai_egNtQKqQA" name="RFC_2697"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VNVVMD6iEeai_egNtQKqQA" name="RFC_2698"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_YMrbMD6iEeai_egNtQKqQA" name="RFC_4115"/>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_nzFRlDA4Eea4fKwSGMr6CA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_X98a8DOGEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_X98a8TOGEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_X98a8jOGEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_X98a8zOGEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_X98a9DOGEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_X98a9TOGEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nzFRlTA4Eea4fKwSGMr6CA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_n0Hy4DA4Eea4fKwSGMr6CA" base_Element="_nbYiwDA4Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_n0Hy4TA4Eea4fKwSGMr6CA" base_Element="_nzFRlDA4Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-NONcd6XEeWd9KDn6x5Skg" base_StructuralFeature="_-NONcN6XEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iDpeNN6YEeWd9KDn6x5Skg" base_StructuralFeature="_iDpeM96YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_YHlhQN7mEeW-BtRsuJPbqg" base_StructuralFeature="_iDpeM96YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_Zfz4cN7mEeW-BtRsuJPbqg" base_StructuralFeature="_-NONcN6XEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vUB31EeaVEcfXx-aEqQ" base_Element="_BnjHcd5lEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vUR31EeaVEcfXx-aEqQ" base_Element="_VMSncN8rEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vUh31EeaVEcfXx-aEqQ" base_Element="_iDpeM96YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vUx31EeaVEcfXx-aEqQ" base_Element="_uRUU8N6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vVB31EeaVEcfXx-aEqQ" base_Element="_uRUU8d6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vVR31EeaVEcfXx-aEqQ" base_Element="_-NONcN6XEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vVh31EeaVEcfXx-aEqQ" base_Element="_R-HlEN6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wv4vVx31EeaVEcfXx-aEqQ" base_Element="_R-HlEd6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-ax31EeaVEcfXx-aEqQ" base_Element="_BnjHcN5lEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_BrRJ0N5lEeWd9KDn6x5Skg" base_Class="_BnjHcN5lEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ejyElOKyEeSq5fATALSQkQ" base_StructuralFeature="_ejyEhOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ejyEmuKyEeSq5fATALSQkQ" base_Class="_ejyEgOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ejyEm-KyEeSq5fATALSQkQ" base_StructuralFeature="_ejyEhOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ejyEnOKyEeSq5fATALSQkQ" base_StructuralFeature="_ejyEhOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xImb5OK4EeSq5fATALSQkQ" base_StructuralFeature="_xImb1OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xImb6-K4EeSq5fATALSQkQ" base_StructuralFeature="_xImb1OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_xImb7OK4EeSq5fATALSQkQ" base_StructuralFeature="_xImb1OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_37o2QOMCEeSdZOEXoN8VDQ" base_StructuralFeature="_37fFROMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_37o2R-MCEeSdZOEXoN8VDQ" base_StructuralFeature="_37fFROMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_37o2SOMCEeSdZOEXoN8VDQ" base_StructuralFeature="_37fFROMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelInterface xmi:id="_-ht5ofMtEeSb-q8_djA2ng" base_Interface="_-ht5oPMtEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_0HRXMvMxEeSb-q8_djA2ng" base_Parameter="_0HRXMPMxEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_B2HeEvM4EeSb-q8_djA2ng" base_Parameter="_B2HeEPM4EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_FmxFMfM4EeSb-q8_djA2ng" base_Parameter="_FmxFMPM4EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_QDy9YfM7EeSb-q8_djA2ng" base_Parameter="_QDy9YPM7EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_bH8AQfM7EeSb-q8_djA2ng" base_Parameter="_bH8AQPM7EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_EGaoEv5BEeSIs5T3yQwyyw" base_Parameter="_0HRXMPMxEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8VW-oT-_EeWNAdBR30aJhw" base_StructuralFeature="_8VW-oD-_EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8VYz0D-_EeWNAdBR30aJhw" base_StructuralFeature="_8VYMwD-_EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GkeWoD_DEeWNAdBR30aJhw" base_StructuralFeature="_Gkdvkj_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_GkgL0D_DEeWNAdBR30aJhw" base_StructuralFeature="_GkfkwD_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9-Bkkz_KEeWNAdBR30aJhw" base_StructuralFeature="_9-Bkkj_KEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9-CysT_KEeWNAdBR30aJhw" base_StructuralFeature="_9-CysD_KEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_T7gvlD_LEeWNAdBR30aJhw" base_StructuralFeature="_T7gvkz_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_T7hWoT_LEeWNAdBR30aJhw" base_StructuralFeature="_T7hWoD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_T3VIQj_NEeWNAdBR30aJhw" base_StructuralFeature="_T3VIQT_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_T3W9cT_NEeWNAdBR30aJhw" base_StructuralFeature="_T3W9cD_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_l8oKkUpeEeW7b92SEnwDVg" base_Parameter="_l8oKkEpeEeW7b92SEnwDVg"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_AgN0MVJFEeWDQNzGZgIgfQ" base_Parameter="_AgHtkVJFEeWDQNzGZgIgfQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_AgN0MlJFEeWDQNzGZgIgfQ" base_Parameter="_AgHtklJFEeWDQNzGZgIgfQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7wyxs2h_EeWZEqTYAF8eqA" base_StructuralFeature="_7vdU-2h_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7wyxtWh_EeWZEqTYAF8eqA" base_StructuralFeature="_7vdVA2h_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tQQ4VGj_EeWZEqTYAF8eqA" base_StructuralFeature="_tQQ4U2j_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tQQ4Vmj_EeWZEqTYAF8eqA" base_StructuralFeature="_tQQ4VWj_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LG1_IGkDEeWZEqTYAF8eqA" base_StructuralFeature="_LGsOI2kDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LG1_ImkDEeWZEqTYAF8eqA" base_StructuralFeature="_LG1_IWkDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_QpQJJINtEeW35P6IpRw6Dg" base_StructuralFeature="_QpQJIINtEeW35P6IpRw6Dg"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_J1SqQJ1REeWJ0fWjnLbawA" base_Realization="_H1WLwJ1REeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_ZCa7wJ1REeWJ0fWjnLbawA" base_Realization="_VMDHIJ1REeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_VY2KoKH_EeWqgMj1FXPlrA" base_StructuralFeature="_T7gvkz_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_gNFwUKH_EeWqgMj1FXPlrA" base_StructuralFeature="_8VW-oD-_EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_093zYaU7EeWkWNPM1BHzGA" base_StructuralFeature="_093zYKU7EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Iz0OAaf4EeW6jfwWQNiYcg" base_StructuralFeature="_Iz0OAKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Iz6Uoaf4EeW6jfwWQNiYcg" base_StructuralFeature="_Iz6UoKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_IFcGYLoSEeWgnN4av0rtYw" base_Realization="_EsX40LoSEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_CtC2oLoYEeWgnN4av0rtYw" base_Realization="_BeLPwLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_QBE4gLoYEeWgnN4av0rtYw" base_Realization="_O7ctMLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_VAmtkLoYEeWgnN4av0rtYw" base_Realization="_UKHxgLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_fN_HkLoYEeWgnN4av0rtYw" base_Realization="_bv0XkLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_IpnUALoeEeWgnN4av0rtYw" base_Realization="_Gt08wLoeEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_GGl5cLolEeWadf5Yweab7g" base_Realization="_FNLlMLolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_lexdQLolEeWadf5Yweab7g" base_Realization="_kAwnILolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_YdKysLomEeWadf5Yweab7g" base_Realization="_WMH9ILomEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_guV-sLomEeWadf5Yweab7g" base_Realization="_crfNQLomEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_Wg0r4LpUEeWadf5Yweab7g" base_Realization="_FVQ-0LpUEeWadf5Yweab7g"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_rDwnoLpYEeWadf5Yweab7g" base_StructuralFeature="_T3VIQT_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_qRQggbsEEeWYrqoqXLgguw" base_Parameter="_qRQggLsEEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_yctfAbsEEeWYrqoqXLgguw" base_Parameter="_yctfALsEEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_2nCKYbsEEeWYrqoqXLgguw" base_Parameter="_2nCKYLsEEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_oFk5wLvNEeWYrqoqXLgguw" base_StructuralFeature="_tQQ4U2j_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rO6sgL1-EeWdore3Cxez9g" base_StructuralFeature="_rNbewr1-EeWdore3Cxez9g" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_0rYyY9nXEeWIOYiRCk5bbQ" base_StructuralFeature="_0rYyYtnXEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_0rYyZdnXEeWIOYiRCk5bbQ" base_StructuralFeature="_0rYyZNnXEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_G1pfNNnfEeWIOYiRCk5bbQ" base_StructuralFeature="_G1pfM9nfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_G1pfNtnfEeWIOYiRCk5bbQ" base_StructuralFeature="_G1pfNdnfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_GapIwNngEeWIOYiRCk5bbQ" base_StructuralFeature="_G1pfM9nfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuYNv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRqw9v-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuYdv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRqx9v-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuYtv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRqy9v-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuY9v-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq0dv-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuZNv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq1dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuadv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq7dv-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWuatv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq8dv-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWua9v-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq9dv-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWubNv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq-9v-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8bWubdv-EeWowYqZXEhn3A" base_StructuralFeature="_8ZRq_9v-EeWowYqZXEhn3A" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvawdyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZW89yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkvaw9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZW-dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvaxdyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZW_9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvaxtyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXA9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvayNyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXCdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvaydyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXDdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvaytyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXEdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkvay9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXFdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvazdyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXG9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_KkvaztyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXH9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkvaz9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXI9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkva0NyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXJ9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kkva0dyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXK9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ksNyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXL9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4kstyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXNdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ks9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXOdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ktNyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXPdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4ktdyKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXQdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Kk4kv9yKEeWXdJnxZxtFYA" base_StructuralFeature="_KjZXXtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_mNsdwd6NEeWd9KDn6x5Skg" base_Parameter="_mNsdwN6NEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tOFAlN7rEeW-BtRsuJPbqg" base_StructuralFeature="_tOFAk97rEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_tOOxkN7rEeW-BtRsuJPbqg" base_StructuralFeature="_tOFAld7rEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7DdfNN7vEeW-BtRsuJPbqg" base_StructuralFeature="_7DdfM97vEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7DmpId7vEeW-BtRsuJPbqg" base_StructuralFeature="_7DmpIN7vEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lqLYBN7wEeW-BtRsuJPbqg" base_StructuralFeature="_lqLYA97wEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_lqLYBt7wEeW-BtRsuJPbqg" base_StructuralFeature="_lqLYBd7wEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kTBiZN7xEeW-BtRsuJPbqg" base_StructuralFeature="_kTBiY97xEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kTBiZt7xEeW-BtRsuJPbqg" base_StructuralFeature="_kTBiZd7xEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WSiGVN71EeW-BtRsuJPbqg" base_StructuralFeature="_WSiGU971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WSiGVt71EeW-BtRsuJPbqg" base_StructuralFeature="_WSiGVd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cQkyFN71EeW-BtRsuJPbqg" base_StructuralFeature="_cQkyE971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_cQujEd71EeW-BtRsuJPbqg" base_StructuralFeature="_cQujEN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gJx4RN71EeW-BtRsuJPbqg" base_StructuralFeature="_gJx4Q971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_gKEzMN71EeW-BtRsuJPbqg" base_StructuralFeature="_gJx4Rd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kZ4bhN71EeW-BtRsuJPbqg" base_StructuralFeature="_kZ4bg971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_kZ4bht71EeW-BtRsuJPbqg" base_StructuralFeature="_kZ4bhd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rJUvBN71EeW-BtRsuJPbqg" base_StructuralFeature="_rJUvA971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rJUvBt71EeW-BtRsuJPbqg" base_StructuralFeature="_rJUvBd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__ET2xN71EeW-BtRsuJPbqg" base_StructuralFeature="__ET2w971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__Ednwd71EeW-BtRsuJPbqg" base_StructuralFeature="__EdnwN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_CM28FN72EeW-BtRsuJPbqg" base_StructuralFeature="_CM28E972EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_CM28Ft72EeW-BtRsuJPbqg" base_StructuralFeature="_CM28Fd72EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_W9zh1N7-EeW-BtRsuJPbqg" base_StructuralFeature="_W9zh097-EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_W9zh1t7-EeW-BtRsuJPbqg" base_StructuralFeature="_W9zh1d7-EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IZggBN8AEeW-BtRsuJPbqg" base_StructuralFeature="_IZggA98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IZpp8d8AEeW-BtRsuJPbqg" base_StructuralFeature="_IZpp8N8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_STzYBO_tEeWLlrwIF3w0vA" base_StructuralFeature="_STzYA-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_STzYBu_tEeWLlrwIF3w0vA" base_StructuralFeature="_STzYBe_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_M2tARvVKEeWQB8HQFBfkJQ" base_Parameter="_M2tAQ_VKEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuirhh31EeaVEcfXx-aEqQ" base_Element="_ejyEgeKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuirhx31EeaVEcfXx-aEqQ" base_Element="_5ybxcO_gEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuiriB31EeaVEcfXx-aEqQ" base_Element="_9-Bkkj_KEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuiriR31EeaVEcfXx-aEqQ" base_Element="_JhtDID_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuirih31EeaVEcfXx-aEqQ" base_Element="_Jhu4UD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuirix31EeaVEcfXx-aEqQ" base_Element="_Gkdvkj_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscgB31EeaVEcfXx-aEqQ" base_Element="_kX5jID_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscgR31EeaVEcfXx-aEqQ" base_Element="_kX7YUD_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscgh31EeaVEcfXx-aEqQ" base_Element="_ejyEhOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuscgx31EeaVEcfXx-aEqQ" base_Element="_ejyEheKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuschB31EeaVEcfXx-aEqQ" base_Element="_ejyEhuKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Nhx31EeaVEcfXx-aEqQ" base_Element="_xImb0eK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NiB31EeaVEcfXx-aEqQ" base_Element="_W9J6MN8BEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NiR31EeaVEcfXx-aEqQ" base_Element="_Iz0OAKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Nih31EeaVEcfXx-aEqQ" base_Element="_QXEkEKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Nix31EeaVEcfXx-aEqQ" base_Element="_QXEkEaf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NjB31EeaVEcfXx-aEqQ" base_Element="_T3VIQT_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NjR31EeaVEcfXx-aEqQ" base_Element="_aQ8VsD_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Njh31EeaVEcfXx-aEqQ" base_Element="_aQ9j0D_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Njx31EeaVEcfXx-aEqQ" base_Element="_T7gvkz_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NkB31EeaVEcfXx-aEqQ" base_Element="_cNt2UD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2NkR31EeaVEcfXx-aEqQ" base_Element="_cNvrgD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XcB31EeaVEcfXx-aEqQ" base_Element="_W9zh097-EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XcR31EeaVEcfXx-aEqQ" base_Element="_tOFAk97rEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xch31EeaVEcfXx-aEqQ" base_Element="_7DdfM97vEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xcx31EeaVEcfXx-aEqQ" base_Element="_lqLYA97wEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XdB31EeaVEcfXx-aEqQ" base_Element="_kTBiY97xEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XdR31EeaVEcfXx-aEqQ" base_Element="_xImb1OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xdh31EeaVEcfXx-aEqQ" base_Element="_xImb1eK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xdx31EeaVEcfXx-aEqQ" base_Element="_xImb1uK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XeR31EeaVEcfXx-aEqQ" base_Element="_37fFQeMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xeh31EeaVEcfXx-aEqQ" base_Element="_kS1h4N8BEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xex31EeaVEcfXx-aEqQ" base_Element="_LGsOI2kDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XfB31EeaVEcfXx-aEqQ" base_Element="_S0GlwGkDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XfR31EeaVEcfXx-aEqQ" base_Element="_S0PvsGkDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xfh31EeaVEcfXx-aEqQ" base_Element="_8VW-oD-_EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xfx31EeaVEcfXx-aEqQ" base_Element="_TiWCoD_AEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XgB31EeaVEcfXx-aEqQ" base_Element="_TiZtAD_AEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XgR31EeaVEcfXx-aEqQ" base_Element="_IZggA98AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xgh31EeaVEcfXx-aEqQ" base_Element="_WSiGU971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xgx31EeaVEcfXx-aEqQ" base_Element="_cQkyE971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XhB31EeaVEcfXx-aEqQ" base_Element="_gJx4Q971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XhR31EeaVEcfXx-aEqQ" base_Element="_kZ4bg971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xhh31EeaVEcfXx-aEqQ" base_Element="_rJUvA971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xhx31EeaVEcfXx-aEqQ" base_Element="__ET2w971EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XiB31EeaVEcfXx-aEqQ" base_Element="_CM28E972EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XiR31EeaVEcfXx-aEqQ" base_Element="_37fFROMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xih31EeaVEcfXx-aEqQ" base_Element="_37fFReMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xix31EeaVEcfXx-aEqQ" base_Element="_37fFRuMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XjB31EeaVEcfXx-aEqQ" base_Element="_QpQJIINtEeW35P6IpRw6Dg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XjR31EeaVEcfXx-aEqQ" base_Element="_QpQJIYNtEeW35P6IpRw6Dg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xjh31EeaVEcfXx-aEqQ" base_Element="_QpQJIoNtEeW35P6IpRw6Dg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xjx31EeaVEcfXx-aEqQ" base_Element="_QpQJI4NtEeW35P6IpRw6Dg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XkR31EeaVEcfXx-aEqQ" base_Element="_i1UzkT-3EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_Xkh31EeaVEcfXx-aEqQ" base_Element="_3vF8gO_nEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XlB31EeaVEcfXx-aEqQ" base_Element="_0rYyYtnXEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIcB31EeaVEcfXx-aEqQ" base_Element="_OlnfwNnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIcR31EeaVEcfXx-aEqQ" base_Element="_OlnfwdnYEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIch31EeaVEcfXx-aEqQ" base_Element="_G1pfM9nfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIcx31EeaVEcfXx-aEqQ" base_Element="_UMztkNnfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIdB31EeaVEcfXx-aEqQ" base_Element="_UMztkdnfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIdR31EeaVEcfXx-aEqQ" base_Element="_STzYA-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIdh31EeaVEcfXx-aEqQ" base_Element="_093zYKU7EeWkWNPM1BHzGA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDZB31EeaVEcfXx-aEqQ" base_Element="_7vdU8Wh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDZR31EeaVEcfXx-aEqQ" base_Element="_V5Y-AN8rEeWT9tG0gGLRFw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDZh31EeaVEcfXx-aEqQ" base_Element="_tQQ4U2j_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDZx31EeaVEcfXx-aEqQ" base_Element="_QK-uwGkAEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDaB31EeaVEcfXx-aEqQ" base_Element="_QK-uwWkAEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDaR31EeaVEcfXx-aEqQ" base_Element="_7vdU-2h_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDah31EeaVEcfXx-aEqQ" base_Element="_7vdU_Gh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDax31EeaVEcfXx-aEqQ" base_Element="_7vdU_Wh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDbB31EeaVEcfXx-aEqQ" base_Element="_7vdU_mh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDbR31EeaVEcfXx-aEqQ" base_Element="_7vdVA2h_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDbh31EeaVEcfXx-aEqQ" base_Element="_7vdVBGh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDbx31EeaVEcfXx-aEqQ" base_Element="_7vdVBWh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDcB31EeaVEcfXx-aEqQ" base_Element="_7vdVBmh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0gx31EeaVEcfXx-aEqQ" base_Element="_KjZW8tyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0hB31EeaVEcfXx-aEqQ" base_Element="_KjZW89yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0hR31EeaVEcfXx-aEqQ" base_Element="_KjZW9NyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0hh31EeaVEcfXx-aEqQ" base_Element="_KjZW9dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0hx31EeaVEcfXx-aEqQ" base_Element="_KjZW9tyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0iR31EeaVEcfXx-aEqQ" base_Element="_KjZW-NyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ih31EeaVEcfXx-aEqQ" base_Element="_KjZW-dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ix31EeaVEcfXx-aEqQ" base_Element="_KjZW-tyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0jB31EeaVEcfXx-aEqQ" base_Element="_KjZW-9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0jR31EeaVEcfXx-aEqQ" base_Element="_KjZW_NyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0jx31EeaVEcfXx-aEqQ" base_Element="_KjZW_tyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0kB31EeaVEcfXx-aEqQ" base_Element="_KjZW_9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0kR31EeaVEcfXx-aEqQ" base_Element="_KjZXANyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0kh31EeaVEcfXx-aEqQ" base_Element="_KjZXAdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0kx31EeaVEcfXx-aEqQ" base_Element="_KjZXAtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0lB31EeaVEcfXx-aEqQ" base_Element="_KjZXA9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0lR31EeaVEcfXx-aEqQ" base_Element="_KjZXBNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0lh31EeaVEcfXx-aEqQ" base_Element="_KjZXBdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0lx31EeaVEcfXx-aEqQ" base_Element="_KjZXBtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0mR31EeaVEcfXx-aEqQ" base_Element="_KjZXCNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0mh31EeaVEcfXx-aEqQ" base_Element="_KjZXCdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0mx31EeaVEcfXx-aEqQ" base_Element="_KjZXCtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0nB31EeaVEcfXx-aEqQ" base_Element="_KjZXC9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0nR31EeaVEcfXx-aEqQ" base_Element="_KjZXDNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0nh31EeaVEcfXx-aEqQ" base_Element="_KjZXDdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0nx31EeaVEcfXx-aEqQ" base_Element="_KjZXDtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0oB31EeaVEcfXx-aEqQ" base_Element="_KjZXD9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0oR31EeaVEcfXx-aEqQ" base_Element="_KjZXENyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0oh31EeaVEcfXx-aEqQ" base_Element="_KjZXEdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ox31EeaVEcfXx-aEqQ" base_Element="_KjZXEtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0pB31EeaVEcfXx-aEqQ" base_Element="_KjZXE9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0pR31EeaVEcfXx-aEqQ" base_Element="_KjZXFNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ph31EeaVEcfXx-aEqQ" base_Element="_KjZXFdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0px31EeaVEcfXx-aEqQ" base_Element="_KjZXFtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0qB31EeaVEcfXx-aEqQ" base_Element="_KjZXF9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0qR31EeaVEcfXx-aEqQ" base_Element="_KjZXGNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0qx31EeaVEcfXx-aEqQ" base_Element="_KjZXGtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0rB31EeaVEcfXx-aEqQ" base_Element="_KjZXG9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0rR31EeaVEcfXx-aEqQ" base_Element="_KjZXHNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0rh31EeaVEcfXx-aEqQ" base_Element="_KjZXHdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0rx31EeaVEcfXx-aEqQ" base_Element="_KjZXHtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0sB31EeaVEcfXx-aEqQ" base_Element="_KjZXH9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0sR31EeaVEcfXx-aEqQ" base_Element="_KjZXINyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0sh31EeaVEcfXx-aEqQ" base_Element="_KjZXIdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0sx31EeaVEcfXx-aEqQ" base_Element="_KjZXItyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0tB31EeaVEcfXx-aEqQ" base_Element="_KjZXI9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0tR31EeaVEcfXx-aEqQ" base_Element="_KjZXJNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0th31EeaVEcfXx-aEqQ" base_Element="_KjZXJdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0tx31EeaVEcfXx-aEqQ" base_Element="_KjZXJtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0uB31EeaVEcfXx-aEqQ" base_Element="_KjZXJ9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0uR31EeaVEcfXx-aEqQ" base_Element="_KjZXKNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0uh31EeaVEcfXx-aEqQ" base_Element="_KjZXKdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0ux31EeaVEcfXx-aEqQ" base_Element="_KjZXKtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0vB31EeaVEcfXx-aEqQ" base_Element="_KjZXK9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0vR31EeaVEcfXx-aEqQ" base_Element="_KjZXLNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0vh31EeaVEcfXx-aEqQ" base_Element="_KjZXLdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0vx31EeaVEcfXx-aEqQ" base_Element="_KjZXLtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0wB31EeaVEcfXx-aEqQ" base_Element="_KjZXL9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-UB31EeaVEcfXx-aEqQ" base_Element="_KjZXMNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-UR31EeaVEcfXx-aEqQ" base_Element="_KjZXMdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Uh31EeaVEcfXx-aEqQ" base_Element="_KjZXMtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-VB31EeaVEcfXx-aEqQ" base_Element="_KjZXNNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-VR31EeaVEcfXx-aEqQ" base_Element="_KjZXNdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Vh31EeaVEcfXx-aEqQ" base_Element="_KjZXNtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Vx31EeaVEcfXx-aEqQ" base_Element="_KjZXN9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-WB31EeaVEcfXx-aEqQ" base_Element="_KjZXONyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-WR31EeaVEcfXx-aEqQ" base_Element="_KjZXOdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Wh31EeaVEcfXx-aEqQ" base_Element="_KjZXOtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Wx31EeaVEcfXx-aEqQ" base_Element="_KjZXO9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-XB31EeaVEcfXx-aEqQ" base_Element="_KjZXPNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-XR31EeaVEcfXx-aEqQ" base_Element="_KjZXPdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Xh31EeaVEcfXx-aEqQ" base_Element="_KjZXPtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Xx31EeaVEcfXx-aEqQ" base_Element="_KjZXP9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-YB31EeaVEcfXx-aEqQ" base_Element="_KjZXQNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-YR31EeaVEcfXx-aEqQ" base_Element="_KjZXQdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Yh31EeaVEcfXx-aEqQ" base_Element="_KjZXQtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Yx31EeaVEcfXx-aEqQ" base_Element="_KjZXQ9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-ZB31EeaVEcfXx-aEqQ" base_Element="_KjZXRNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Zh31EeaVEcfXx-aEqQ" base_Element="_KjZXXdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Zx31EeaVEcfXx-aEqQ" base_Element="_KjZXXtyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-aB31EeaVEcfXx-aEqQ" base_Element="_KjZXX9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-aR31EeaVEcfXx-aEqQ" base_Element="_KjZXYNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-ah31EeaVEcfXx-aEqQ" base_Element="_KjZXYdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLquB31EeaVEcfXx-aEqQ" base_Element="_smkSYL1yEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLquR31EeaVEcfXx-aEqQ" base_Element="_UEqsALvUEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLquh31EeaVEcfXx-aEqQ" base_Element="_HBQVkL2AEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqux31EeaVEcfXx-aEqQ" base_Element="_1YyV8L1yEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqvB31EeaVEcfXx-aEqQ" base_Element="_z7f4kL1yEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqvR31EeaVEcfXx-aEqQ" base_Element="_7cCR0L1yEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbQB31EeaVEcfXx-aEqQ" base_Element="_gyYdML1zEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbQR31EeaVEcfXx-aEqQ" base_Element="_Ye91gL1zEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbQh31EeaVEcfXx-aEqQ" base_Element="_bhtNwL1zEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbQx31EeaVEcfXx-aEqQ" base_Element="_x85d4L1yEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbRB31EeaVEcfXx-aEqQ" base_Element="_oRItwL1zEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwVbRR31EeaVEcfXx-aEqQ" base_Element="_mXlyML1zEeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWMh31EeaVEcfXx-aEqQ" base_Element="_rNbewL1-EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWMx31EeaVEcfXx-aEqQ" base_Element="_rNbewb1-EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWNB31EeaVEcfXx-aEqQ" base_Element="_rNbewr1-EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWNR31EeaVEcfXx-aEqQ" base_Element="_rNbew71-EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWNh31EeaVEcfXx-aEqQ" base_Element="_rNbexL1-EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWNx31EeaVEcfXx-aEqQ" base_Element="_rNbexb1-EeWdore3Cxez9g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWRB31EeaVEcfXx-aEqQ" base_Element="_8ZRqwdv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWRR31EeaVEcfXx-aEqQ" base_Element="_8ZRqwtv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWRh31EeaVEcfXx-aEqQ" base_Element="_8ZRqw9v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWRx31EeaVEcfXx-aEqQ" base_Element="_8ZRqxNv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWSB31EeaVEcfXx-aEqQ" base_Element="_8ZRqxdv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWSR31EeaVEcfXx-aEqQ" base_Element="_8ZRqxtv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWSh31EeaVEcfXx-aEqQ" base_Element="_8ZRqx9v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWSx31EeaVEcfXx-aEqQ" base_Element="_8ZRqyNv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWTB31EeaVEcfXx-aEqQ" base_Element="_8ZRqydv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWTR31EeaVEcfXx-aEqQ" base_Element="_8ZRqytv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWTh31EeaVEcfXx-aEqQ" base_Element="_8ZRqy9v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWTx31EeaVEcfXx-aEqQ" base_Element="_8ZRqzNv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWUB31EeaVEcfXx-aEqQ" base_Element="_8ZRqzdv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWUR31EeaVEcfXx-aEqQ" base_Element="_8ZRqztv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWUh31EeaVEcfXx-aEqQ" base_Element="_8ZRq-dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWUx31EeaVEcfXx-aEqQ" base_Element="_8ZRq-tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWVB31EeaVEcfXx-aEqQ" base_Element="_8ZRq-9v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWVR31EeaVEcfXx-aEqQ" base_Element="_8ZRq_Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWVh31EeaVEcfXx-aEqQ" base_Element="_8ZRq_dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWVx31EeaVEcfXx-aEqQ" base_Element="_8ZRq_tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWWB31EeaVEcfXx-aEqQ" base_Element="_8ZRq_9v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWWR31EeaVEcfXx-aEqQ" base_Element="_8ZRrANv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWWh31EeaVEcfXx-aEqQ" base_Element="_8ZRrAdv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWWx31EeaVEcfXx-aEqQ" base_Element="_8ZRrAtv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWXB31EeaVEcfXx-aEqQ" base_Element="_8ZRqz9v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWXR31EeaVEcfXx-aEqQ" base_Element="_8ZRq0Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWXh31EeaVEcfXx-aEqQ" base_Element="_8ZRq0dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWXx31EeaVEcfXx-aEqQ" base_Element="_8ZRq0tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWYB31EeaVEcfXx-aEqQ" base_Element="_8ZRq09v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWYR31EeaVEcfXx-aEqQ" base_Element="_8ZRq1Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWYh31EeaVEcfXx-aEqQ" base_Element="_8ZRq1dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWYx31EeaVEcfXx-aEqQ" base_Element="_8ZRq1tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWZB31EeaVEcfXx-aEqQ" base_Element="_8ZRq19v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWZR31EeaVEcfXx-aEqQ" base_Element="_8ZRq2Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWZh31EeaVEcfXx-aEqQ" base_Element="_8ZRq69v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWZx31EeaVEcfXx-aEqQ" base_Element="_8ZRq7Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWaB31EeaVEcfXx-aEqQ" base_Element="_8ZRq7dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWaR31EeaVEcfXx-aEqQ" base_Element="_8ZRq7tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWah31EeaVEcfXx-aEqQ" base_Element="_8ZRq79v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWax31EeaVEcfXx-aEqQ" base_Element="_8ZRq8Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWbB31EeaVEcfXx-aEqQ" base_Element="_8ZRq8dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWbR31EeaVEcfXx-aEqQ" base_Element="_8ZRq8tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWbh31EeaVEcfXx-aEqQ" base_Element="_8ZRq89v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWbx31EeaVEcfXx-aEqQ" base_Element="_8ZRq9Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWcB31EeaVEcfXx-aEqQ" base_Element="_8ZRq9dv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWcR31EeaVEcfXx-aEqQ" base_Element="_8ZRq9tv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWch31EeaVEcfXx-aEqQ" base_Element="_8ZRq99v-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWcx31EeaVEcfXx-aEqQ" base_Element="_8ZRq-Nv-EeWowYqZXEhn3A"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWgR31EeaVEcfXx-aEqQ" base_Element="_GkchcD_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWgh31EeaVEcfXx-aEqQ" base_Element="_GkfkwD_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWgx31EeaVEcfXx-aEqQ" base_Element="_jcBwwD_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWhB31EeaVEcfXx-aEqQ" base_Element="_jcC-4D_DEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWhR31EeaVEcfXx-aEqQ" base_Element="_8VTUQD-_EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWhh31EeaVEcfXx-aEqQ" base_Element="_8VYMwD-_EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWhx31EeaVEcfXx-aEqQ" base_Element="_GSZ2kD_AEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWiB31EeaVEcfXx-aEqQ" base_Element="_GScS0D_AEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWiR31EeaVEcfXx-aEqQ" base_Element="_9-A9gD_KEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWih31EeaVEcfXx-aEqQ" base_Element="_9-CysD_KEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWix31EeaVEcfXx-aEqQ" base_Element="_GAXDUD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWjB31EeaVEcfXx-aEqQ" base_Element="_GAZfkD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWjR31EeaVEcfXx-aEqQ" base_Element="_T7gvkD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWjh31EeaVEcfXx-aEqQ" base_Element="_T7hWoD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWjx31EeaVEcfXx-aEqQ" base_Element="_XgIs4D_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWkB31EeaVEcfXx-aEqQ" base_Element="_XgJ7AD_LEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWkR31EeaVEcfXx-aEqQ" base_Element="_T3T6ID_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWkh31EeaVEcfXx-aEqQ" base_Element="_T3W9cD_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWkx31EeaVEcfXx-aEqQ" base_Element="_8J_TwD_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWlB31EeaVEcfXx-aEqQ" base_Element="_8KCXED_NEeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWqx31EeaVEcfXx-aEqQ" base_Element="_tQQ4UGj_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWrB31EeaVEcfXx-aEqQ" base_Element="_tQQ4VWj_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWrR31EeaVEcfXx-aEqQ" base_Element="_VEfbYGkAEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWrh31EeaVEcfXx-aEqQ" base_Element="_VEfbYWkAEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWsB31EeaVEcfXx-aEqQ" base_Element="_LG1_IWkDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgPh31EeaVEcfXx-aEqQ" base_Element="_H1WLwJ1REeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgPx31EeaVEcfXx-aEqQ" base_Element="_VMDHIJ1REeWJ0fWjnLbawA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgSh31EeaVEcfXx-aEqQ" base_Element="_Gt08wLoeEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgTB31EeaVEcfXx-aEqQ" base_Element="_FNLlMLolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgTR31EeaVEcfXx-aEqQ" base_Element="_kAwnILolEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgTh31EeaVEcfXx-aEqQ" base_Element="_WMH9ILomEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgTx31EeaVEcfXx-aEqQ" base_Element="_crfNQLomEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgVB31EeaVEcfXx-aEqQ" base_Element="_BeLPwLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgVR31EeaVEcfXx-aEqQ" base_Element="_O7ctMLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgVh31EeaVEcfXx-aEqQ" base_Element="_EsX40LoSEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgVx31EeaVEcfXx-aEqQ" base_Element="_UKHxgLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgWB31EeaVEcfXx-aEqQ" base_Element="_bv0XkLoYEeWgnN4av0rtYw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgXB31EeaVEcfXx-aEqQ" base_Element="_IzuHYKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgXR31EeaVEcfXx-aEqQ" base_Element="_Iz6UoKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgXh31EeaVEcfXx-aEqQ" base_Element="_N1sMcKf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgXx31EeaVEcfXx-aEqQ" base_Element="_N1sMcaf4EeW6jfwWQNiYcg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgYB31EeaVEcfXx-aEqQ" base_Element="_FVQ-0LpUEeWadf5Yweab7g"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgZR31EeaVEcfXx-aEqQ" base_Element="_0rPocNnXEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgZh31EeaVEcfXx-aEqQ" base_Element="_0rYyZNnXEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgaR31EeaVEcfXx-aEqQ" base_Element="_G1pfMNnfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgah31EeaVEcfXx-aEqQ" base_Element="_G1pfNdnfEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgeh31EeaVEcfXx-aEqQ" base_Element="_WSiGVd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgfB31EeaVEcfXx-aEqQ" base_Element="_cQujEN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgfh31EeaVEcfXx-aEqQ" base_Element="_gJx4Rd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxggB31EeaVEcfXx-aEqQ" base_Element="_rJUvBd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxggh31EeaVEcfXx-aEqQ" base_Element="_IZpp8N8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxghB31EeaVEcfXx-aEqQ" base_Element="_kZ4bhd71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxghh31EeaVEcfXx-aEqQ" base_Element="_CM28Fd72EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgiB31EeaVEcfXx-aEqQ" base_Element="__EdnwN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgih31EeaVEcfXx-aEqQ" base_Element="_tOFAld7rEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgjB31EeaVEcfXx-aEqQ" base_Element="_7DmpIN7vEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgjh31EeaVEcfXx-aEqQ" base_Element="_lqLYBd7wEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgkB31EeaVEcfXx-aEqQ" base_Element="_W9zh1d7-EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgkh31EeaVEcfXx-aEqQ" base_Element="_kTBiZd7xEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RJx31EeaVEcfXx-aEqQ" base_Element="_STzYAO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RKB31EeaVEcfXx-aEqQ" base_Element="_STzYBe_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RYR31EeaVEcfXx-aEqQ" base_Element="_-ht5oPMtEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RYx31EeaVEcfXx-aEqQ" base_Element="_0HRXMPMxEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RZB31EeaVEcfXx-aEqQ" base_Element="_0HRXMfMxEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RZR31EeaVEcfXx-aEqQ" base_Element="_l8oKkEpeEeW7b92SEnwDVg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RZx31EeaVEcfXx-aEqQ" base_Element="_qRQggLsEEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RaB31EeaVEcfXx-aEqQ" base_Element="_B2HeEPM4EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RaR31EeaVEcfXx-aEqQ" base_Element="_FmxFMPM4EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rax31EeaVEcfXx-aEqQ" base_Element="_mNsdwN6NEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RbB31EeaVEcfXx-aEqQ" base_Element="_2nCKYLsEEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RbR31EeaVEcfXx-aEqQ" base_Element="_QDy9YPM7EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rbh31EeaVEcfXx-aEqQ" base_Element="_bH8AQPM7EeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RcB31EeaVEcfXx-aEqQ" base_Element="_yctfALsEEeWYrqoqXLgguw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RcR31EeaVEcfXx-aEqQ" base_Element="_AgHtkVJFEeWDQNzGZgIgfQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rch31EeaVEcfXx-aEqQ" base_Element="_AgHtklJFEeWDQNzGZgIgfQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RdB31EeaVEcfXx-aEqQ" base_Element="_M2tAQ_VKEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RdR31EeaVEcfXx-aEqQ" base_Element="_QCEJAPVKEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rdh31EeaVEcfXx-aEqQ" base_Element="_QCEJAfVKEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="__NBzECM_EeaA8dOpokrEww" base_Association="_STzYAO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgjR31EeaVEcfXx-aEqQ" base_Element="_lqLYAN7wEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgix31EeaVEcfXx-aEqQ" base_Element="_7DdfMN7vEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgjx31EeaVEcfXx-aEqQ" base_Element="_W9zh0N7-EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxghx31EeaVEcfXx-aEqQ" base_Element="__ET2wN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgiR31EeaVEcfXx-aEqQ" base_Element="_tOFAkN7rEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgfx31EeaVEcfXx-aEqQ" base_Element="_rJUvAN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgfR31EeaVEcfXx-aEqQ" base_Element="_gJx4QN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgkR31EeaVEcfXx-aEqQ" base_Element="_kTBiYN7xEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWrx31EeaVEcfXx-aEqQ" base_Element="_LGsOIGkDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_LIrVIBXsEeaOevPmmmHXcA" base_Association="_LGsOIGkDEeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxghR31EeaVEcfXx-aEqQ" base_Element="_CM28EN72EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgex31EeaVEcfXx-aEqQ" base_Element="_cQkyEN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgeR31EeaVEcfXx-aEqQ" base_Element="_WSiGUN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxggR31EeaVEcfXx-aEqQ" base_Element="_IZggAN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxggx31EeaVEcfXx-aEqQ" base_Element="_kZ4bgN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvcDYx31EeaVEcfXx-aEqQ" base_Element="_7vdU8Gh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_7wyxsGh_EeWZEqTYAF8eqA" base_Class="_7vdU8Gh_EeWZEqTYAF8eqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XkB31EeaVEcfXx-aEqQ" base_Element="_i1UzkD-3EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_i4nYID-3EeWNAdBR30aJhw" base_Class="_i1UzkD-3EeWNAdBR30aJhw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0jh31EeaVEcfXx-aEqQ" base_Element="_KjZW_dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KkvaxNyKEeWXdJnxZxtFYA" base_Class="_KjZW_dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0iB31EeaVEcfXx-aEqQ" base_Element="_KjZW99yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KkvawtyKEeWXdJnxZxtFYA" base_Class="_KjZW99yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0gh31EeaVEcfXx-aEqQ" base_Element="_KjZW8dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KkvawNyKEeWXdJnxZxtFYA" base_Class="_KjZW8dyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-Ux31EeaVEcfXx-aEqQ" base_Element="_KjZXM9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Kk4ksdyKEeWXdJnxZxtFYA" base_Class="_KjZXM9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0mB31EeaVEcfXx-aEqQ" base_Element="_KjZXB9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Kkvax9yKEeWXdJnxZxtFYA" base_Class="_KjZXB9yKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ejyEk-KyEeSq5fATALSQkQ" base_Class="_ejyEgOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvl0qh31EeaVEcfXx-aEqQ" base_Element="_KjZXGdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_KkvazNyKEeWXdJnxZxtFYA" base_Class="_KjZXGdyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvu-ZR31EeaVEcfXx-aEqQ" base_Element="_KjZXXNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Kk4kvtyKEeWXdJnxZxtFYA" base_Class="_KjZXXNyKEeWXdJnxZxtFYA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_37fFU-MCEeSdZOEXoN8VDQ" base_Class="_37fFQOMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wuirhR31EeaVEcfXx-aEqQ" base_Element="_ejyEgOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ejyEmeKyEeSq5fATALSQkQ" base_Class="_ejyEgOKyEeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_37o2ReMCEeSdZOEXoN8VDQ" base_Class="_37fFQOMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rbx31EeaVEcfXx-aEqQ" base_Element="_AgHtkFJFEeWDQNzGZgIgfQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_AgN0MFJFEeWDQNzGZgIgfQ" base_Operation="_AgHtkFJFEeWDQNzGZgIgfQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rah31EeaVEcfXx-aEqQ" base_Element="_dACyYPMwEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_dACyYfMwEeSb-q8_djA2ng" base_Operation="_dACyYPMwEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RZh31EeaVEcfXx-aEqQ" base_Element="_N-W74PMwEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_N-W74fMwEeSb-q8_djA2ng" base_Operation="_N-W74PMwEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7Rcx31EeaVEcfXx-aEqQ" base_Element="_M2tAQPVKEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_M2tARPVKEeWQB8HQFBfkJQ" base_Operation="_M2tAQPVKEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_EGReIP5BEeSIs5T3yQwyyw" base_Operation="_taDjMPMvEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RYh31EeaVEcfXx-aEqQ" base_Element="_taDjMPMvEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_taDjMfMvEeSb-q8_djA2ng" base_Operation="_taDjMPMvEeSb-q8_djA2ng"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_QOouEC5xEea0_JngOlSKcA" base_Element="_QOoHAC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_RPCbIC5xEea0_JngOlSKcA" base_Element="_RPB0EC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_SXdbwC5xEea0_JngOlSKcA" base_Element="_SXc0sC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_TTQVoC5xEea0_JngOlSKcA" base_Element="_TTPukC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_UWAzIS5xEea0_JngOlSKcA" base_Element="_UWAzIC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WC-rQC5xEea0_JngOlSKcA" base_Element="_WC-EMC5xEea0_JngOlSKcA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_IAP54C59Eea0_JngOlSKcA" base_Association="_0rPocNnXEeWIOYiRCk5bbQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_xImb4-K4EeSq5fATALSQkQ" base_Class="_xImb0OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_xImb6eK4EeSq5fATALSQkQ" base_Class="_xImb0OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu2Nhh31EeaVEcfXx-aEqQ" base_Element="_xImb0OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_xImb6uK4EeSq5fATALSQkQ" base_Class="_xImb0OK4EeSq5fATALSQkQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wu_XeB31EeaVEcfXx-aEqQ" base_Element="_37fFQOMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_37o2RuMCEeSdZOEXoN8VDQ" base_Class="_37fFQOMCEeSdZOEXoN8VDQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LArf4TA8Eea4fKwSGMr6CA" base_Element="_LArf4DA8Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_7CCMQDM4EeaULOmJRJKM0Q" base_Association="_WSiGUN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_9fdQ8DM4EeaULOmJRJKM0Q" base_Association="_CM28EN72EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_M258EDM5EeaULOmJRJKM0Q" base_Association="_gJx4QN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_OWTSQDM5EeaULOmJRJKM0Q" base_Association="_kZ4bgN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_QSstgDM5EeaULOmJRJKM0Q" base_Association="_IZggAN8AEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_Rrz1gDM5EeaULOmJRJKM0Q" base_Association="__ET2wN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_TAKZUDM5EeaULOmJRJKM0Q" base_Association="_rJUvAN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_YbjrADM5EeaULOmJRJKM0Q" base_Association="_tOFAkN7rEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_ZhLPQDM5EeaULOmJRJKM0Q" base_Association="_7DdfMN7vEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_azmgcDM5EeaULOmJRJKM0Q" base_Association="_lqLYAN7wEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_ceaccDM5EeaULOmJRJKM0Q" base_Association="_kTBiYN7xEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_dvC94DM5EeaULOmJRJKM0Q" base_Association="_W9zh0N7-EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_-NONc96XEeWd9KDn6x5Skg" base_StructuralFeature="_-NONct6XEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iDpeNt6YEeWd9KDn6x5Skg" base_StructuralFeature="_iDpeNd6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgbR31EeaVEcfXx-aEqQ" base_Element="_-NFDgN6XEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgbh31EeaVEcfXx-aEqQ" base_Element="_-NONct6XEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgbx31EeaVEcfXx-aEqQ" base_Element="_JNPzcN7nEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgcB31EeaVEcfXx-aEqQ" base_Element="_JNZkcN7nEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgcR31EeaVEcfXx-aEqQ" base_Element="_iDpeMN6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgch31EeaVEcfXx-aEqQ" base_Element="_iDpeNd6YEeWd9KDn6x5Skg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgcx31EeaVEcfXx-aEqQ" base_Element="_LyFuwN7nEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgdB31EeaVEcfXx-aEqQ" base_Element="_LyFuwd7nEeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:ExtendedComposite xmi:id="_9RLnkDM8EeaULOmJRJKM0Q" base_Association="_cQkyEN71EeW-BtRsuJPbqg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Eui5cD6gEeai_egNtQKqQA" base_Element="_EuZIcD6gEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_Lrs40T6gEeai_egNtQKqQA" base_Element="_Lrs40D6gEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_PYdMgT6iEeai_egNtQKqQA" base_Element="_PYdMgD6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_R0GvkT6iEeai_egNtQKqQA" base_Element="_R0GvkD6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VNVVMT6iEeai_egNtQKqQA" base_Element="_VNVVMD6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_YMrbMT6iEeai_egNtQKqQA" base_Element="_YMrbMD6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_zB_30T6iEeai_egNtQKqQA" base_Element="_zB_30D6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_zB_30j6iEeai_egNtQKqQA" base_StructuralFeature="_zB_30D6iEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_FKRr0T6jEeai_egNtQKqQA" base_Element="_FKRr0D6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_FKRr0j6jEeai_egNtQKqQA" base_StructuralFeature="_FKRr0D6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_HJt0AT6jEeai_egNtQKqQA" base_Element="_HJt0AD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_HJt0Az6jEeai_egNtQKqQA" base_Element="_HJt0Aj6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_VJ4jIT6jEeai_egNtQKqQA" base_Element="_VJ4jID6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_VJ4jIj6jEeai_egNtQKqQA" base_StructuralFeature="_VJ4jID6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WDdPcT6jEeai_egNtQKqQA" base_Element="_WDdPcD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_WDdPcz6jEeai_egNtQKqQA" base_Element="_WDdPcj6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_aMoEQT6jEeai_egNtQKqQA" base_Element="_aMoEQD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_aMoEQj6jEeai_egNtQKqQA" base_StructuralFeature="_aMoEQD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_btxt8T6jEeai_egNtQKqQA" base_Element="_btxt8D6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_bt634T6jEeai_egNtQKqQA" base_Element="_bt634D6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_g9oeAT6jEeai_egNtQKqQA" base_Element="_g9oeAD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_g9oeAj6jEeai_egNtQKqQA" base_StructuralFeature="_g9oeAD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_iAAhAT6jEeai_egNtQKqQA" base_Element="_iAAhAD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_iAAhAz6jEeai_egNtQKqQA" base_Element="_iAAhAj6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_or7mcj6jEeai_egNtQKqQA" base_Element="_or7mcD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_or7mcz6jEeai_egNtQKqQA" base_StructuralFeature="_or7mcD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_or7mdD6jEeai_egNtQKqQA" base_Element="_or7mcT6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_u_PXkj6jEeai_egNtQKqQA" base_Element="_u_PXkD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_u_PXkz6jEeai_egNtQKqQA" base_StructuralFeature="_u_PXkD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_u_PXlD6jEeai_egNtQKqQA" base_Element="_u_PXkT6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wlCQsD6jEeai_egNtQKqQA" base_Element="_wk4fsD6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wlCQsj6jEeai_egNtQKqQA" base_Element="_wlCQsT6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_xq1bIT6jEeai_egNtQKqQA" base_Element="_xq1bID6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_xq1bIz6jEeai_egNtQKqQA" base_Element="_xq1bIj6jEeai_egNtQKqQA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_rS5u4kNoEeaF1NC7HRCQgw" base_Element="_rS5u4ENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_rS5u40NoEeaF1NC7HRCQgw" base_StructuralFeature="_rS5u4ENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_rS5u5ENoEeaF1NC7HRCQgw" base_Element="_rS5u4UNoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ywQ4UUNoEeaF1NC7HRCQgw" base_Element="_ywQ4UENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ywQ4UkNoEeaF1NC7HRCQgw" base_StructuralFeature="_ywQ4UENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_1PqS8ENoEeaF1NC7HRCQgw" base_StructuralFeature="_rS5u4ENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_30ve0ENoEeaF1NC7HRCQgw" base_StructuralFeature="_ywQ4UENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_6v0v4UNoEeaF1NC7HRCQgw" base_Element="_6v0v4ENoEeaF1NC7HRCQgw"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oDy10ETtEead1bezhJG4aw" base_Class="_oCmjAETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_oDy10UTtEead1bezhJG4aw" base_Element="_oCmjAETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_uF7-cUTtEead1bezhJG4aw" base_Element="_uF7-cETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_v4NNUUTtEead1bezhJG4aw" base_Element="_v4NNUETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_v4NNVUTtEead1bezhJG4aw" base_StructuralFeature="_v4NNVETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_v4NNVkTtEead1bezhJG4aw" base_Element="_v4NNVETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_v4W-UUTtEead1bezhJG4aw" base_StructuralFeature="_v4W-UETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_v4W-UkTtEead1bezhJG4aw" base_Element="_v4W-UETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1QQQEUTtEead1bezhJG4aw" base_Element="_1QQQEETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_1QaBEUTtEead1bezhJG4aw" base_Element="_1QaBEETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_9aQdEUTtEead1bezhJG4aw" base_Element="_9aQdEETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_9aQdE0TtEead1bezhJG4aw" base_Element="_9aQdEkTtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_ko4_wkTuEead1bezhJG4aw" base_StructuralFeature="_ko4_wETuEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ko4_w0TuEead1bezhJG4aw" base_Element="_ko4_wETuEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ko4_xETuEead1bezhJG4aw" base_Element="_ko4_wUTuEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yEfCMkTuEead1bezhJG4aw" base_StructuralFeature="_yEfCMETuEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yEfCM0TuEead1bezhJG4aw" base_Element="_yEfCMETuEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_yEfCNETuEead1bezhJG4aw" base_Element="_yEfCMUTuEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_z2ADIETuEead1bezhJG4aw" base_StructuralFeature="_ko4_wETuEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_2UmMgETuEead1bezhJG4aw" base_StructuralFeature="_yEfCMETuEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7GUK4kT1Eead1bezhJG4aw" base_StructuralFeature="_7GUK4ET1Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7GUK40T1Eead1bezhJG4aw" base_Element="_7GUK4ET1Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_7GUK5ET1Eead1bezhJG4aw" base_Element="_7GUK4UT1Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BCToMkT2Eead1bezhJG4aw" base_StructuralFeature="_BCToMET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BCToM0T2Eead1bezhJG4aw" base_Element="_BCToMET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BCToNET2Eead1bezhJG4aw" base_Element="_BCToMUT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_ERI7sET2Eead1bezhJG4aw" base_StructuralFeature="_7GUK4ET1Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_Fxt9oET2Eead1bezhJG4aw" base_StructuralFeature="_BCToMET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_LErsEkT2Eead1bezhJG4aw" base_StructuralFeature="_LErsEET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LErsE0T2Eead1bezhJG4aw" base_Element="_LErsEET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LErsFET2Eead1bezhJG4aw" base_Element="_LErsEUT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_Q51hkET2Eead1bezhJG4aw" base_StructuralFeature="_LErsEET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_V5vxIkT2Eead1bezhJG4aw" base_StructuralFeature="_V5vxIET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_V5vxI0T2Eead1bezhJG4aw" base_Element="_V5vxIET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_V5vxJET2Eead1bezhJG4aw" base_Element="_V5vxIUT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_Z1WEAET2Eead1bezhJG4aw" base_StructuralFeature="_V5vxIET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_fJEnckT2Eead1bezhJG4aw" base_StructuralFeature="_fJEncET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_fJEnc0T2Eead1bezhJG4aw" base_Element="_fJEncET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_fJEndET2Eead1bezhJG4aw" base_Element="_fJEncUT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jW-yUET2Eead1bezhJG4aw" base_StructuralFeature="_jW1BUET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_jW-yUUT2Eead1bezhJG4aw" base_Element="_jW1BUET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_jW-yUkT2Eead1bezhJG4aw" base_Element="_jW1BUUT2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_pNR3UET2Eead1bezhJG4aw" base_StructuralFeature="_fJEncET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_q6oJ8ET2Eead1bezhJG4aw" base_StructuralFeature="_jW1BUET2Eead1bezhJG4aw"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_VQf9cEmkEeaKuvClDq6rqA" base_StructuralFeature="_v4NNVETtEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_3Qgr4Um0EeaKuvClDq6rqA" base_Element="_3Qgr4Em0EeaKuvClDq6rqA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_dT_qEUm1EeaKuvClDq6rqA" base_Element="_dT_qEEm1EeaKuvClDq6rqA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MM6iEUHBEeWqPKyD1j6LMg" base_StructuralFeature="_MM6iEEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWlh31EeaVEcfXx-aEqQ" base_Element="_MM6iEEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWlx31EeaVEcfXx-aEqQ" base_Element="_eKdFsEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWmB31EeaVEcfXx-aEqQ" base_Element="_eKfh8EHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MM8XQEHBEeWqPKyD1j6LMg" base_StructuralFeature="_MM7wMEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:PruneAndRefactor xmi:id="_j2tuUJ1dEeWAQercC81WNA" base_Realization="_ek0W4J1dEeWAQercC81WNA"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_6vylYKIfEeWDu_9VgujMbw" base_StructuralFeature="_MM7wMEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIfh31EeaVEcfXx-aEqQ" base_Element="_MM7wMEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIfx31EeaVEcfXx-aEqQ" base_Element="_euOhIEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wvJIgB31EeaVEcfXx-aEqQ" base_Element="_euQ9YEHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwoWlR31EeaVEcfXx-aEqQ" base_Element="_MM4s4EHBEeWqPKyD1j6LMg"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwxgSR31EeaVEcfXx-aEqQ" base_Element="_ek0W4J1dEeWAQercC81WNA"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/TapiVirtualNetwork.uml
+++ b/xmi2yang tool-v2.0/project/TapiVirtualNetwork.uml
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_zUTaADOEEeansfg7-s4Unw/16 /TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw">
+  <uml:Model xmi:id="_K39JEDA5Eea4fKwSGMr6CA" name="TapiVirtualNetwork">
+    <packagedElement xmi:type="uml:Package" xmi:id="_P2OtwC50Eea0_JngOlSKcA" name="Associations">
+      <packagedElement xmi:type="uml:Association" xmi:id="_9CCfAPTYEeWQB8HQFBfkJQ" name="VNwServiceHasServicePorts" memberEnd="_9DOx0vTYEeWQB8HQFBfkJQ _9DYi0PTYEeWQB8HQFBfkJQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_9DOx0PTYEeWQB8HQFBfkJQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_9DOx0fTYEeWQB8HQFBfkJQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_9DYi0PTYEeWQB8HQFBfkJQ" name="_service" type="_--7mUPTUEeWQB8HQFBfkJQ" association="_9CCfAPTYEeWQB8HQFBfkJQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_fr8GsPTjEeWQB8HQFBfkJQ" name="VNwServiceHasVNwConstraints" memberEnd="_fr8Gs_TjEeWQB8HQFBfkJQ _fr8GtfTjEeWQB8HQFBfkJQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fr8GsfTjEeWQB8HQFBfkJQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_fr8GsvTjEeWQB8HQFBfkJQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_fr8GtfTjEeWQB8HQFBfkJQ" name="_service" type="_--7mUPTUEeWQB8HQFBfkJQ" association="_fr8GsPTjEeWQB8HQFBfkJQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_c2U6IPVUEeWQB8HQFBfkJQ" name="CreatesDeletesVirtualNwService" client="_02QCUPUlEeWQB8HQFBfkJQ" supplier="_--7mUPTUEeWQB8HQFBfkJQ"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_N1FvkPVUEeWQB8HQFBfkJQ" name="RetrievesVirtualNwService" client="_02QCUPUlEeWQB8HQFBfkJQ" supplier="_--7mUPTUEeWQB8HQFBfkJQ"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_oWBRAPTaEeWQB8HQFBfkJQ" name="VNwServiceHasTopology" memberEnd="_oWBRA_TaEeWQB8HQFBfkJQ _oWBRBfTaEeWQB8HQFBfkJQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oWBRAfTaEeWQB8HQFBfkJQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oWBRAvTaEeWQB8HQFBfkJQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_oWBRBfTaEeWQB8HQFBfkJQ" name="_vnwService" type="_--7mUPTUEeWQB8HQFBfkJQ" association="_oWBRAPTaEeWQB8HQFBfkJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_u8augPTgEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_u8augfTgEeWQB8HQFBfkJQ" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_PryBUPTZEeWQB8HQFBfkJQ" name="VNwServicePortTerminatesOnServiceEP" memberEnd="_PryBU_TZEeWQB8HQFBfkJQ _PryBVfTZEeWQB8HQFBfkJQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_PryBUfTZEeWQB8HQFBfkJQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PryBUvTZEeWQB8HQFBfkJQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_PryBVfTZEeWQB8HQFBfkJQ" name="_vnwServicePort" type="_pbiZgPTYEeWQB8HQFBfkJQ" association="_PryBUPTZEeWQB8HQFBfkJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_bwYboPTZEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_bwYbofTZEeWQB8HQFBfkJQ" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_MS8H8D3wEea-1_BGg-qcjQ" name="VNwConstrHasSinkSvcEP" memberEnd="_MTF48j3wEea-1_BGg-qcjQ _MTF49T3wEea-1_BGg-qcjQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_MTF48D3wEea-1_BGg-qcjQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_MTF48T3wEea-1_BGg-qcjQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_MTF49T3wEea-1_BGg-qcjQ" name="virtualnetworkconstraint" type="_BBDOEPTgEeWQB8HQFBfkJQ" association="_MS8H8D3wEea-1_BGg-qcjQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xkGRUD3wEea-1_BGg-qcjQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xkGRUj3wEea-1_BGg-qcjQ" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_IYXv0D3wEea-1_BGg-qcjQ" name="VnwConstrHasSrcSvcEP" memberEnd="_IYXv1D3wEea-1_BGg-qcjQ _IYhg0D3wEea-1_BGg-qcjQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IYXv0j3wEea-1_BGg-qcjQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IYXv0z3wEea-1_BGg-qcjQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_IYhg0D3wEea-1_BGg-qcjQ" name="virtualnetworkconstraint" type="_BBDOEPTgEeWQB8HQFBfkJQ" association="_IYXv0D3wEea-1_BGg-qcjQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_tbFNgD3wEea-1_BGg-qcjQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tbFNgj3wEea-1_BGg-qcjQ" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_3TaNAEXREeaB8vMnkFQLXQ" name="VNwHasDiversityExclusions" memberEnd="_3TbbIkXREeaB8vMnkFQLXQ _3TbbJUXREeaB8vMnkFQLXQ">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_3TbbIEXREeaB8vMnkFQLXQ" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_3TbbIUXREeaB8vMnkFQLXQ" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_3TbbJUXREeaB8vMnkFQLXQ" name="_vnwConstraint" type="_BBDOEPTgEeWQB8HQFBfkJQ" association="_3TaNAEXREeaB8vMnkFQLXQ"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_RD4zsC50Eea0_JngOlSKcA" name="Diagrams"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_LFrv4C50Eea0_JngOlSKcA" name="Imports">
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_sPRnMDBGEeam35bpdXJzEw">
+        <importedPackage xmi:type="uml:Model" href="TapiTopology.uml#_nbYiwDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+      <packageImport xmi:type="uml:PackageImport" xmi:id="_h_MjgDKAEeapu9k56t8ZKQ">
+        <importedPackage xmi:type="uml:Model" href="Tapi.uml#_cOw5UDA4Eea4fKwSGMr6CA"/>
+      </packageImport>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_MJbr4C50Eea0_JngOlSKcA" name="Interfaces">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_02QCUPUlEeWQB8HQFBfkJQ" name="VirtualNetworkService" isLeaf="true">
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_02QCaPUlEeWQB8HQFBfkJQ" name="createVirtualNetworkService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCafUlEeWQB8HQFBfkJQ" name="servicePort" type="_pbiZgPTYEeWQB8HQFBfkJQ" isUnique="false" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_02QCavUlEeWQB8HQFBfkJQ" value="2"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_02QCa_UlEeWQB8HQFBfkJQ" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbPUlEeWQB8HQFBfkJQ" name="vnwConstraint" type="_BBDOEPTgEeWQB8HQFBfkJQ" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbfUlEeWQB8HQFBfkJQ" name="connSchedule" isUnique="false" effect="read">
+            <type xmi:type="uml:Class" href="Tapi.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+          </ownedParameter>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCbvUlEeWQB8HQFBfkJQ" name="vnwService" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_02QCdPUlEeWQB8HQFBfkJQ" name="deleteVirtualNetworkService" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCdfUlEeWQB8HQFBfkJQ" name="serviceIdOrName" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_02QCdvUlEeWQB8HQFBfkJQ" name="vnwService" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out" effect="delete"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_CK3tgPU7EeWQB8HQFBfkJQ" name="getVirtualNetworkServiceDetails" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_CK3tgfU7EeWQB8HQFBfkJQ" name="serviceIdOrName" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_CK3tgvU7EeWQB8HQFBfkJQ" name="vnwService" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out" effect="read"/>
+        </ownedOperation>
+        <ownedOperation xmi:type="uml:Operation" xmi:id="_KfrcUPU7EeWQB8HQFBfkJQ" name="getVirtualNetworkServiceList" isLeaf="true">
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_KfrcUfU7EeWQB8HQFBfkJQ" name="vnwService" type="_--7mUPTUEeWQB8HQFBfkJQ" direction="out" effect="read">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_KfrcUvU7EeWQB8HQFBfkJQ"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KfrcU_U7EeWQB8HQFBfkJQ" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_NT9lUC50Eea0_JngOlSKcA" name="ObjectClasses">
+      <packagedElement xmi:type="uml:Class" xmi:id="_BBDOEPTgEeWQB8HQFBfkJQ" name="VirtualNetworkConstraint">
+        <generalization xmi:type="uml:Generalization" xmi:id="_TtSeMD4zEea-1_BGg-qcjQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IYXv1D3wEea-1_BGg-qcjQ" name="_srcServiceEndPoint" isReadOnly="true" association="_IYXv0D3wEea-1_BGg-qcjQ">
+          <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_MTF48j3wEea-1_BGg-qcjQ" name="_sinkServiceEndPoint" isReadOnly="true" association="_MS8H8D3wEea-1_BGg-qcjQ">
+          <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3TbbIkXREeaB8vMnkFQLXQ" name="_diversityExclusion" type="_BBDOEPTgEeWQB8HQFBfkJQ" association="_3TaNAEXREeaB8vMnkFQLXQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BImwgEXSEeaB8vMnkFQLXQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BIpz0EXSEeaB8vMnkFQLXQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BBDOGfTgEeWQB8HQFBfkJQ" name="requestedCapacity">
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_rNbewL1-EeWdore3Cxez9g"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BBDOEvTgEeWQB8HQFBfkJQ" name="serviceLevel">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_BBDOE_TgEeWQB8HQFBfkJQ">
+            <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BBDOFPTgEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BBDOFfTgEeWQB8HQFBfkJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BBDOFvTgEeWQB8HQFBfkJQ" name="serviceLayer">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BBDOF_TgEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BBDOGPTgEeWQB8HQFBfkJQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BBDOGvTgEeWQB8HQFBfkJQ" name="costCharacteristic" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_BBDOG_TgEeWQB8HQFBfkJQ" annotatedElement="_BBDOGvTgEeWQB8HQFBfkJQ">
+            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BBDOHPTgEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BBDOHfTgEeWQB8HQFBfkJQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BBDOIvTgEeWQB8HQFBfkJQ" name="latencyCharacteristic" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_BBDOI_TgEeWQB8HQFBfkJQ" annotatedElement="_BBDOIvTgEeWQB8HQFBfkJQ">
+            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
+          </ownedComment>
+          <type xmi:type="uml:DataType" href="TapiTopology.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_BBDOJPTgEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_BBDOJfTgEeWQB8HQFBfkJQ" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_--7mUPTUEeWQB8HQFBfkJQ" name="VirtualNetworkService" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_--7mUfTUEeWQB8HQFBfkJQ" annotatedElement="_--7mUPTUEeWQB8HQFBfkJQ">
+          <body>The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.&#xD;
+&#xD;
+At the lowest level of recursion, a FC represents a cross-connection within an NE.</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_--7mUvTUEeWQB8HQFBfkJQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_zC-54D3fEea-1_BGg-qcjQ"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_OdvxEETfEead1bezhJG4aw" name="serviceSpecification" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_OdvxEUTfEead1bezhJG4aw" value="/TapiVirtualNetwork:VirtualNetworkService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_36HEED3jEea-1_BGg-qcjQ"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_XuLaoETfEead1bezhJG4aw" name="serviceSpecTarget" isReadOnly="true">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_XuLaoUTfEead1bezhJG4aw" value="/Tapi:Context/Tapi:_vnwService"/>
+          <redefinedProperty xmi:type="uml:Property" href="Tapi.uml#_4oopgEJuEea-2Meh9kw1kA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oWBRA_TaEeWQB8HQFBfkJQ" name="_topology" isReadOnly="true" aggregation="composite" association="_oWBRAPTaEeWQB8HQFBfkJQ">
+          <type xmi:type="uml:Class" href="TapiTopology.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wU0E0PTgEeWQB8HQFBfkJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wU0E0fTgEeWQB8HQFBfkJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9DOx0vTYEeWQB8HQFBfkJQ" name="_servicePort" type="_pbiZgPTYEeWQB8HQFBfkJQ" aggregation="composite" association="_9CCfAPTYEeWQB8HQFBfkJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FlZAIPTZEeWQB8HQFBfkJQ" value="2"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FlZAIfTZEeWQB8HQFBfkJQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_fr8Gs_TjEeWQB8HQFBfkJQ" name="_vnwConstraint" type="_BBDOEPTgEeWQB8HQFBfkJQ" aggregation="composite" association="_fr8GsPTjEeWQB8HQFBfkJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jxpqkD3vEea-1_BGg-qcjQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jxy0gD3vEea-1_BGg-qcjQ" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_--7mWvTUEeWQB8HQFBfkJQ" name="_schedule" aggregation="composite">
+          <type xmi:type="uml:Class" href="Tapi.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_--7mW_TUEeWQB8HQFBfkJQ" name="_state" aggregation="composite">
+          <type xmi:type="uml:Class" href="Tapi.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_--7mXPTUEeWQB8HQFBfkJQ" name="layerProtocolName" visibility="public">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_--7mXfTUEeWQB8HQFBfkJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_--7mXvTUEeWQB8HQFBfkJQ" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_pbiZgPTYEeWQB8HQFBfkJQ" name="VirtualNetworkServicePort" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_pbiZgfTYEeWQB8HQFBfkJQ" annotatedElement="_pbiZgPTYEeWQB8HQFBfkJQ">
+          <body>The association of the FC to LTPs is made via EndPoints.&#xD;
+The EndPoint (EP) object class models the access to the FC function. &#xD;
+The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  &#xD;
+In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. &#xD;
+It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.&#xD;
+The EP replaces the Protection Unit of a traditional protection model. &#xD;
+The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component</body>
+        </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_pbiZgvTYEeWQB8HQFBfkJQ">
+          <general xmi:type="uml:Class" href="Tapi.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
+        </generalization>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PryBU_TZEeWQB8HQFBfkJQ" name="_serviceEndPoint" isReadOnly="true" association="_PryBUPTZEeWQB8HQFBfkJQ">
+          <type xmi:type="uml:Class" href="Tapi.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZpvfQPTZEeWQB8HQFBfkJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Zp5QQPTZEeWQB8HQFBfkJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pbiZhPTYEeWQB8HQFBfkJQ" name="role" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pbiZhfTYEeWQB8HQFBfkJQ" annotatedElement="_pbiZhPTYEeWQB8HQFBfkJQ">
+            <body>Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. </body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_EILagL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pbiZhvTYEeWQB8HQFBfkJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pbiZh_TYEeWQB8HQFBfkJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pbiZiPTYEeWQB8HQFBfkJQ" name="direction" visibility="public" isReadOnly="true">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_pbiZifTYEeWQB8HQFBfkJQ" annotatedElement="_pbiZiPTYEeWQB8HQFBfkJQ">
+            <body>The orientation of defined flow at the EndPoint.</body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_dLDeINnjEeWIOYiRCk5bbQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pbiZivTYEeWQB8HQFBfkJQ" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pbiZi_TYEeWQB8HQFBfkJQ" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_pbiZjPTYEeWQB8HQFBfkJQ" name="serviceLayer" isReadOnly="true">
+          <type xmi:type="uml:Enumeration" href="Tapi.uml#_i92HIL6PEeWRz-VHgA3LJQ"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pbiZjfTYEeWQB8HQFBfkJQ"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pbiZjvTYEeWQB8HQFBfkJQ" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_LPnbpDA5Eea4fKwSGMr6CA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aML0LDOGEeansfg7-s4Unw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aML0LTOGEeansfg7-s4Unw" key="Version" value="0.2.4"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aML0LjOGEeansfg7-s4Unw" key="Comment" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aML0LzOGEeansfg7-s4Unw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aML0MDOGEeansfg7-s4Unw" key="Date" value="2016-06-16"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aML0MTOGEeansfg7-s4Unw" key="Author" value="TAPI"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_LPnbpTA5Eea4fKwSGMr6CA" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="/TapiModel/OpenModel_Profile.profile.uml#_zUTaATOEEeansfg7-s4Unw"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="/TapiModel/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LQp88DA5Eea4fKwSGMr6CA" base_Element="_K39JEDA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LQp88TA5Eea4fKwSGMr6CA" base_Element="_LPnbpDA5Eea4fKwSGMr6CA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__A3gBPTUEeWQB8HQFBfkJQ" base_StructuralFeature="_--7mWvTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__A3gBfTUEeWQB8HQFBfkJQ" base_StructuralFeature="_--7mW_TUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="__A3gBvTUEeWQB8HQFBfkJQ" base_StructuralFeature="_--7mXPTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pbiZkfTYEeWQB8HQFBfkJQ" base_StructuralFeature="_pbiZhPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pbiZkvTYEeWQB8HQFBfkJQ" base_StructuralFeature="_pbiZiPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_pbiZk_TYEeWQB8HQFBfkJQ" base_StructuralFeature="_pbiZjPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9DOx0_TYEeWQB8HQFBfkJQ" base_StructuralFeature="_9DOx0vTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9DYi0fTYEeWQB8HQFBfkJQ" base_StructuralFeature="_9DYi0PTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PryBVPTZEeWQB8HQFBfkJQ" base_StructuralFeature="_PryBU_TZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_PryBVvTZEeWQB8HQFBfkJQ" base_StructuralFeature="_PryBVfTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_uAhLIPTZEeWQB8HQFBfkJQ" base_StructuralFeature="_PryBU_TZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oWBRBPTaEeWQB8HQFBfkJQ" base_StructuralFeature="_oWBRA_TaEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oWBRBvTaEeWQB8HQFBfkJQ" base_StructuralFeature="_oWBRBfTaEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BCYq0vTgEeWQB8HQFBfkJQ" base_StructuralFeature="_BBDOEvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BCYq0_TgEeWQB8HQFBfkJQ" base_StructuralFeature="_BBDOFvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BCYq1PTgEeWQB8HQFBfkJQ" base_StructuralFeature="_BBDOGfTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BCYq1fTgEeWQB8HQFBfkJQ" base_StructuralFeature="_BBDOGvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_BCYq1_TgEeWQB8HQFBfkJQ" base_StructuralFeature="_BBDOIvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:PassedByReference xmi:id="_6vnaUPThEeWQB8HQFBfkJQ" base_StructuralFeature="_oWBRA_TaEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_fr8GtPTjEeWQB8HQFBfkJQ" base_StructuralFeature="_fr8Gs_TjEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_fr8GtvTjEeWQB8HQFBfkJQ" base_StructuralFeature="_fr8GtfTjEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelInterface xmi:id="_03cVIPUlEeWQB8HQFBfkJQ" base_Interface="_02QCUPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_03cVNfUlEeWQB8HQFBfkJQ" base_Parameter="_02QCafUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_03cVNvUlEeWQB8HQFBfkJQ" base_Parameter="_02QCbPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_03cVN_UlEeWQB8HQFBfkJQ" base_Parameter="_02QCbfUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_03cVOPUlEeWQB8HQFBfkJQ" base_Parameter="_02QCbvUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_03cVP_UlEeWQB8HQFBfkJQ" base_Parameter="_02QCdfUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_03cVQPUlEeWQB8HQFBfkJQ" base_Parameter="_02QCdvUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_CMgsQfU7EeWQB8HQFBfkJQ" base_Parameter="_CK3tgfU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_CMgsQvU7EeWQB8HQFBfkJQ" base_Parameter="_CK3tgvU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelParameter xmi:id="_Kg3vIfU7EeWQB8HQFBfkJQ" base_Parameter="_KfrcUfU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqfh31EeaVEcfXx-aEqQ" base_Element="_--7mUfTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqfx31EeaVEcfXx-aEqQ" base_Element="_--7mUvTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqgB31EeaVEcfXx-aEqQ" base_Element="_oWBRA_TaEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqgR31EeaVEcfXx-aEqQ" base_Element="_wU0E0PTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqgh31EeaVEcfXx-aEqQ" base_Element="_wU0E0fTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqgx31EeaVEcfXx-aEqQ" base_Element="_9DOx0vTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqhB31EeaVEcfXx-aEqQ" base_Element="_FlZAIPTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqhR31EeaVEcfXx-aEqQ" base_Element="_FlZAIfTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqhh31EeaVEcfXx-aEqQ" base_Element="_fr8Gs_TjEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqhx31EeaVEcfXx-aEqQ" base_Element="_--7mWvTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqiB31EeaVEcfXx-aEqQ" base_Element="_--7mW_TUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqiR31EeaVEcfXx-aEqQ" base_Element="_--7mXPTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqih31EeaVEcfXx-aEqQ" base_Element="_--7mXfTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqix31EeaVEcfXx-aEqQ" base_Element="_--7mXvTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqjR31EeaVEcfXx-aEqQ" base_Element="_pbiZgfTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqjh31EeaVEcfXx-aEqQ" base_Element="_pbiZgvTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqjx31EeaVEcfXx-aEqQ" base_Element="_PryBU_TZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqkB31EeaVEcfXx-aEqQ" base_Element="_ZpvfQPTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqkR31EeaVEcfXx-aEqQ" base_Element="_Zp5QQPTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqkh31EeaVEcfXx-aEqQ" base_Element="_pbiZhPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqkx31EeaVEcfXx-aEqQ" base_Element="_pbiZhfTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqlB31EeaVEcfXx-aEqQ" base_Element="_pbiZhvTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqlR31EeaVEcfXx-aEqQ" base_Element="_pbiZh_TYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqlh31EeaVEcfXx-aEqQ" base_Element="_pbiZiPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqlx31EeaVEcfXx-aEqQ" base_Element="_pbiZifTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqmB31EeaVEcfXx-aEqQ" base_Element="_pbiZivTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqmR31EeaVEcfXx-aEqQ" base_Element="_pbiZi_TYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqmh31EeaVEcfXx-aEqQ" base_Element="_pbiZjPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqmx31EeaVEcfXx-aEqQ" base_Element="_pbiZjfTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqnB31EeaVEcfXx-aEqQ" base_Element="_pbiZjvTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqnx31EeaVEcfXx-aEqQ" base_Element="_BBDOEvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqoB31EeaVEcfXx-aEqQ" base_Element="_BBDOE_TgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqoR31EeaVEcfXx-aEqQ" base_Element="_BBDOFPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqoh31EeaVEcfXx-aEqQ" base_Element="_BBDOFfTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqox31EeaVEcfXx-aEqQ" base_Element="_BBDOFvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqpB31EeaVEcfXx-aEqQ" base_Element="_BBDOF_TgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqpR31EeaVEcfXx-aEqQ" base_Element="_BBDOGPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqph31EeaVEcfXx-aEqQ" base_Element="_BBDOGfTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqpx31EeaVEcfXx-aEqQ" base_Element="_BBDOGvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqqB31EeaVEcfXx-aEqQ" base_Element="_BBDOG_TgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqqR31EeaVEcfXx-aEqQ" base_Element="_BBDOHPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqqh31EeaVEcfXx-aEqQ" base_Element="_BBDOHfTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqrx31EeaVEcfXx-aEqQ" base_Element="_BBDOIvTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqsB31EeaVEcfXx-aEqQ" base_Element="_BBDOI_TgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqsR31EeaVEcfXx-aEqQ" base_Element="_BBDOJPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqsh31EeaVEcfXx-aEqQ" base_Element="_BBDOJfTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RPh31EeaVEcfXx-aEqQ" base_Element="_9DYi0PTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RPx31EeaVEcfXx-aEqQ" base_Element="_oWBRAPTaEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RQB31EeaVEcfXx-aEqQ" base_Element="_oWBRBfTaEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RQR31EeaVEcfXx-aEqQ" base_Element="_u8augPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RQh31EeaVEcfXx-aEqQ" base_Element="_u8augfTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RQx31EeaVEcfXx-aEqQ" base_Element="_PryBUPTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RRB31EeaVEcfXx-aEqQ" base_Element="_PryBVfTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RRR31EeaVEcfXx-aEqQ" base_Element="_bwYboPTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RRh31EeaVEcfXx-aEqQ" base_Element="_bwYbofTZEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RTh31EeaVEcfXx-aEqQ" base_Element="_fr8GtfTjEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RTx31EeaVEcfXx-aEqQ" base_Element="_c2U6IPVUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RUB31EeaVEcfXx-aEqQ" base_Element="_N1FvkPVUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCMh31EeaVEcfXx-aEqQ" base_Element="_02QCUPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCNB31EeaVEcfXx-aEqQ" base_Element="_02QCafUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCNR31EeaVEcfXx-aEqQ" base_Element="_02QCavUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCNh31EeaVEcfXx-aEqQ" base_Element="_02QCa_UlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCNx31EeaVEcfXx-aEqQ" base_Element="_02QCbPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCOB31EeaVEcfXx-aEqQ" base_Element="_02QCbfUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCOR31EeaVEcfXx-aEqQ" base_Element="_02QCbvUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCOx31EeaVEcfXx-aEqQ" base_Element="_02QCdfUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCPB31EeaVEcfXx-aEqQ" base_Element="_02QCdvUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCPh31EeaVEcfXx-aEqQ" base_Element="_CK3tgfU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCPx31EeaVEcfXx-aEqQ" base_Element="_CK3tgvU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCQR31EeaVEcfXx-aEqQ" base_Element="_KfrcUfU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCQh31EeaVEcfXx-aEqQ" base_Element="_KfrcUvU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCQx31EeaVEcfXx-aEqQ" base_Element="_KfrcU_U7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RPR31EeaVEcfXx-aEqQ" base_Element="_9CCfAPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_FtJDQBYdEeaOevPmmmHXcA" base_Association="_9CCfAPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_ww7RTR31EeaVEcfXx-aEqQ" base_Element="_fr8GsPTjEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_ldAtcPTjEeWQB8HQFBfkJQ" base_Association="_fr8GsPTjEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqnR31EeaVEcfXx-aEqQ" base_Element="_BBDOEPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_BCYq0PTgEeWQB8HQFBfkJQ" base_Class="_BBDOEPTgEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqfR31EeaVEcfXx-aEqQ" base_Element="_--7mUPTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="__A3gAPTUEeWQB8HQFBfkJQ" base_Class="_--7mUPTUEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wwLqjB31EeaVEcfXx-aEqQ" base_Element="_pbiZgPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_pbiZj_TYEeWQB8HQFBfkJQ" base_Class="_pbiZgPTYEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCMx31EeaVEcfXx-aEqQ" base_Element="_02QCaPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_03cVNPUlEeWQB8HQFBfkJQ" base_Operation="_02QCaPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCOh31EeaVEcfXx-aEqQ" base_Element="_02QCdPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_03cVPvUlEeWQB8HQFBfkJQ" base_Operation="_02QCdPUlEeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCPR31EeaVEcfXx-aEqQ" base_Element="_CK3tgPU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_CMgsQPU7EeWQB8HQFBfkJQ" base_Operation="_CK3tgPU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_wxFCQB31EeaVEcfXx-aEqQ" base_Element="_KfrcUPU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_Kg3vIPU7EeWQB8HQFBfkJQ" base_Operation="_KfrcUPU7EeWQB8HQFBfkJQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_LFsW8C50Eea0_JngOlSKcA" base_Element="_LFrv4C50Eea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MJbr4S50Eea0_JngOlSKcA" base_Element="_MJbr4C50Eea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_NT9lUS50Eea0_JngOlSKcA" base_Element="_NT9lUC50Eea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_P2OtwS50Eea0_JngOlSKcA" base_Element="_P2OtwC50Eea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_RD5awC50Eea0_JngOlSKcA" base_Element="_RD4zsC50Eea0_JngOlSKcA"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_sPRnMTBGEeam35bpdXJzEw" base_Element="_sPRnMDBGEeam35bpdXJzEw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_h_MjgTKAEeapu9k56t8ZKQ" base_Element="_h_MjgDKAEeapu9k56t8ZKQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_jxpqkT3vEea-1_BGg-qcjQ" base_Element="_jxpqkD3vEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_jxy0gT3vEea-1_BGg-qcjQ" base_Element="_jxy0gD3vEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IYXv0T3wEea-1_BGg-qcjQ" base_Element="_IYXv0D3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IYXv1T3wEea-1_BGg-qcjQ" base_Element="_IYXv1D3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IYXv1j3wEea-1_BGg-qcjQ" base_StructuralFeature="_IYXv1D3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MS8H8T3wEea-1_BGg-qcjQ" base_Element="_MS8H8D3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MTF48z3wEea-1_BGg-qcjQ" base_Element="_MTF48j3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MTF49D3wEea-1_BGg-qcjQ" base_StructuralFeature="_MTF48j3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_tbFNgT3wEea-1_BGg-qcjQ" base_Element="_tbFNgD3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_tbFNgz3wEea-1_BGg-qcjQ" base_Element="_tbFNgj3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_xkGRUT3wEea-1_BGg-qcjQ" base_Element="_xkGRUD3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_xkGRUz3wEea-1_BGg-qcjQ" base_Element="_xkGRUj3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_TtSeMT4zEea-1_BGg-qcjQ" base_Element="_TtSeMD4zEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_IYhg0T3wEea-1_BGg-qcjQ" base_Element="_IYhg0D3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_IlnhoD3wEea-1_BGg-qcjQ" base_StructuralFeature="_IYhg0D3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_MTF49j3wEea-1_BGg-qcjQ" base_Element="_MTF49T3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_MTF49z3wEea-1_BGg-qcjQ" base_StructuralFeature="_MTF49T3wEea-1_BGg-qcjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_OdvxEkTfEead1bezhJG4aw" base_StructuralFeature="_OdvxEETfEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_OdvxE0TfEead1bezhJG4aw" base_Element="_OdvxEETfEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_OdvxFETfEead1bezhJG4aw" base_Element="_OdvxEUTfEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_XuLaokTfEead1bezhJG4aw" base_StructuralFeature="_XuLaoETfEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_XuLao0TfEead1bezhJG4aw" base_Element="_XuLaoETfEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_XuLapETfEead1bezhJG4aw" base_Element="_XuLaoUTfEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecReference xmi:id="_avl9METfEead1bezhJG4aw" base_StructuralFeature="_OdvxEETfEead1bezhJG4aw"/>
+  <OpenModel_Profile:SpecTarget xmi:id="_cmE9sETfEead1bezhJG4aw" base_StructuralFeature="_XuLaoETfEead1bezhJG4aw"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_3TaNAUXREeaB8vMnkFQLXQ" base_Element="_3TaNAEXREeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_3TbbI0XREeaB8vMnkFQLXQ" base_Element="_3TbbIkXREeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3TbbJEXREeaB8vMnkFQLXQ" base_StructuralFeature="_3TbbIkXREeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_3TbbJkXREeaB8vMnkFQLXQ" base_Element="_3TbbJUXREeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_3TbbJ0XREeaB8vMnkFQLXQ" base_StructuralFeature="_3TbbJUXREeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BImwgUXSEeaB8vMnkFQLXQ" base_Element="_BImwgEXSEeaB8vMnkFQLXQ"/>
+  <OpenModel_Profile:OpenModelElement xmi:id="_BIpz0UXSEeaB8vMnkFQLXQ" base_Element="_BIpz0EXSEeaB8vMnkFQLXQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/UmlYangSimpleTestModel.uml
+++ b/xmi2yang tool-v2.0/project/UmlYangSimpleTestModel.uml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14 ../OpenModelProfile/OpenModel_Profile.profile.uml#_0tZP0NyQEeW6C_FaABjU5w">
+  <uml:Model xmi:id="_BktSwMY6EeS3c4fca529YQ" name="UmlYangSimpleTestModel">
+    <ownedComment xmi:type="uml:Comment" xmi:id="_Pab3oD3gEeaL34aOS1eioA" annotatedElement="_BktSwMY6EeS3c4fca529YQ">
+      <body>This is a simple test model for the UML -> YANG mapping tool.</body>
+    </ownedComment>
+    <packagedElement xmi:type="uml:Class" xmi:id="_ZO4CAMY6EeS3c4fca529YQ" name="NetworkElement">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_vS44MAxiEeaC8OaDmeSeFA" annotatedElement="_ZO4CAMY6EeS3c4fca529YQ">
+        <body>This object class models the ...</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_9XG0cMY6EeS3c4fca529YQ" name="_forwardingDomainList" type="_uEXDIMY6EeS3c4fca529YQ" aggregation="composite" association="_9XIpoMY6EeS3c4fca529YQ">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_T_HxsD4KEeaqaaFeZqMcrg" annotatedElement="_9XG0cMY6EeS3c4fca529YQ">
+          <body>This navigable relationship models the ...</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9XG0ccY6EeS3c4fca529YQ"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9XG0csY6EeS3c4fca529YQ" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_y8_1MBHCEeaIF6emprsrUQ" name="attribute1" type="_kqTLoBHCEeaIF6emprsrUQ">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_GGX50BHDEeaIF6emprsrUQ" annotatedElement="_y8_1MBHCEeaIF6emprsrUQ">
+          <body>This attribute defines the ...</body>
+        </ownedComment>
+        <ownedComment xmi:type="uml:Comment" xmi:id="_KQE6IBHDEeaIF6emprsrUQ" annotatedElement="_y8_1MBHCEeaIF6emprsrUQ">
+          <body>Second applied comment.</body>
+        </ownedComment>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="_uEXDIMY6EeS3c4fca529YQ" name="ForwardingDomain">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_1BARkAxiEeaC8OaDmeSeFA" annotatedElement="_uEXDIMY6EeS3c4fca529YQ">
+        <body>This object class models the ...</body>
+      </ownedComment>
+      <generalization xmi:type="uml:Generalization" xmi:id="_6d8ZcMb_EeSv8_ABoIdJ0w" general="_oQo7gMb_EeSv8_ABoIdJ0w"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_OGC28MY7EeS3c4fca529YQ" name="layerRate">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_9mZaEAxiEeaC8OaDmeSeFA" annotatedElement="_OGC28MY7EeS3c4fca529YQ">
+          <body>This attribute models the ...</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_us7ScMZPEeS3c4fca529YQ" name="_terminationPointList" type="_s_0ngMY7EeS3c4fca529YQ" aggregation="composite" association="_us-VwMZPEeS3c4fca529YQ">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Me8k0D4KEeaqaaFeZqMcrg" annotatedElement="_us7ScMZPEeS3c4fca529YQ">
+          <body>This association models the ...</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_us7SccZPEeS3c4fca529YQ"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_us7ScsZPEeS3c4fca529YQ" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_vmTxgMZPEeS3c4fca529YQ" name="_forwardingConstructList" type="_vYPQYMY7EeS3c4fca529YQ" aggregation="composite" association="_vmW00MZPEeS3c4fca529YQ">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Qc9SgD4KEeaqaaFeZqMcrg" annotatedElement="_vmTxgMZPEeS3c4fca529YQ">
+          <body>This navigable relationship models the ...</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vmTxgcZPEeS3c4fca529YQ"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vmTxgsZPEeS3c4fca529YQ" value="*"/>
+      </ownedAttribute>
+      <ownedOperation xmi:type="uml:Operation" xmi:id="_duCfgMY7EeS3c4fca529YQ" name="createForwardingConstruct"/>
+      <ownedOperation xmi:type="uml:Operation" xmi:id="_jJhQwMY7EeS3c4fca529YQ" name="deleteForwardingConstruct"/>
+      <ownedOperation xmi:type="uml:Operation" xmi:id="_ZU3DQMcAEeSv8_ABoIdJ0w" name="activateForwardingConstruct"/>
+      <ownedOperation xmi:type="uml:Operation" xmi:id="_Z7NRkMcAEeSv8_ABoIdJ0w" name="deactivateForwardingConstruct"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="_9XIpoMY6EeS3c4fca529YQ" memberEnd="_9XIpocY6EeS3c4fca529YQ _9XG0cMY6EeS3c4fca529YQ">
+      <name xsi:nil="true"/>
+      <ownedEnd xmi:type="uml:Property" xmi:id="_9XIpocY6EeS3c4fca529YQ" name="_networkElement" type="_ZO4CAMY6EeS3c4fca529YQ" association="_9XIpoMY6EeS3c4fca529YQ">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9XIposY6EeS3c4fca529YQ" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9XIpo8Y6EeS3c4fca529YQ" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="_s_0ngMY7EeS3c4fca529YQ" name="TerminationPoint">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_2-XWIAxiEeaC8OaDmeSeFA" annotatedElement="_s_0ngMY7EeS3c4fca529YQ">
+        <body>This object class models the ...</body>
+      </ownedComment>
+      <generalization xmi:type="uml:Generalization" xmi:id="_8q6AQMb_EeSv8_ABoIdJ0w" general="_oQo7gMb_EeSv8_ABoIdJ0w"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="_vYPQYMY7EeS3c4fca529YQ" name="ForwardingConstruct">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_2Ea2YAxiEeaC8OaDmeSeFA" annotatedElement="_vYPQYMY7EeS3c4fca529YQ">
+        <body>This object class models the ...</body>
+      </ownedComment>
+      <generalization xmi:type="uml:Generalization" xmi:id="_-5G9MMb_EeSv8_ABoIdJ0w" general="_oQo7gMb_EeSv8_ABoIdJ0w"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_8pEdMMZPEeS3c4fca529YQ" name="_terminationPointList" type="_s_0ngMY7EeS3c4fca529YQ" association="_8pJVsMZPEeS3c4fca529YQ">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_yiOPAD4HEeaqaaFeZqMcrg" annotatedElement="_8pEdMMZPEeS3c4fca529YQ">
+          <body>This association models the ...</body>
+        </ownedComment>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pEdMcZPEeS3c4fca529YQ" value="2"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pEdMsZPEeS3c4fca529YQ" value="*"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_HsdSIMZQEeS3c4fca529YQ" name="forwardingConstructState" type="_X09osMb-EeSv8_ABoIdJ0w">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_-kEjQAxiEeaC8OaDmeSeFA" annotatedElement="_HsdSIMZQEeS3c4fca529YQ">
+          <body>This attribute models the ...</body>
+        </ownedComment>
+        <defaultValue xmi:type="uml:LiteralString" xmi:id="_P37OwMcAEeSv8_ABoIdJ0w" value="PENDING"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="_us-VwMZPEeS3c4fca529YQ" memberEnd="_us-VwcZPEeS3c4fca529YQ _us7ScMZPEeS3c4fca529YQ">
+      <name xsi:nil="true"/>
+      <ownedEnd xmi:type="uml:Property" xmi:id="_us-VwcZPEeS3c4fca529YQ" name="_flowDomain" type="_uEXDIMY6EeS3c4fca529YQ" association="_us-VwMZPEeS3c4fca529YQ">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_us-VwsZPEeS3c4fca529YQ" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_us-Vw8ZPEeS3c4fca529YQ" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="_vmW00MZPEeS3c4fca529YQ" memberEnd="_vmW00cZPEeS3c4fca529YQ _vmTxgMZPEeS3c4fca529YQ">
+      <name xsi:nil="true"/>
+      <ownedEnd xmi:type="uml:Property" xmi:id="_vmW00cZPEeS3c4fca529YQ" name="_flowDomain" type="_uEXDIMY6EeS3c4fca529YQ" association="_vmW00MZPEeS3c4fca529YQ">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_vmW00sZPEeS3c4fca529YQ" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_vmW008ZPEeS3c4fca529YQ" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="_8pJVsMZPEeS3c4fca529YQ" memberEnd="_8pJVscZPEeS3c4fca529YQ _8pEdMMZPEeS3c4fca529YQ">
+      <name xsi:nil="true"/>
+      <ownedEnd xmi:type="uml:Property" xmi:id="_8pJVscZPEeS3c4fca529YQ" name="_forwardingConstruct" type="_vYPQYMY7EeS3c4fca529YQ" association="_8pJVsMZPEeS3c4fca529YQ">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8pJVssZPEeS3c4fca529YQ" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8pJVs8ZPEeS3c4fca529YQ" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="_X09osMb-EeSv8_ABoIdJ0w" name="FcState">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_6t0qcAxiEeaC8OaDmeSeFA" annotatedElement="_X09osMb-EeSv8_ABoIdJ0w">
+        <body>This enumeration models the ...</body>
+      </ownedComment>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_daCa0Mb-EeSv8_ABoIdJ0w" name="PENDING">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_BmUzUAxjEeaC8OaDmeSeFA" annotatedElement="_daCa0Mb-EeSv8_ABoIdJ0w">
+          <body>This literal models the ...</body>
+        </ownedComment>
+      </ownedLiteral>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eVfWcMb-EeSv8_ABoIdJ0w" name="ACTIVE">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_CfVe8AxjEeaC8OaDmeSeFA" annotatedElement="_eVfWcMb-EeSv8_ABoIdJ0w">
+          <body>This literal models the ...</body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="_oQo7gMb_EeSv8_ABoIdJ0w" name="GenericObject" isAbstract="true">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_37nBgAxiEeaC8OaDmeSeFA" annotatedElement="_oQo7gMb_EeSv8_ABoIdJ0w">
+        <body>This object class models the ...</body>
+      </ownedComment>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="_yUIZsMb_EeSv8_ABoIdJ0w" name="objectIdentifier">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_oPvZwD3fEeaL34aOS1eioA" annotatedElement="_yUIZsMb_EeSv8_ABoIdJ0w">
+          <body>This attribute defines the generic identifier for all object instances.</body>
+        </ownedComment>
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="_G6WPwMcAEeSv8_ABoIdJ0w" client="_vYPQYMY7EeS3c4fca529YQ" supplier="_X09osMb-EeSv8_ABoIdJ0w"/>
+    <packagedElement xmi:type="uml:StateMachine" xmi:id="_gQ0pgMsWEeSSVs9TmSNKlQ" name="forwardingConstructState State Diagram">
+      <connectionPoint xmi:type="uml:Pseudostate" xmi:id="_k0oy8MsWEeSSVs9TmSNKlQ" name="Entry" kind="entryPoint"/>
+      <connectionPoint xmi:type="uml:Pseudostate" xmi:id="_SqqgYMsXEeSSVs9TmSNKlQ" name="Exit" kind="exitPoint"/>
+      <connectionPoint xmi:type="uml:Pseudostate" xmi:id="_rACqkMvtEeS6PsZY9XIQjQ" name="Exit" kind="exitPoint"/>
+      <region xmi:type="uml:Region" xmi:id="_gyRwwMsWEeSSVs9TmSNKlQ" name="Region1">
+        <transition xmi:type="uml:Transition" xmi:id="_rq7VUMsWEeSSVs9TmSNKlQ" source="_k0oy8MsWEeSSVs9TmSNKlQ" target="_oCkHgMsWEeSSVs9TmSNKlQ">
+          <effect xmi:type="uml:Activity" xmi:id="_4dawYMsWEeSSVs9TmSNKlQ" name="createForwardingConstruct"/>
+        </transition>
+        <transition xmi:type="uml:Transition" xmi:id="_-F-UUMsWEeSSVs9TmSNKlQ" source="_oCkHgMsWEeSSVs9TmSNKlQ" target="_673IwMsWEeSSVs9TmSNKlQ">
+          <effect xmi:type="uml:Activity" xmi:id="_Aj8yoMsXEeSSVs9TmSNKlQ" name="activateForwardingConstruct"/>
+        </transition>
+        <transition xmi:type="uml:Transition" xmi:id="_L1f_YMsXEeSSVs9TmSNKlQ" source="_673IwMsWEeSSVs9TmSNKlQ" target="_oCkHgMsWEeSSVs9TmSNKlQ">
+          <effect xmi:type="uml:Activity" xmi:id="_P_zcoMsXEeSSVs9TmSNKlQ" name="deactivateForwardingConstruct"/>
+        </transition>
+        <transition xmi:type="uml:Transition" xmi:id="_Vb8VMMsXEeSSVs9TmSNKlQ" source="_673IwMsWEeSSVs9TmSNKlQ" target="_SqqgYMsXEeSSVs9TmSNKlQ">
+          <effect xmi:type="uml:Activity" xmi:id="_YLuVMMsXEeSSVs9TmSNKlQ" name="deleteForwardingConstruct"/>
+        </transition>
+        <transition xmi:type="uml:Transition" xmi:id="_vrYYUMvtEeS6PsZY9XIQjQ" source="_oCkHgMsWEeSSVs9TmSNKlQ" target="_rACqkMvtEeS6PsZY9XIQjQ">
+          <effect xmi:type="uml:Activity" xmi:id="_zVlZMMvtEeS6PsZY9XIQjQ" name="deleteForwardingConstruct"/>
+        </transition>
+        <subvertex xmi:type="uml:State" xmi:id="_oCkHgMsWEeSSVs9TmSNKlQ" name="PENDING"/>
+        <subvertex xmi:type="uml:State" xmi:id="_673IwMsWEeSSVs9TmSNKlQ" name="ACTIVE"/>
+      </region>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Enumeration" xmi:id="_kqTLoBHCEeaIF6emprsrUQ" name="Enumeration1">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_OahhUBHDEeaIF6emprsrUQ" annotatedElement="_kqTLoBHCEeaIF6emprsrUQ">
+        <body>This enumeration defines ...</body>
+      </ownedComment>
+      <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_phT94BHCEeaIF6emprsrUQ" name="SINGLE_LITERAL">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_Qq_vIBHDEeaIF6emprsrUQ" annotatedElement="_phT94BHCEeaIF6emprsrUQ">
+          <body>This literal models the ...</body>
+        </ownedComment>
+      </ownedLiteral>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Dependency" xmi:id="_8OP-IBHCEeaIF6emprsrUQ" client="_ZO4CAMY6EeS3c4fca529YQ" supplier="_kqTLoBHCEeaIF6emprsrUQ"/>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_IPd6kMY6EeS3c4fca529YQ">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Rkt_IAxiEeaC8OaDmeSeFA" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Rkt_IQxiEeaC8OaDmeSeFA" key="Version" value="0.2.2"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Rkt_IgxiEeaC8OaDmeSeFA" key="Comment" value="Stereotypes extending more than one metaclass (Cond, Choice, PassedByReference) made optional."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Rkt_IwxiEeaC8OaDmeSeFA" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Rkt_JAxiEeaC8OaDmeSeFA" key="Date" value="2016-02-26"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Rkt_JQxiEeaC8OaDmeSeFA" key="Author" value=""/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IPgW0MY6EeS3c4fca529YQ" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_0tZP0NyQEeW6C_FaABjU5w"/>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
+    </profileApplication>
+  </uml:Model>
+  <OpenModel_Profile:OpenModelClass xmi:id="_ZO4pEMY6EeS3c4fca529YQ" base_Class="_ZO4CAMY6EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9XHbgMY6EeS3c4fca529YQ" base_StructuralFeature="_9XG0cMY6EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_uEXqMMY6EeS3c4fca529YQ" base_Class="_uEXDIMY6EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_OGC28cY7EeS3c4fca529YQ" base_StructuralFeature="_OGC28MY7EeS3c4fca529YQ" valueRange="&lt;range definition>"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_us75gMZPEeS3c4fca529YQ" base_StructuralFeature="_us7ScMZPEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vmUYkMZPEeS3c4fca529YQ" base_StructuralFeature="_vmTxgMZPEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_duDGkMY7EeS3c4fca529YQ" base_Operation="_duCfgMY7EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_jJh30MY7EeS3c4fca529YQ" base_Operation="_jJhQwMY7EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_ZU3DQccAEeSv8_ABoIdJ0w" base_Operation="_ZU3DQMcAEeSv8_ABoIdJ0w"/>
+  <OpenModel_Profile:OpenModelOperation xmi:id="_Z7N4oMcAEeSv8_ABoIdJ0w" base_Operation="_Z7NRkMcAEeSv8_ABoIdJ0w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_9XIppMY6EeS3c4fca529YQ" base_StructuralFeature="_9XIpocY6EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_s_0ngcY7EeS3c4fca529YQ" base_Class="_s_0ngMY7EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_vYP3cMY7EeS3c4fca529YQ" base_Class="_vYPQYMY7EeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8pFEQMZPEeS3c4fca529YQ" base_StructuralFeature="_8pEdMMZPEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_Hsd5MMZQEeS3c4fca529YQ" base_StructuralFeature="_HsdSIMZQEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_us-80MZPEeS3c4fca529YQ" base_StructuralFeature="_us-VwcZPEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_vmW01MZPEeS3c4fca529YQ" base_StructuralFeature="_vmW00cZPEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_8pJ8wMZPEeS3c4fca529YQ" base_StructuralFeature="_8pJVscZPEeS3c4fca529YQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_oQo7gcb_EeSv8_ABoIdJ0w" base_Class="_oQo7gMb_EeSv8_ABoIdJ0w"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_yUIZscb_EeSv8_ABoIdJ0w" base_StructuralFeature="_yUIZsMb_EeSv8_ABoIdJ0w" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_gUNUsMsWEeSSVs9TmSNKlQ" base_Class="_gQ0pgMsWEeSSVs9TmSNKlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_4dbXcMsWEeSSVs9TmSNKlQ" base_Class="_4dawYMsWEeSSVs9TmSNKlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_Aj9ZsMsXEeSSVs9TmSNKlQ" base_Class="_Aj8yoMsXEeSSVs9TmSNKlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_P_zcocsXEeSSVs9TmSNKlQ" base_Class="_P_zcoMsXEeSSVs9TmSNKlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_YLuVMcsXEeSSVs9TmSNKlQ" base_Class="_YLuVMMsXEeSSVs9TmSNKlQ"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_zVmAQMvtEeS6PsZY9XIQjQ" base_Class="_zVlZMMvtEeS6PsZY9XIQjQ"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_y9AcQBHCEeaIF6emprsrUQ" base_StructuralFeature="_y8_1MBHCEeaIF6emprsrUQ"/>
+</xmi:XMI>

--- a/xmi2yang tool-v2.0/project/config.txt
+++ b/xmi2yang tool-v2.0/project/config.txt
@@ -3,7 +3,7 @@ Notice: this config file will be read to JSON. If you want to write some special
 If there are errors in reading config file, please report an issue on git.
 
 {"namespace":"urn:onf:params:xml:ns:yang:",
-"prefix":"Tapi-abc",
+"prefix":"",
 "organization":"ONF (Open Networking Foundation) IMP Working Group",
 "contact":"WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
 WG List: mailto: <wg list name>@opennetworking.org>,.
@@ -11,4 +11,4 @@ WG Chair: your-WG-chair
     <mailto:your-WG-chair@example.com>
 Editor: your-name
     <mailto:your-email@example.com>",
-"revision":{"date":"2016-11-05", "description":"Test revision", "reference":"Papyrus"}}
+"revision":{"date":"", "description":"Test revision", "reference":"Papyrus"}}

--- a/xmi2yang tool-v2.0/project/core-model.yang
+++ b/xmi2yang tool-v2.0/project/core-model.yang
@@ -1,0 +1,1806 @@
+module core-model {
+    namespace "urn:onf:params:xml:ns:yang:CoreModel";
+    prefix core-model;
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    /***********************
+    * package core-network-module
+    **********************/ 
+        /***********************
+        * package type-definitions
+        **********************/ 
+            /***********************
+            * package topology-pacs
+            **********************/ 
+                grouping cost-characteristics {
+                    leaf cost-name {
+                        type string;
+                        description "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.";
+                    }
+                    leaf cost-value {
+                        type string;
+                        description "The specific cost.";
+                    }
+                    leaf cost-algorithm {
+                        type string;
+                        description "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.";
+                    }
+                    description "The information for a particular cost characteristic.";
+                }
+                grouping risk-characteristic {
+                    leaf risk-characteristic-name {
+                        type string;
+                        description "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. 
+                            For example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).
+                            Depending upon the importance of the traffic being routed different risk characteristics will be evaluated.";
+                    }
+                    leaf-list risk-identifier-list {
+                        type string;
+                        min-elements 1;
+                        description "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.";
+                    }
+                    description "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.";
+                }
+                grouping capacity {
+                    leaf total-size {
+                        type string;
+                        description "Total capacity of the TopologicalEntity in MB/s";
+                    }
+                    leaf number-of-client-instances {
+                        type string;
+                        description "Where there is some limit to the number of client (e.g. in a channelized case).";
+                    }
+                    leaf maximum-client-size {
+                        type string;
+                        description "Where a client is of variable capacity but due to some underlying realization the maximum size of the client is smaller than the totalSize.";
+                    }
+                    leaf numbering-range {
+                        type string;
+                        description "Method for identifying units of capacity via some numbering scheme.";
+                    }
+                    description "Informtion on capacity of a particular TopologicalEntity.";
+                }
+                grouping validation-mechanism {
+                    leaf validation-mechanism {
+                        type string;
+                        description "Name of mechanism used to validate adjacency";
+                    }
+                    leaf layer-protocol-adjacency-validated {
+                        type string;
+                        description "State of validatiion";
+                    }
+                    leaf validation-robustness {
+                        type string;
+                        description "Quality of validation (i.e. how likely is the stated validation to be invalid)";
+                    }
+                    description "Identifies the validation mechanism and describes the characteristics of that mechanism";
+                }
+                grouping queuing-latency {
+                    leaf traffic-property {
+                        type string;
+                        description "The identifier of the specific traffic property to which the queuing latency applies.";
+                    }
+                    leaf latency-for-traffic-with-property {
+                        type string;
+                        description "The specific queuing latency for the traffic property.";
+                    }
+                    description "Provides information on latency characteristic for a particular stated trafficProperty.";
+                }
+
+            typedef operational-state {
+                type enumeration {
+                    enum enabled {
+                        description "none";
+                    }
+                    enum disabled {
+                        description "none";
+                    }
+                }
+                description "OBSOLETE: The list of valid operational states for the connection.";
+            }
+            typedef oper-type {
+                type enumeration {
+                    enum revertive {
+                        description "Traffic will return to a preferred route on recovery of that route (potentiall after some hold-off time)";
+                    }
+                    enum non-revertive {
+                        description "Traffic will be rerouted on failure and not on recovery of any particular route.";
+                    }
+                }
+                description "The operation type associated with the protection mechanism (either non-revertive or revertive).";
+            }
+            typedef directionality {
+                type enumeration {
+                    enum sink {
+                        description "none";
+                    }
+                    enum source {
+                        description "none";
+                    }
+                    enum bidirectional {
+                        description "none";
+                    }
+                }
+                description "OBSOLETE: The enumeration with the options for directionality of the termination point.";
+            }
+            typedef layer-protocol-name {
+                type string;
+                description "Provides a controlled list of layer protocol names and indicates the naming authority.
+                    Note that it is expected that attributes will be added to this structure to convey the naming authority name, the name of the layer protocol using a human readable string and any particular standard reference.
+                    Layer protocol names include:
+                    -    Layer 1 (L1): OTU, ODU
+                    -    Layer 2 (L2): Carrier Grade Ethernet (ETY, ETH), MPLS-TP (MT)
+                    ";
+            }
+            typedef port-role {
+                type string;
+                description "The role of a port in the context of the function of the forwarding entity that it bounds";
+            }
+            typedef port-direction {
+                type enumeration {
+                    enum bidirectional {
+                        description "The Port has both an INPUT flow and an OUTPUT flow defined.";
+                    }
+                    enum input {
+                        description "The Port only has definition for a flow into the Forwarding entity (i.e. an ingress flow).";
+                    }
+                    enum output {
+                        description "The Port only has definition for a flow out of the Forwarding entity (i.e. an egress flow).";
+                    }
+                    enum unidentified-or-unknown {
+                        description "Not a normal state. The system is unable to determine the correct value.";
+                    }
+                }
+                description "The orientation of flow at the Port of a Forwarding entity";
+            }
+            typedef forwarding-direction {
+                type enumeration {
+                    enum bidirectional {
+                        description "The Fowarding entity supports both BIDIRECTIONAL flows at all Ports (i.e. all Ports have both an INPUT flow and an OUTPUT flow defined)";
+                    }
+                    enum unidirectional {
+                        description "The Forwarding entity has Ports that are either INPUT or OUTPUT. It has no BIDIRECTIONAL Ports.";
+                    }
+                    enum undefined-or-unknown {
+                        description "Not a normal state. The system is unable to determine the correct value.";
+                    }
+                }
+                description "The directionality of a Forwarding entity.";
+            }
+            typedef termination-direction {
+                type enumeration {
+                    enum bidirectional {
+                        description "A Termination with both SINK and SOURCE flows.";
+                    }
+                    enum sink {
+                        description "The flow is up the layer stack from the server side to the client side. 
+                            Considering an example of a Termination function within the termination entity, a SINK flow:
+                            - will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component
+                            - then will be decoded and deconstructed 
+                            - then relevant parts of the flow will be sent out of the termination function (the client side) where it is essentially at an OUTPUT from the termination component
+                            A SINK termination is one that only supports a SINK flow.
+                            A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity";
+                    }
+                    enum source {
+                        description "The flow is down the layer stack from the server side to the client side. 
+                            Considering an example of a Termination function within the termination entity, a SOURCE flow:
+                            - will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component
+                            - then will be assembled with various overheads etc and will be coded 
+                            - then coded form of the assembly of flow will be sent out of the termination function (the server side) where it is essentially at an OUTPUT from the termination component
+                            A SOURCE termination is one that only supports a SOURCE flow.
+                            A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity";
+                    }
+                    enum undefined-or-unknown {
+                        description "Not a normal state. The system is unable to determine the correct value.";
+                    }
+                }
+                description "The directionality of a termination entity";
+            }
+            typedef extended-termination-direction {
+                type enumeration {
+                    enum bidirectional {
+                        description "A Termination with both SINK and SOURCE flows.";
+                    }
+                    enum sink {
+                        description "The flow is up the layer stack from the server side to the client side. 
+                            Considering an example of a Termination function within the termination entity, a SINK flow:
+                            - will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component
+                            - then will be decoded and deconstructed 
+                            - then relevant parts of the flow will be sent out of the termination function (the client side) where it is essentially at an OUTPUT from the termination component
+                            A SINK termination is one that only supports a SINK flow.
+                            A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity";
+                    }
+                    enum source {
+                        description "The flow is down the layer stack from the server side to the client side. 
+                            Considering an example of a Termination function within the termination entity, a SOURCE flow:
+                            - will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component
+                            - then will be assembled with various overheads etc and will be coded 
+                            - then coded form of the assembly of flow will be sent out of the termination function (the server side) where it is essentially at an OUTPUT from the termination component
+                            A SOURCE termination is one that only supports a SOURCE flow.
+                            A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity";
+                    }
+                    enum undefined-or-unknown {
+                        description "Not a normal state. The system is unable to determine the correct value.";
+                    }
+                    enum contra-direction-sink {
+                        description "The essential flow of the Termination entity is SINK (i.e. up the layer stack) but the INPUT flow of the Termination entity was provided by a SOURCE OUTPUT or taken from a SOURCE INPUT (duplicating the input signal) hence reversing the flow orientation from down the layer stack to up the layer stack.";
+                    }
+                    enum contra-direction-source {
+                        description "The essential flow of the Termination entity is SOURCE (i.e. down the layer stack) but the OUTPUT flow of the Termination entity was fed to (and replaces) a SINK OUTPUT or was fed to a SINK INPUT (replacing the normal flow) hence reversing the flow orientation from down the layer stack to up the layer stack.";
+                    }
+                }
+                description "Extended to include contra-direction considerations. Only applies to LP and elements of LP not to LTP??";
+            }
+            typedef protection-type {
+                type string;
+                description "Identifies the type of rotection of an FcSwitch.";
+            }
+            typedef termination-state {
+                type enumeration {
+                    enum lp-can-never-terminate {
+                        description "A non-flexible case that can never be terminated.";
+                    }
+                    enum lt-not-terminated {
+                        description "A flexible termination that can terminate but is currently not terminated.";
+                    }
+                    enum terminated-server-to-client-flow {
+                        description "A flexible termination that is currently terminated for server to client flow only.";
+                    }
+                    enum terminated-client-to-server-flow {
+                        description "A flexible termination that is currently terminated for client to server flow only.";
+                    }
+                    enum terminated-bidirectional {
+                        description "A flexible termination that is currently terminated in both directions of flow.";
+                    }
+                    enum lt-permenantly-terminated {
+                        description "A non-flexible termination that is always terminated (in both directions of flow for a bidirectional case and in the one direction of flow for both unidirectional cases).";
+                    }
+                    enum termination-state-unknown {
+                        description "There TerminationState cannot be determined.";
+                    }
+                }
+                description "Provides support for the range of behaviours and specific states that an LP can take with respect to termination of the signal.
+                    Indicates to what degree the LayerTermination is terminated.";
+            }
+
+        /***********************
+        * package object-classes
+        **********************/ 
+            /***********************
+            * package topology-pacs
+            **********************/ 
+                grouping transfer-cost-pac {
+                    list cost-characteristic-list {
+                        min-elements 1;
+                        uses cost-characteristics;
+                        description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
+                    }
+                    description "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. 
+                        They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity
+                        There may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. 
+                        Using an entity will incur a cost. ";
+                }
+                grouping risk-parameter-pac {
+                    list risk-characteristic-list {
+                        min-elements 1;
+                        uses risk-characteristic;
+                        description "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.";
+                    }
+                    description "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. 
+                        The risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.
+                        A TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.
+                        The realization can be partitioned into segments which have some relevant common failure modes.
+                        There is a risk of failure/degradation of each segment of the underlying realization.
+                        Each segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).
+                        Disruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.
+                        Any TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.
+                        The identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.
+                        A segment has one or more risk characteristic.
+                        Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.
+                        Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.";
+                }
+                grouping layer-protocol-transition-pac {
+                    leaf-list transitioned-layer-protocol-list {
+                        type string;
+                        min-elements 1;
+                        description "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.";
+                    }
+                    leaf-list ltp-ref-list {
+                        type leafref {
+                            path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                        }
+                        min-elements 1;
+                        description "Lists the LTPs that define the layer protocol transition of the transitional link.";
+                    }
+                    description "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. 
+                        This abstraction is relevant when considering multi-layer routing. 
+                        The layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.
+                        This Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.
+                        Links that included details in this Pac are often referred to as Transitional Links.";
+                }
+                grouping transfer-timing-pac {
+                    leaf fixed-latency-characteristic {
+                        type string;
+                        description "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity";
+                    }
+                    leaf jitter-characteristic {
+                        if-feature Present if jitterCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if jitterCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to TDM.;
+                        type string;
+                        description "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.
+                            Applies to TDM systems (and not packet).";
+                    }
+                    leaf wander-characteristic {
+                        if-feature Present if wanderCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if wanderCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to TDM.;
+                        type string;
+                        description "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.
+                            Applies to TDM systems (and not packet).";
+                    }
+                    list queuing-latency-list {
+                        if-feature Present if queuingLatencyCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+There may be more than one instance if the queuing behavior depends upon traffic properties.
+Note that if queuingLatencyCharacteristics is relevant but consistent statement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to packet system.;
+                        uses queuing-latency;
+                        description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
+                    }
+                    description "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.";
+                }
+                grouping transfer-integrity-pac {
+                    leaf error-characteristic {
+                        if-feature Present if errorCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if errorCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to TDM.;
+                        type string;
+                        description "Describes the degree to which the signal propagated can be errored. 
+                            Applies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.";
+                    }
+                    leaf loss-characteristic {
+                        if-feature Present if lossCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if lossCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to packet systems.;
+                        type string;
+                        description "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.
+                            Applies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).";
+                    }
+                    leaf repeat-delivery-characteristic {
+                        if-feature Present if repeatCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if repeatCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this primarily applies to packet systemswhere a packet may be delivered more than once (in fault recovery for example). 
+Note that it can also apply to TDM where several frames may  be received twice due to switching in a system with a large differential propagation delay.;
+                        type string;
+                        description "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). 
+                            It can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.";
+                    }
+                    leaf delivery-order-characteristic {
+                        if-feature Present if deliveryOrderCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if deliveryOrderCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to packet systems.
+;
+                        type string;
+                        description "Describes the degree to which packets will be delivered out of sequence.
+                            Does not apply to TDM as the TDM protocols maintain strict order.";
+                    }
+                    leaf unavailable-time-characteristic {
+                        type string;
+                        description "Describes the duration for which there may be no valid signal propagated.";
+                    }
+                    leaf server-integrity-process-characteristic {
+                        if-feature Present if serverIntegrityProcessCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if serverIntegrityProcessCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies where the server has some error recovery mechanism alters the characteristics of the link from a normal distribution.;
+                        type string;
+                        description "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.";
+                    }
+                    description "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.
+                        It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.
+                        Note that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.";
+                }
+                grouping transfer-capacity-pac {
+                    container total-potential-capacity {
+                        uses capacity;
+                        description "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.";
+                    }
+                    container available-capacity {
+                        uses capacity;
+                        description "Capacity available to be assigned.";
+                    }
+                    list capacity-assigned-to-user-view {
+                        uses capacity;
+                        description "Capacity already assigned";
+                    }
+                    leaf capacity-interaction-algorithm {
+                        type string;
+                        description "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)";
+                    }
+                    description "The TopologicalEntity derives capacity from the underlying realization. 
+                        A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.
+                        A TopologicalEntity may be directly used in the view or may be assigned to another view for use.
+                        The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.
+                        Represents the capacity available to user (client) along with client interaction and usage. 
+                        A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
+                }
+                grouping topological-entity {
+                    container risk-parameter-pac {
+                        if-feature Present if risk information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if risk is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.;
+                        uses risk-parameter-pac;
+                        description "none";
+                    }
+                    container transfer-cost-pac {
+                        if-feature Present if cost information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if cost is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.;
+                        uses transfer-cost-pac;
+                        description "none";
+                    }
+                    container transfer-timing-pac {
+                        if-feature Present if transfer timing information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if transfer timing is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.;
+                        uses transfer-timing-pac;
+                        description "none";
+                    }
+                    container transfer-capacity-pac {
+                        if-feature Present if transfer capacity information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if transfer capacity is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.;
+                        uses transfer-capacity-pac;
+                        description "none";
+                    }
+                    container transfer-integrity-pac {
+                        if-feature Present if transfer integrity information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if transfer integrity is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.;
+                        uses transfer-integrity-pac;
+                        description "none";
+                    }
+                    container validation-pac {
+                        if-feature Present if validation information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if validation is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that validation may not be possible for the specific layer protocol or in the particular case.;
+                        uses validation-pac;
+                        description "none";
+                    }
+                    list layer-transition-pac {
+                        if-feature Present if layer transition information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if layer transiotio is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that layer transition occurs in a limited number of cases.;
+                        uses layer-protocol-transition-pac;
+                        description "none";
+                    }
+                    description "A TopologicalEntity is an abstract representation of the emergent effect of the combined functioning of an arrangement of components (running hardware, software running on hardware etc). 
+                        The effect can be considered as the realization of the potential for apparent communication adjacency for entities that are bound to the terminations at the boundary of the TopologicalEntity.
+                        The TopologicalEntity enables the creation of constrained forwarding to achieve the apparent adjacency.
+                        The apparent adjacency has intended performance degraded from perfect adjacency and a statement of that degradation is conveyed via the attributes of the packages associated with this class.
+                        In the model both ForwardingDomain and Link are TopologicalEntities. 
+                        This abstract class is used as a modeling approach to apply packages of attributes to both Link and ForwardingDomain. Link and ForwardingDomain are the key TopologicalEntities.";
+                }
+                grouping validation-pac {
+                    list validation-mechanism-list {
+                        min-elements 1;
+                        uses validation-mechanism;
+                        description "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.";
+                    }
+                    description "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.";
+                }
+                feature Present if jitterCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if jitterCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to TDM. {
+                    description "none";
+                }
+                feature Present if wanderCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if wanderCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to TDM. {
+                    description "none";
+                }
+                feature Present if queuingLatencyCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+There may be more than one instance if the queuing behavior depends upon traffic properties.
+Note that if queuingLatencyCharacteristics is relevant but consistent statement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to packet system. {
+                    description "none";
+                }
+                feature Present if errorCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if errorCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to TDM. {
+                    description "none";
+                }
+                feature Present if lossCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if lossCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to packet systems. {
+                    description "none";
+                }
+                feature Present if repeatCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if repeatCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this primarily applies to packet systemswhere a packet may be delivered more than once (in fault recovery for example). 
+Note that it can also apply to TDM where several frames may  be received twice due to switching in a system with a large differential propagation delay. {
+                    description "none";
+                }
+                feature Present if deliveryOrderCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if deliveryOrderCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies to packet systems.
+ {
+                    description "none";
+                }
+                feature Present if serverIntegrityProcessCharacteristics information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if serverIntegrityProcessCharacteristics is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that this only applies where the server has some error recovery mechanism alters the characteristics of the link from a normal distribution. {
+                    description "none";
+                }
+                feature Present if risk information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if risk is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made. {
+                    description "none";
+                }
+                feature Present if cost information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if cost is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made. {
+                    description "none";
+                }
+                feature Present if transfer timing information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if transfer timing is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made. {
+                    description "none";
+                }
+                feature Present if transfer capacity information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if transfer capacity is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made. {
+                    description "none";
+                }
+                feature Present if transfer integrity information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if transfer integrity is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made. {
+                    description "none";
+                }
+                feature Present if validation information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if validation is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that validation may not be possible for the specific layer protocol or in the particular case. {
+                    description "none";
+                }
+                feature Present if layer transition information is relevant to usage and statement can be made that applies equally to all flows that can be supported by the TopologicalEntity.
+Note that if layer transiotio is relevant but consistent ststement cannot be made then the TopologicalEntity should be described in terms of subordinate parts against which coherent statements can be made.
+Note that layer transition occurs in a limited number of cases. {
+                    description "none";
+                }
+
+            grouping forwarding-domain {
+                leaf-list layer-protocol-name-list {
+                    type layer-protocol-name;
+                    min-elements 1;
+                    description "One or more protocol layers at which the FD represents the opportunity to enable forwarding between LTP that bound it.";
+                }
+                leaf-list lower-level-fd-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:fd-ref-list/';
+                    }
+                    description "The FD object class supports a recursive aggregation relationship (HigherLevelFdEncompassesLowerLevelFds) such that the internal construction of an FD can be exposed as multiple lower level FDs and associated Links (partitioning).
+                        The aggregated FDs and Links form an interconnected topology that provides and describes the capability of the aggregating FD.
+                        Note that the model actually represents aggregation of lower level FDs into higher level FDs as views rather than FD partition, and supports multiple views. 
+                        Aggregation allow reallocation of capacity from lower level FDs to different higher level FDs as if the network is reorganized  (as the association is aggregation not composition).";
+                }
+                leaf-list fc-ref-list {
+                    type leafref {
+                        path '/core-model:fc-route/core-model:fc-list/';
+                    }
+                    description "An FD contains one or more FCs. A contained FC connects LTPs that bound the FD.";
+                }
+                leaf-list ltp-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "An instance of FD is associated with zero or more LTP objects. 
+                        The LTPs that bound the FD provide capacity for forwarding.";
+                }
+                leaf-list link-ref-list {
+                    type leafref {
+                        path '/core-model:link/';
+                    }
+                    description "The FD encompasses Links that interconnect lower level FDs and collect links that are wholly within the bounds of the FD.
+                        See also _lowerLevelFdRefList.";
+                }
+                uses global-class;
+                uses topological-entity;
+                description "The ForwardingDomain (FD) object class models the topological component which represents the opportunity to enable forwarding (of specific transport characteristic information at one or more protocol layers) between points represented by the LTP in the model.
+                    The FD object provides the context for instructing the formation, adjustment and removal of FCs and hence offers the potential to enable forwarding. 
+                    The LTPs available are those defined at the boundary of the FD.
+                    At a lowere level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). 
+                    Note that an NE can encompass multiple switch matrices (FDs) and the FD representing the switch matrix can be further partitioned.
+                    ";
+            }
+            grouping forwarding-construct {
+                leaf layer-protocol-name {
+                    type layer-protocol-name;
+                    description "The layerProtocol at which the FC enables potential for forwarding.";
+                }
+                leaf-list lower-level-fc-ref-list {
+                    type leafref {
+                        path '/core-model:fc-route/core-model:fc-list/';
+                    }
+                    description "An FC object supports a recursive aggregation relationship such that the internal construction of an FC can be exposed as multiple lower level FC objects (partitioning).
+                        Aggregation is used as for the FD to allow changes in hierarchy.
+                        ";
+                }
+                list fc-route-ref-list {
+                    uses fc-route;
+                    description "An FC object can have zero or more routes, each of which is defined as a list of lower level FC objects describing the flow across the network.";
+                }
+                list fc-port-list {
+                    min-elements 2;
+                    uses fc-port;
+                    description "The association of the FC to LTPs is made via FcPorts (essentially the ports of the FC).";
+                }
+                list fc-switch-list {
+                    uses fc-switch;
+                    description "If an FC exposes protection (having two FcPorts that provide alternative identical inputs/outputs), the FC will have one or more associated FcSwitch objects.
+                        The arrangement of switches for a particular instance is described by a referenced FcSpec";
+                }
+                list configuration-and-switch-control-list {
+                    uses configuration-and-switch-controller;
+                    description "A multi-switch controller encapsulated in the FC.
+                        The multi-switch controller coordinates multiple switches in the same FC.";
+                }
+                leaf fc-spec-ref {
+                    type leafref {
+                        path '/core-model:configuration-group-spec/core-model:fc-spec/';
+                    }
+                    description "References the specification that describes the capability and internal structure of of the FC (e.g. The arrangement of switches for a particular instance is described by a referenced FcSpec).
+                        The specification allows interpretation of FcPort role and switch configurations etc.";
+                }
+                leaf forwarding-direction {
+                    type forwarding-direction;
+                    description "The directionality of the ForwardingConstruct. 
+                        Is applicable to simple ForwardingConstructs where all FcPorts are BIDIRECTIONAL (the ForwardingConstruct will be BIDIRECTIONAL) or UNIDIRECTIONAL (the ForwardingConstruct will be UNIDIRECTIONAL). 
+                        Is not present in more complex cases.";
+                }
+                uses global-class;
+                description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs at a particular specific layerProtocol.
+                    Like the LTP the FC supports any transport protocol including all circuit and packet forms.
+                    It is used to effect forwarding of transport characteristic (layer protocol) information.
+                    An FC can be in only one FD.
+                    The ForwardingConstruct is a Forwarding entity.
+                    At a low level of the recursion, a FC represents a cross-connection within an NE. It may also represent a fragment of a cross-connection under certain circumstances.
+                    The FC object can be used to represent many different structures including point-to-point (P2P), point-to-multipoint (P2MP), rooted-multipoint (RMP) and multipoint-to-multipoint (MP2MP) bridge and selector structure for linear, ring or mesh protection schemes.";
+            }
+            list network-control-domain {
+                min-elements 1;
+                max-elements 2;
+                leaf-list forwarding-domain-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:fd-ref-list/';
+                    }
+                    description "The FDs accessible via the NCD.";
+                }
+                leaf-list link-ref-list {
+                    type leafref {
+                        path '/core-model:link/';
+                    }
+                    description "The links accessible in the scope of the NCD. 
+                        The domain is bounded by off-network links.";
+                }
+                list network-element-ref-list {
+                    uses network-element;
+                    description "The network elements within the scope of the NCD where each NE is within one and only one domain.";
+                }
+                uses global-class;
+                description "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected network elements).
+                    In the interfaces between SDN controllers where virtualization is necessary, e.g., in client/server SDN controller relationship, the NCD object defines the scope of control of the client SDN controller on the virtual network that has been provided by the server SDN controller (i.e., the scope of control relates to the partitioned provider resources allocated to that particular client). 
+                    The NCD provides the scope of naming space for identifying objects representing the virtual resources within the virtual network.";
+            }
+            grouping link {
+                leaf-list layer-protocol-name-list {
+                    type layer-protocol-name;
+                    min-elements 1;
+                    description "The Link can support multiple transport layer protocols via the associated LTP object. 
+                        For implementation optimization, where appropriate, multiple layer-specific links can be merged and represented as a single Link instance as the Link can represent a list of layer protocols.
+                        A link may support different layer protocols at each Port when it is a transitional link.";
+                }
+                leaf-list fd-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:fd-ref-list/';
+                    }
+                    min-elements 2;
+                    description "The Link associates with two or more FDs. 
+                        This association provides a direct summarization of the association via LinkPort and LTP.";
+                }
+                list link-port-list {
+                    min-elements 2;
+                    uses link-port;
+                    description "The association of the Link to LTPs is made via LinkPort (essentially the ports of the Link).";
+                }
+                leaf link-spec-ref {
+                    type leafref {
+                        path '/core-model:link-spec/';
+                    }
+                    description "References the specification that describes the capability and internal structure of of the Link (e.g. asymmetric flows between points).
+                        The specification allows interpretation of LinkPort role and switch configurations etc.
+                        See also ForwardingConstruct.";
+                }
+                leaf-list aggregated-link {
+                    type leafref {
+                        path '/core-model:link/';
+                    }
+                    description "A link may formed from subordinate links (similar FD formations from subordiate FDs). This association is intended to cover concepts such as serial compound links. ";
+                }
+                leaf link-direction {
+                    type forwarding-direction;
+                    description "The directionality of the Link. 
+                        Is applicable to simple Links where all LinkPorts are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). 
+                        Is not present in more complex cases.";
+                }
+                uses global-class;
+                uses topological-entity;
+                description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). 
+                    In its basic form (i.e., point-to-point Link) it associates a set of LTP clients on one FD with an equivalent set of LTP clients on another FD. 
+                    Like the FC, the Link has ports (LinkPort) which take roles relevant to the constraints on flows offered by the Link (e.g., Root role or leaf role for a Link that has a constrained Tree configuration). 
+                    The Link is a Forwarding entity.";
+            }
+            grouping network-element {
+                list fd-ref-list {
+                    uses forwarding-domain;
+                    description "Represents the FD that is completely within the boundary of the NE.
+                        At a low level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). 
+                        Note that an NE can encompass multiple switch matrices (FDs) and the FD representing the switch matrix can be further partitioned.
+                        Where an FD is referenced by the NeEncompassesFd association, any FDs that it encompasses (i.e., that are associated with it by HigherLevelFdEncompassesLowerLevelFds), must also be encompassed by the NE and hence must have the NeEncompassesFd association.
+                        ";
+                }
+                leaf-list ltpp-list {
+                    type string;
+                    description "OBSOLETE. Was reference to LtpPool. The pool has now been subsumed into the LTP.
+                        This will be deleted in the next release.";
+                }
+                list ltp-ref-list {
+                    uses logical-termination-point;
+                    description "An NE has associated LTPs that are at its boundary.
+                        The NeEncompassesFd association occurs for FDs that are within the bounds of the NetworkElement definition such that the FD is bounded by LTPs, all of which are on the boundary of the NetworkElement or are within the NetworkElement. 
+                        An LTP can be independent of an NE.";
+                }
+                uses global-class;
+                description "The Network Element (NE) object class represents a network element (traditional NE) in the data plane.
+                    A data plane network element is essentially a consolidation of capabilities that can be viewed and controlled through a 'single' management-control port.
+                    In the direct interface from an SDN controller to a network element in the data plane, the NetworkElement object defines the scope of control for the resources within the network element
+                    For example internal transfer of user information between the external terminations (ports of the NE), encapsulation, multiplexing/demultiplexing, and OAM functions, etc. 
+                    The NetworkElement provides the scope of the naming space for identifying objects representing the resources within the data plane network element.
+                    NE is really a product bundling or some view of management scope, management access, session. 
+                    The NE is not directly part of topology but brings meaning to the FD context and the LTP context (and hence the links). ";
+            }
+            grouping sdn-controller {
+                uses global-class;
+                description "Represents the SDN controller.";
+            }
+            grouping fc-port {
+                leaf-list ltp-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    max-elements 2;
+                    description "The FcPort may be associated with more than one LTP when the FcPort is bidirectional and the LTPs are unidirectional.
+                        Multiple Ltp
+                        - Bidirectional FcPort to two Uni Ltps
+                        Zero Ltp
+                        - BreakBeforeMake transition
+                        - Planned Ltp not yet in place
+                        - Off-network LTP referenced through other mechanism";
+                }
+                leaf role {
+                    type port-role;
+                    description "Each FcPort of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+                }
+                leaf fc-port-direction {
+                    type port-direction;
+                    description "The orientation of defined flow at the FcPort.";
+                }
+                uses local-class;
+                description "The association of the FC to LTPs is made via FcPorts.
+                    The FcPort object class models the access to the FC function. 
+                    The traffic forwarding between the associated FcPorts of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
+                    In cases where there is resilience the FcPort may convey the resilience role of the access to the FC. 
+                    It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.
+                    The FcPort replaces the Protection Unit of a traditional protection model. 
+                    The ForwadingConstruct can be considered as a component and the FcPort as a Port on that component";
+            }
+            grouping layer-protocol {
+                leaf layer-protocol-name {
+                    type layer-protocol-name;
+                    description "Indicate the specific layer-protocol described by the LayerProtocol entity.";
+                }
+                leaf lp-spec {
+                    type leafref {
+                        path '/core-model:lp-spec/';
+                    }
+                    description "The LpSpec identifies the interna structure of the LP explaining internal flexibilities, degree of termination and degree of adaptation on both client and server side.";
+                }
+                leaf configured-client-capacity {
+                    type string;
+                    description "Provides a summarized view of the client capacity that is configurable for use.
+                        Note the cleint LTP association should provide all necessary detail hence this attribute is questionable.";
+                }
+                leaf lp-direction {
+                    type termination-direction;
+                    description "The overall directionality of the LP. 
+                        - A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.
+                        - A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows
+                        - A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows";
+                }
+                leaf termination-state {
+                    type string;
+                    description "Indicates whether the layer is terminated and if so how.";
+                }
+                uses local-class;
+                description "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. 
+                    It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. 
+                    Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ";
+            }
+            grouping logical-termination-point {
+                leaf-list server-ltp-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "References contained LTPs representing servers of this LTP in an inverse multiplexing configuration (e.g. VCAT).";
+                }
+                leaf-list client-ltp-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "References contained LTPs representing client traffic of this LTP for normal cases of multiplexing.";
+                }
+                list lp-list {
+                    min-elements 1;
+                    uses layer-protocol;
+                    description "Ordered list of LayerProtocols that this LTP is comprised of where the first entry in the list is the lowest server layer (e.g. physical)";
+                }
+                leaf connected-ltp-ref {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "Applicable in a simple context where two LTPs are associated via a non-adjustable enabled forwarding.
+                        Reduces clutter removing the need for two additional LTPs and an FC with a pair of FcPorts.";
+                }
+                leaf peer-ltp-ref {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "References contained LTPs representing the reversal of orientation of flow where two LTPs are associated via a non-adjustable enabled forwarding and where the referenced LTP is fully dependent on the this LTP.";
+                }
+                leaf ltp-spec {
+                    type leafref {
+                        path '/core-model:ltp-spec/';
+                    }
+                    description "The specification of the LTP defines internal structure of the LTP.
+                        The specification allows interpretation of organisatoon of LPs making up the LTP and also identifies which inter-LTP associations are valid.";
+                }
+                leaf-list physical-port-reference {
+                    type string;
+                    description "One or more text labels for the unmodelled physical port associated with the LTP.
+                        In many cases there is no associated physical port";
+                }
+                leaf-list ltp-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "References one or more LTPs in other views that represent this LTP. 
+                        The referencing LTP is the rovider of capability.";
+                }
+                leaf ltp-direction {
+                    type termination-direction;
+                    description "The overall directionality of the LTP. 
+                        - A BIDIRECTIONAL LTP must have at least some LPs that are BIDIRECTIONAL but may also have some SINK and/or SOURCE LPs.
+                        - A SINK LTP can only contain SINK LPs
+                        - A SOURCE LTP can only contain SOURCE LPs";
+                }
+                uses global-class;
+                description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
+                    The structure of LTP supports all transport protocols including circuit and packet forms.";
+            }
+            grouping fc-route {
+                list fc-list {
+                    min-elements 2;
+                    uses forwarding-construct;
+                    description "The list of FCs describing the route of an FC.";
+                }
+                uses local-class;
+                description "The FC Route (FcRoute) object class models the individual routes of an FC. The route is an alternative view of the internal structure of the FC.
+                    The route of an FC object is represented by a list of FCs at a lower level with the implicit understanding that unmodelled link connections are interleaved between the lower level FCs. 
+                    Note that depending on the service supported by an FC, an the FC can have multiple routes.
+                    Also applicable where NE level ForwardingDomain may be decomposed into subordinate ForwardingDomains. Applies to both virtual and real NE cases.";
+            }
+            grouping fc-switch {
+                leaf hold-off-time {
+                    type uint64;
+                    description "This attribute indicates the time, in seconds, between declaration of unacceptable quality of signal on the currently selected FcPort, and the initialization of the protection switching algorithm. ";
+                }
+                leaf wait-to-restore-time {
+                    type uint64;
+                    description "If the protection system is revertive, this attribute specifies the amount of time, in seconds, to wait after the preferred FcPort returns to an acceptable state of operaion (e.g a fault has cleared) before restoring traffic to that preferred FcPort. ";
+                }
+                leaf prot-type {
+                    type protection-type;
+                    description "Indicates the protection scheme that is used for the ProtectionGroup.";
+                }
+                leaf oper-type {
+                    type oper-type;
+                    description "This attribute whether or not the protection scheme is revertive or non-revertive. ";
+                }
+                leaf-list selected-fc-port-ref-list {
+                    type leafref {
+                        path '/core-model:fc-route/core-model:fc-list/core-model:fc-port-list/';
+                    }
+                    min-elements 1;
+                    description "Indicates which points are selected by the switch.";
+                }
+                leaf-list profile-proxy-ref-list {
+                    type leafref {
+                        path '/core-model:profile-proxy/';
+                    }
+                    description "Provides a set of predefined values for switch control in place of the direct values avaiable via the FcSwitch or via _configurationAndSwitchControl ";
+                }
+                leaf configuration-and-switch-control-ref {
+                    type leafref {
+                        path '/core-model:fc-route/core-model:fc-list/core-model:configuration-and-switch-control-list/';
+                    }
+                    description "A multi-switch controller external to the FcSwitch.
+                        The multi-switch controller coordinates multiple switches in the same FC or across multple FCs";
+                }
+                container configuration-and-switch-control {
+                    uses configuration-and-switch-controller;
+                    description "A switch controller encapsulated in the FcSwitch.
+                        ";
+                }
+                uses local-class;
+                description "none";
+            }
+            grouping link-port {
+                leaf ltpp {
+                    type string;
+                    description "OBSOLETE. Was reference to LtpPool. The pool has now been subsumed into the LTP.
+                        This will be deleted in the next release.";
+                }
+                leaf-list ltp-ref-list {
+                    type leafref {
+                        path '/core-model:network-control-domain/core-model:network-element-ref-list/core-model:ltp-ref-list/';
+                    }
+                    description "The LinkPort may be associated with more than one LTP when the LinkPort is bidirectional and the LTPs are unidirectional.
+                        Multiple Ltp
+                        - Bidirectional LinkPort to two Uni Ltps
+                        Zero Ltp
+                        - BreakBeforeMake transition
+                        - Planned Ltp not yet in place
+                        - Off-network LTP referenced through other mechanism";
+                }
+                leaf role {
+                    type port-role;
+                    description "Each LinkPort of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ";
+                }
+                leaf off-network-address {
+                    type string;
+                    description "A freeform opportunity to express a reference for an Port of the Link that is not outside the scope of the control domain.
+                        This attribute is expected to convey a foreign identifier/name/address or a shared reference for some mid-span point at the boundary between two administrative domains.
+                        This attribute is used when an LTP cannot be referenced.";
+                }
+                leaf link-port-direction {
+                    type port-direction;
+                    description "The orientation of defined flow at the LinkPort.";
+                }
+                uses local-class;
+                description "none";
+            }
+
+        /***********************
+        * package diagrams
+        **********************/ 
+
+        /***********************
+        * package associations
+        **********************/ 
+
+
+    /***********************
+    * package core-foundation-module
+    **********************/ 
+        /***********************
+        * package type-definitions
+        **********************/ 
+            typedef date-and-time {
+                type string;
+                description "This primitive type defines the date and time according to the following structure:
+                    'yyyyMMddhhmmss.s[Z|{+|-}HHMm]' where:
+                    yyyy    '0000'..'9999'    year
+                    MM        '01'..'12'            month
+                    dd        '01'..'31'            day
+                    hh        '00'..'23'            hour
+                    mm        '00'..'59'            minute
+                    ss        '00'..'59'            second
+                    s        '.0'..'.9'            tenth of second (set to '.0' if EMS or NE cannot support this granularity)
+                    Z        'Z'                    indicates UTC (rather than local time)
+                    {+|-}    '+' or '-'            delta from UTC
+                    HH        '00'..'23'            time zone difference in hours
+                    Mm        '00'..'59'            time zone difference in minutes.";
+            }
+            typedef bit-string {
+                type string;
+                description "This primitive type defines a bit oriented string.
+                    The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).
+                    The semantic of each bit position will be defined in the Documentation field of the attribute.";
+            }
+            typedef real {
+                type string;
+                description "This primitive type maps to the 'realnumber' defined in Recommendation X.680.";
+            }
+            typedef printable-string {
+                type string;
+                description "A string that only includes printable characters";
+            }
+
+        /***********************
+        * package super-classes-and-common-packages
+        **********************/ 
+            /***********************
+            * package object-classes
+            **********************/ 
+                grouping name {
+                    list name-list {
+                        min-elements 1;
+                        uses name-and-value;
+                        description "List of names.";
+                    }
+                    description "Name: A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
+                }
+                grouping global-class {
+                    list local-id-list {
+                        uses name-and-value;
+                        description "An identifier that is unique in the context of some scope that is less than the global scope.
+                            (consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself unique, and immutable. The identifier therefore represents the identity of the entity/role. An identifier carries no semantics with respect to the purpose of the entity.)";
+                    }
+                    leaf uuid {
+                        type universal-id;
+                        description "UUID: An identifier that is universally unique
+                            (consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)";
+                    }
+                    uses name;
+                    uses label;
+                    uses extension;
+                    uses state-pac;
+                    description "Represents a type of thing (an Entity) that has instances which can exist in their own right (independently of any others).
+                        Entity: Has identity, defined boundary, properties, functionality and lifecycle in a global context.
+                        (consider in the context of an Object Class: (usage) The representation of a thing that may be an entity or an inseparable Entity Feature)";
+                }
+                grouping local-class {
+                    list local-id-list {
+                        min-elements 1;
+                        uses name-and-value;
+                        description "An identifier that is unique in the context of some scope that is less than the global scope.
+                            (consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself unique, and immutable. The identifier therefore represents the identity of the entity/role. An identifier carries no semantics with respect to the purpose of the entity.)";
+                    }
+                    uses name;
+                    uses label;
+                    uses extension;
+                    uses state-pac;
+                    description "A LocalClass represents a Feature of an Entity. It is inseparable from a GlobalClass but is a distinct feature of that GlobalClass such that the instances of LocalClass are able to have associations to other instances..
+                        Feature of an Entity: An inseparable, externally distinguishable part of an entity.
+                        The mandatory LocalId of the LocalClass instance is unique in the context of the GlobalClass from which it is inseparable.
+                        (consider in the context of an Object Class: (usage) The representation of a thing that may be an entity or an inseparable feature of an entity)
+                        ";
+                }
+                grouping label {
+                    list label-list {
+                        uses name-and-value;
+                        description "List of labels.";
+                    }
+                    description "A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.";
+                }
+                grouping extension {
+                    list extension-list {
+                        uses name-and-value;
+                        description "List of simple name-value extentions";
+                    }
+                    description "Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.";
+                }
+                grouping universal-id-authority {
+                    leaf uuid {
+                        type universal-id;
+                        description "The UUID for the UUID authority.";
+                    }
+                    description "Represents the authority that controls the allocation of UUIDs.";
+                }
+                grouping name-and-value-authority {
+                    leaf uuid {
+                        type universal-id;
+                        description "The UUID for the NameValueAuthority.";
+                    }
+                    description "Represents the authority that controls the legal valuse for the names and values of a name/value attribute.";
+                }
+                grouping conditional-package {
+                    uses extension;
+                    uses label;
+                    description "The base class for conditional packages.";
+                }
+
+            /***********************
+            * package type-definitions
+            **********************/ 
+                grouping name-and-value {
+                    leaf value-name {
+                        type string;
+                        description "The name of the value. The value need not have a name.";
+                    }
+                    leaf value {
+                        type string;
+                        description "The value";
+                    }
+                    leaf name-and-value-authority-ref {
+                        type leafref {
+                            path '/core-model:name-and-value-authority/';
+                        }
+                        description "The authority that defines the named value.";
+                    }
+                    leaf global-class-ref {
+                        type leafref {
+                            path '/core-model:global-class/';
+                        }
+                        description "The scope of the name uniqueness";
+                    }
+                    leaf local-class-ref {
+                        type leafref {
+                            path '/core-model:local-class/';
+                        }
+                        description "The scope of the name uniqueness";
+                    }
+                    description "A scoped name-value pair";
+                }
+                typedef universal-id {
+                    type string;
+                    description "The univeral ID value where the mechanism for generation is defned by some authority not directly referenced in the structure.";
+                }
+
+
+        /***********************
+        * package state-model
+        **********************/ 
+            /***********************
+            * package object-classes
+            **********************/ 
+                grouping state-pac {
+                    leaf operational-state {
+                        type operational-state;
+                        config false;
+                        description "The operational state is used to indicate whether or not the resource is installed and working";
+                    }
+                    leaf administrative-control {
+                        type administrative-control;
+                        description "The administrativeControl state provides control of the availability of specific resources without modification to the provisioning of those resources.
+                            The value is the current control target. The actual administrativeState may or may not be at target.";
+                    }
+                    leaf adminsatratve-state {
+                        type administrative-state;
+                        config false;
+                        description "Shows whether or not the client has permission to use or has a prohibition against using the resource.
+                            The administrative state expresses usage permissions for specific resources without modification to the provisioning of those resources.";
+                    }
+                    leaf lifecycle-state {
+                        type lifecycle-state;
+                        description "Used to track the planned deployment, allocation to clients and withdrawal of resources. ";
+                    }
+                    description "Provides general state attributes.";
+                }
+
+            /***********************
+            * package type-definitions
+            **********************/ 
+                typedef operational-state {
+                    type enumeration {
+                        enum disabled {
+                            description "The resource is unable to meet the SLA of the user of the resource. If no (explicit) SLA is defined the resource is disabled if it is totally inoperable and unable to provide service to the user.";
+                        }
+                        enum enabled {
+                            description "The resource is partially or fully operable and available for use";
+                        }
+                    }
+                    description "The possible values of the operationalState.";
+                }
+                typedef administrative-state {
+                    type enumeration {
+                        enum locked {
+                            description "Users are administratively prohibited from making use of the resource.";
+                        }
+                        enum unlocked {
+                            description "Users are allowed to use the resource";
+                        }
+                    }
+                    description "The possible values of the administrativeState.";
+                }
+                typedef administrative-control {
+                    type enumeration {
+                        enum unlock {
+                            description "The intention is for the entity to become unlocked.
+                                The entity may already be UNLOCKED.";
+                        }
+                        enum lock-passive {
+                            description "The intention is for the entity to become locked but no effort is expected to move to the Locked state (the state will be achieved once all users stop using the resource). 
+                                The entity may be LOCKED";
+                        }
+                        enum lock-active {
+                            description "The intention is for the entity to become locked and it is expected that effort will be made to move to the Locked state (users will be actively removed). 
+                                The entity may already be LOCKED.";
+                        }
+                        enum lock-immediate {
+                            description "The intention is for the entity to become locked and it is expected to move to the Locked state immediately (users will be force removed). 
+                                The entity may already be LOCKED.";
+                        }
+                    }
+                    description "Reflects the current control action when the entity is not in the desired state.
+                        The possible values of the current target administrative state.";
+                }
+                typedef extended-admin-state {
+                    type enumeration {
+                        enum locked {
+                            description "Users are administratively prohibited from making use of the resource.";
+                        }
+                        enum unlocked {
+                            description "Users are allowed to use the resource";
+                        }
+                        enum shutting-down-active {
+                            description "The entity is administratively restricted to existing instances of use only. There are specific actions to remove existing uses. There may be no new instances of use enabled. This corresponds to a control of LOCK_ACTIVE.";
+                        }
+                        enum shutting-down-passive {
+                            description "The entity is administratively restricted to existing instances of use only. There may be no new instances of use enabled. This corresponds to a control of LOCK_PASSIVE.";
+                        }
+                    }
+                    description "Possible extentions to AdministrativeState";
+                }
+                typedef lifecycle-state {
+                    type enumeration {
+                        enum planned {
+                            description "The resource is planned but is not present in the network.";
+                        }
+                        enum potential {
+                            description "The supporting resources are present in the network but are shared with other clients; or require further configuration before they can be used; or both.
+                                o    When a potential resource is configured and allocated to a client it is moved to the “installed” state for that client.
+                                o    If the potential resource has been consumed (e.g. allocated to another client) it is moved to the “planned” state for all other clients.";
+                        }
+                        enum installed {
+                            description "The resource is present in the network and is capable of providing the service expected.";
+                        }
+                        enum pending-removal {
+                            description "The resource has been marked for removal";
+                        }
+                    }
+                    description "The possible values of the lifecycleState.";
+                }
+
+
+
+    /***********************
+    * package core-model-enhancements
+    **********************/ 
+        /***********************
+        * package fc-switch-enhancements-developed
+        **********************/ 
+            grouping profile-proxy {
+                leaf profile-proxy-mode {
+                    type string;
+                    description "A parameter profile may be used in a number of different ways:
+                        - Forces the values on the target with no opportunity to see or override the values in the target
+                        - Sets the values on the target that can be seen on the target
+                        - Sets the values on the target and supports override on the target so the target can be set away from the value in the profile
+                        - etc";
+                }
+                container control-parameters {
+                    uses control-parameters;
+                    description "The control parameters that can be set int the profile and applied to the target.
+                        Not all parameters need be selected and applied.";
+                }
+                description "A lightweight sketch placeholder for the profile model.";
+            }
+            grouping configuration-and-switch-controller {
+                leaf swich-rule {
+                    type string;
+                    description "A sketch of the presence of complex rules governing the switch behavior.";
+                }
+                leaf-list fc-switch-ref-list {
+                    type leafref {
+                        path '/core-model:fc-route/core-model:fc-list/core-model:fc-switch-list/';
+                    }
+                    description "The switch being controlled.";
+                }
+                container control-parameters {
+                    uses control-parameters;
+                    description "The control parameters to be aplied if local parameters are used rather than profiles";
+                }
+                leaf-list profile-proxy-ref {
+                    type leafref {
+                        path '/core-model:profile-proxy/';
+                    }
+                    description "Applied profiles.";
+                }
+                description "Sketch representation of a cntroller with basic capability to control switched and add/delete/modify FCs.";
+            }
+            grouping control-parameters {
+                leaf oper-type {
+                    type oper-type;
+                    description "This attribute whether or not the protection scheme is revertive or non-revertive. ";
+                }
+                leaf wait-to-restore-time {
+                    type uint64;
+                    description "If the protection system is revertive, this attribute specifies the amount of time, in seconds, to wait after a fault clears before restoring traffic to the protected protectionUnit that initiated the switching. Valid values for this attribute are integers.";
+                }
+                leaf prot-type {
+                    type protection-type;
+                    description "Indicates the protection scheme that is used for the ProtectionGroup.";
+                }
+                leaf hold-off-time {
+                    type uint64;
+                    description "This attribute indicates the time, in seconds, between declaration of signal degrade or signal fail, and the initialization of the protection switching algorithm. Valid values are integers in units of seconds.";
+                }
+                description "A list of control parameters to apply to a switch";
+            }
+            container configuration-group {
+                list configuration-and-switch-control-ref-list {
+                    uses configuration-and-switch-controller;
+                    description "A controller operating in the scope defined.";
+                }
+                description "Represents a scope of control for one or more Controllers";
+            }
+
+        /***********************
+        * package profiles-templates-and-specifications-module
+        **********************/ 
+            /***********************
+            * package fc-capability-developed
+            **********************/ 
+                /***********************
+                * package object-classes
+                **********************/ 
+                    grouping multi-switched-uni-flow {
+                        list ingress-fc-port {
+                            min-elements 1;
+                            uses ingress-fc-port-set;
+                            description "none";
+                        }
+                        list egress-fc-port {
+                            min-elements 1;
+                            uses egress-fc-port-set;
+                            description "none";
+                        }
+                        container switch-control {
+                            uses configuration-and-switch-control;
+                            description "none";
+                        }
+                        leaf ingress-fc-port-set {
+                            type leafref {
+                                path '/core-model:configuration-group-spec/core-model:fc-spec/core-model:multi-switched-uni-flow/core-model:ingress-fc-port/';
+                            }
+                            description "none";
+                        }
+                        leaf egress-fc-port-set {
+                            type leafref {
+                                path '/core-model:configuration-group-spec/core-model:fc-spec/core-model:multi-switched-uni-flow/core-model:egress-fc-port/';
+                            }
+                            description "none";
+                        }
+                        uses local-class;
+                        description "none";
+                    }
+                    grouping ingress-fc-port-set {
+                        uses local-class;
+                        description "none";
+                    }
+                    grouping egress-fc-port-set {
+                        uses local-class;
+                        description "none";
+                    }
+                    grouping configuration-and-switch-control {
+                        list switch-control-rule {
+                            min-elements 1;
+                            uses control-rule;
+                            description "none";
+                        }
+                        leaf-list switch {
+                            type string;
+                            min-elements 1;
+                            description "none";
+                        }
+                        leaf-list egress-selection {
+                            type string;
+                            min-elements 1;
+                            description "none";
+                        }
+                        uses global-class;
+                        description "none";
+                    }
+                    grouping fc-spec {
+                        list multi-switched-uni-flow {
+                            min-elements 1;
+                            uses multi-switched-uni-flow;
+                            description "none";
+                        }
+                        list switch-control {
+                            uses configuration-and-switch-control;
+                            description "none";
+                        }
+                        list fc-port-spec {
+                            min-elements 1;
+                            uses fc-port-set-spec;
+                            description "none";
+                        }
+                        leaf fc-switch-group-spec {
+                            type leafref {
+                                path '/core-model:configuration-group-spec/';
+                            }
+                            description "none";
+                        }
+                        container ltp-association-rule {
+                            uses ltp-association-rule;
+                            description "none";
+                        }
+                        uses global-class;
+                        description "none";
+                    }
+                    grouping configuration-group-spec {
+                        container switch-control {
+                            uses configuration-and-switch-control;
+                            description "none";
+                        }
+                        container fc-spec {
+                            uses fc-spec;
+                            description "none";
+                        }
+                        container ltp-association-rule {
+                            uses ltp-association-rule;
+                            description "none";
+                        }
+                        uses global-class;
+                        description "none";
+                    }
+                    grouping control-rule {
+                        leaf switch-control-switch-1 {
+                            type string;
+                            description "none";
+                        }
+                        uses local-class;
+                        description "none";
+                    }
+                    grouping fc-port-set-spec {
+                        leaf-list ingress-fc-port-set {
+                            type leafref {
+                                path '/core-model:configuration-group-spec/core-model:fc-spec/core-model:multi-switched-uni-flow/core-model:ingress-fc-port/';
+                            }
+                            description "none";
+                        }
+                        leaf-list egress-fc-port-set {
+                            type leafref {
+                                path '/core-model:configuration-group-spec/core-model:fc-spec/core-model:multi-switched-uni-flow/core-model:egress-fc-port/';
+                            }
+                            description "none";
+                        }
+                        leaf ltp-association-rule {
+                            type leafref {
+                                path '/core-model:configuration-group-spec/core-model:fc-spec/core-model:ltp-association-rule/';
+                            }
+                            description "none";
+                        }
+                        leaf role {
+                            type string;
+                            default "true";
+                            description "none";
+                        }
+                        uses local-class;
+                        description "none";
+                    }
+                    grouping ltp-association-rule {
+                        uses local-class;
+                        description "none";
+                    }
+                    container switch-property-spec-pac {
+                        description "none";
+                    }
+                    container ingress-fc-port-set-spec-pac {
+                        description "none";
+                    }
+
+
+            /***********************
+            * package ltp-capability-developed
+            **********************/ 
+                /***********************
+                * package object-classes
+                **********************/ 
+                    grouping lp-spec {
+                        container adapter-spec {
+                            uses connection-point-and-adapter-spec;
+                            description "none";
+                        }
+                        container termination-spec {
+                            uses termination-spec;
+                            description "none";
+                        }
+                        list adapter-property-spec-list {
+                            uses adapter-property-spec;
+                            description "none";
+                        }
+                        container provider-view-spec {
+                            uses provider-view-spec;
+                            description "none";
+                        }
+                        list server-spec-list {
+                            uses server-spec;
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping client-spec {
+                        leaf-list mapping-interaction-rule-ref-list {
+                            type leafref {
+                                path '/core-model:lp-spec/core-model:adapter-property-spec-list/core-model:mapping-interaction-rule-list/';
+                            }
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping mapping-interaction-rule {
+                        description "none";
+                    }
+                    grouping termination-spec {
+                        container connection-spec {
+                            uses connection-spec;
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping adapter-property-spec {
+                        list pool-property-spec-list {
+                            uses pool-property-spec;
+                            description "none";
+                        }
+                        leaf-list mapping-interaction-rule-ref-list {
+                            type leafref {
+                                path '/core-model:lp-spec/core-model:adapter-property-spec-list/core-model:mapping-interaction-rule-list/';
+                            }
+                            description "none";
+                        }
+                        list mapping-interaction-rule-list {
+                            uses mapping-interaction-rule;
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping pool-property-spec {
+                        container client-spec {
+                            uses client-spec;
+                            description "none";
+                        }
+                        leaf client-capacity {
+                            type string;
+                            default "true";
+                            description "none";
+                        }
+                        leaf-list adapter-property-spec-ref-list {
+                            type leafref {
+                                path '/core-model:lp-spec/core-model:adapter-property-spec-list/';
+                            }
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping connection-spec {
+                        description "none";
+                    }
+                    grouping connection-point-and-adapter-spec {
+                        leaf connection-spec {
+                            type leafref {
+                                path '/core-model:lp-spec/core-model:termination-spec/core-model:connection-spec/';
+                            }
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping provider-view-spec {
+                        leaf-list pool-property-spec-list {
+                            type leafref {
+                                path '/core-model:lp-spec/core-model:adapter-property-spec-list/core-model:pool-property-spec-list/';
+                            }
+                            description "none";
+                        }
+                        description "none";
+                    }
+                    grouping server-spec {
+                        description "none";
+                    }
+                    grouping ltp-spec {
+                        leaf-list lp-spec-list {
+                            type leafref {
+                                path '/core-model:lp-spec/';
+                            }
+                            min-elements 1;
+                            description "none";
+                        }
+                        description "none";
+                    }
+
+
+            /***********************
+            * package link-capability-sketch
+            **********************/ 
+                grouping link-spec {
+                    description "Describes the capabilities of the Link focussing on link asymmetries and constraints.";
+                }
+
+            /***********************
+            * package spec-and-profile-sketch
+            **********************/ 
+                list any-entity-instance {
+                    leaf-list profile-ref-list {
+                        type leafref {
+                            path '/core-model:profile-instance/';
+                        }
+                        description "none";
+                    }
+                    leaf spec-ref {
+                        type leafref {
+                            path '/core-model:spec-instance/';
+                        }
+                        description "none";
+                    }
+                    leaf class {
+                        type leafref {
+                            path '/core-model:any-entity-class/';
+                        }
+                        description "none";
+                    }
+                    description "none";
+                }
+                grouping profile-instance {
+                    leaf spec-instance-ref {
+                        type leafref {
+                            path '/core-model:spec-instance/';
+                        }
+                        description "none";
+                    }
+                    leaf profile-class {
+                        type leafref {
+                            path '/core-model:profile-class/';
+                        }
+                        description "none";
+                    }
+                    leaf class {
+                        type leafref {
+                            path '/core-model:any-entity-class/';
+                        }
+                        description "none";
+                    }
+                    description "none";
+                }
+                grouping spec-instance {
+                    leaf spec-class {
+                        type leafref {
+                            path '/core-model:spec-class/';
+                        }
+                        description "none";
+                    }
+                    leaf class-ref {
+                        type leafref {
+                            path '/core-model:any-entity-class/';
+                        }
+                        description "none";
+                    }
+                    description "none";
+                }
+                grouping any-entity-class {
+                    description "none";
+                }
+                grouping spec-class {
+                    uses any-entity-class;
+                    description "none";
+                }
+                grouping profile-class {
+                    uses any-entity-class;
+                    description "none";
+                }
+
+
+        /***********************
+        * package modeling-enhancements
+        **********************/ 
+
+        /***********************
+        * package view-abstraction-rule-sketch
+        **********************/ 
+            list view-abstraction-rules {
+                leaf-list -ltp-relatest-to-ltp-in-other-view {
+                    type string;
+                    description "none";
+                }
+                description "Provides rules and access to policies that govern and explain the view abstraction.
+                    At this point it appears that this is not necessary however it has been left in the model as there is still some view abstraction work to be done.";
+            }
+
+        /***********************
+        * package information-architecture-and-patterns
+        **********************/ 
+            /***********************
+            * package essential-structure-sketch
+            **********************/ 
+                grouping component {
+                    list port {
+                        min-elements 1;
+                        uses port;
+                        description "none";
+                    }
+                    list attribute-package-list {
+                        uses attribute-package;
+                        description "none";
+                    }
+                    leaf bound-component {
+                        type leafref {
+                            path '/core-model:component/';
+                        }
+                        description "none";
+                    }
+                    leaf encapsulated-system {
+                        type leafref {
+                            path '/core-model:system/';
+                        }
+                        description "none";
+                    }
+                    description "none";
+                }
+                grouping port {
+                    leaf role {
+                        type string;
+                        default "true";
+                        description "none";
+                    }
+                    leaf bound-port {
+                        type leafref {
+                            path '/core-model:component/core-model:port/';
+                        }
+                        description "none";
+                    }
+                    description "none";
+                }
+                grouping system {
+                    description "none";
+                }
+                grouping attribute-package {
+                    description "none";
+                }
+
+
+        /***********************
+        * package inter-view-relationships-sketch
+        **********************/ 
+            grouping sketch-fc {
+                leaf supporting-fc-in-other-view-ref {
+                    type leafref {
+                        path '/core-model:sketch-fc/';
+                    }
+                    description "none";
+                }
+                leaf-list suported-fc-in-other-view {
+                    type leafref {
+                        path '/core-model:sketch-fc/';
+                    }
+                    description "none";
+                }
+                description "none";
+            }
+            grouping sketch-ltp {
+                leaf supporting-ltp-in-other-view-ref {
+                    type leafref {
+                        path '/core-model:sketch-ltp/';
+                    }
+                    description "none";
+                }
+                leaf-list supported-ltp-in-other-view-ref {
+                    type leafref {
+                        path '/core-model:sketch-ltp/';
+                    }
+                    description "none";
+                }
+                description "none";
+            }
+
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-connectivity.yang
+++ b/xmi2yang tool-v2.0/project/tapi-connectivity.yang
@@ -1,0 +1,468 @@
+module tapi-connectivity {
+    namespace "urn:onf:params:xml:ns:yang:TapiConnectivity";
+    prefix tapi-connectivity;
+    import tapi {
+        prefix tapi;
+    }
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_connection" {
+        uses connection;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_connectivityService" {
+        uses connectivity-service;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping connection {
+            list connection-port {
+                key 'local-id';
+                config false;
+                min-elements 2;
+                uses connection-port;
+                description "none";
+            }
+            list route {
+                key 'local-id';
+                config false;
+                uses route;
+                description "none";
+            }
+            leaf node {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            container state {
+                config false;
+                uses tapi:operational-state-pac;
+                description "none";
+            }
+            leaf layer-protocol-name {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            leaf direction {
+                type tapi:forwarding-direction;
+                config false;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
+                At the lowest level of recursion, a FC represents a cross-connection within an NE.";
+        }
+        grouping connection-end-point {
+            list layer-protocol {
+                key 'local-id';
+                config false;
+                min-elements 1;
+                uses tapi:layer-protocol;
+                description "none";
+            }
+            leaf-list client-node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf server-node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf peer-connection-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:connection/tapi-connectivity:connection-port/tapi-connectivity:connection-end-point/tapi-connectivity:uuid';
+                }
+                config false;
+                description "none";
+            }
+            container state {
+                config false;
+                uses tapi:operational-state-pac;
+                description "none";
+            }
+            leaf direction {
+                type tapi:termination-direction;
+                config false;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
+                The structure of LTP supports all transport protocols including circuit and packet forms.";
+        }
+        grouping connection-port {
+            container connection-end-point {
+                config false;
+                uses connection-end-point;
+                description "none";
+            }
+            leaf role {
+                type tapi:port-role;
+                config false;
+                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+            }
+            leaf direction {
+                type tapi:port-direction;
+                config false;
+                description "The orientation of defined flow at the EndPoint.";
+            }
+            uses tapi:local-class;
+            description "The association of the FC to LTPs is made via EndPoints.
+                The EndPoint (EP) object class models the access to the FC function. 
+                The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
+                In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. 
+                It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.
+                The EP replaces the Protection Unit of a traditional protection model. 
+                The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
+        }
+        grouping connectivity-constraint {
+            leaf service-type {
+                type service-type;
+                config false;
+                description "none";
+            }
+            leaf service-level {
+                type string;
+                config false;
+                description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
+            }
+            leaf-list service-layer {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            container requested-capacity {
+                config false;
+                uses tapi-topology:capacity;
+                description "none";
+            }
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
+                config false;
+                uses tapi-topology:cost-characteristic;
+                description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
+            }
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
+                config false;
+                uses tapi-topology:latency-characteristic;
+                description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
+            }
+            leaf-list diversity-exclusion {
+                type leafref {
+                    path '/tapi:context/tapi:connectivity-service/tapi:uuid';
+                }
+                description "none";
+            }
+            leaf-list include-topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf-list avoid-topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            list include-path {
+                key 'local-id';
+                config false;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            list exclude-path {
+                key 'local-id';
+                config false;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "none";
+        }
+        grouping connectivity-service {
+            leaf-list connection {
+                type leafref {
+                    path '/tapi:context/tapi:connection/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            list service-port {
+                key 'local-id';
+                min-elements 2;
+                uses connectivity-service-port;
+                description "none";
+            }
+            container conn-constraint {
+                uses connectivity-constraint;
+                description "none";
+            }
+            container schedule {
+                uses tapi:time-range;
+                description "none";
+            }
+            container state {
+                uses tapi:admin-state-pac;
+                description "none";
+            }
+            leaf direction {
+                type tapi:forwarding-direction;
+                description "none";
+            }
+            leaf layer-protocol-name {
+                type tapi:layer-protocol-name;
+                description "none";
+            }
+            uses tapi:service-spec;
+            description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
+                At the lowest level of recursion, a FC represents a cross-connection within an NE.";
+        }
+        grouping connectivity-service-port {
+            leaf service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf role {
+                type tapi:port-role;
+                config false;
+                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+            }
+            leaf direction {
+                type tapi:port-direction;
+                config false;
+                description "The orientation of defined flow at the EndPoint.";
+            }
+            leaf service-layer {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "The association of the FC to LTPs is made via EndPoints.
+                The EndPoint (EP) object class models the access to the FC function. 
+                The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
+                In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. 
+                It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.
+                The EP replaces the Protection Unit of a traditional protection model. 
+                The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
+        }
+        grouping route {
+            leaf-list lower-connection {
+                type leafref {
+                    path '/tapi:context/tapi:connection/tapi:uuid';
+                }
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "The FC Route (FcRoute) object class models the individual routes of an FC. 
+                The route of an FC object is represented by a list of FCs at a lower level. 
+                Note that depending on the service supported by an FC, an the FC can have multiple routes.";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        typedef service-type {
+            type enumeration {
+                enum point-to-point-connectivity {
+                    description "none";
+                }
+                enum point-to-multipoint-connectivty {
+                    description "none";
+                }
+                enum multipoint-connectivity {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+
+    /***********************
+    * package interfaces
+    **********************/ 
+        rpc get-connection-details {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf connection-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container connection {
+                    uses connection;
+                    description "none";
+                }
+            }
+        }
+        rpc get-connectivity-service-list {
+            description "none";
+            output {
+                list conn-service {
+                    uses connectivity-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-connection-end-point-details {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf connection-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf conn-epid-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container conn-ep {
+                    uses connection-end-point;
+                    description "none";
+                }
+            }
+        }
+        rpc get-service-end-point-details {
+            description "none";
+            input {
+                leaf service-epid-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                leaf service-end-point {
+                    type string;
+                    description "none";
+                }
+            }
+        }
+        rpc get-connectivity-service-details {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container conn-service {
+                    uses connectivity-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-service-end-point-list {
+            description "none";
+            output {
+                leaf service-end-point {
+                    type string;
+                    description "none";
+                }
+            }
+        }
+        rpc create-connectivity-service {
+            description "none";
+            input {
+                list service-port {
+                    min-elements 2;
+                    uses connectivity-service-port;
+                    description "none";
+                }
+                container conn-constraint {
+                    uses connectivity-constraint;
+                    description "none";
+                }
+                leaf conn-schedule {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container conn-service {
+                    uses connectivity-service;
+                    description "none";
+                }
+            }
+        }
+        rpc update-connectivity-service {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+                container conn-constraint {
+                    uses connectivity-constraint;
+                    description "none";
+                }
+                leaf conn-schedule {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container conn-service {
+                    uses connectivity-service;
+                    description "none";
+                }
+            }
+        }
+        rpc delete-connectivity-service {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container conn-service {
+                    uses connectivity-service;
+                    description "none";
+                }
+            }
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-eth.yang
+++ b/xmi2yang tool-v2.0/project/tapi-eth.yang
@@ -1,0 +1,791 @@
+module tapi-eth {
+    namespace "urn:onf:params:xml:ns:yang:TapiEth";
+    prefix tapi-eth;
+    import tapi {
+        prefix tapi;
+    }
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    import tapi-connectivity {
+        prefix tapi-connectivity;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
+        uses connection-end-point-lp-spec;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
+        uses node-edge-point-lp-spec;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping connection-point-and-adapter-pac {
+            leaf-list auxiliary-function-position-sequence {
+                type uint64;
+                description "This attribute indicates the positions (i.e., the relative order) of all the MEP, MIP, and TCS objects which are associated with the CTP.";
+            }
+            leaf vlan-config {
+                type uint64;
+                description "This attribute models the ETHx/ETH-m_A_So_MI_Vlan_Config information defined in G.8021.
+                    range of type : -1, 0, 1..4094";
+            }
+            leaf csf-rdi-fdi-enable {
+                type boolean;
+                description "This attribute models the MI_CSFrdifdiEnable information defined in G.8021.";
+            }
+            leaf csf-report {
+                type boolean;
+                description "This attribute models the MI_CSF_Reported information defined in G.8021.
+                    range of type : true, false";
+            }
+            leaf-list filter-config-snk {
+                type mac-address;
+                min-elements 33;
+                max-elements 33;
+                description "This attribute models the FilteConfig MI defined in 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:
+                    01-80-C2-00-00-10, 
+                    01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and 
+                    01-80-C2-00-00-20 to 01-80-C2-00-00-2F.
+                    The filter action is Pass or Block. 
+                    If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. 
+                    If none of the above addresses match, the ETH_CI_D is passed.";
+            }
+            leaf mac-length {
+                type uint64;
+                default "2000";
+                description "This attribute models the MAC_Lenght MI defined in 8.6/G.8021 for the MAC Length Check process. It indicates the allowed maximum frame length in bytes.
+                    range of type : 1518, 1522, 2000";
+            }
+            container filter-config {
+                uses control-frame-filter;
+                description "This attribute models the FilterConfig MI defined in section 8.3/G.8021. It indicates the configured filter action for each of the 33 group MAC addresses for control frames. The 33 MAC addresses are:
+                    - All bridges address: 01-80-C2-00-00-10,
+                    - Reserved addresses: 01-80-C2-00-00-00 to 01-80-C2-00-00-0F,
+                    - GARP Application addresses: 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.
+                    The filter action is Pass or Block. 
+                    If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. 
+                    If none of the above addresses match, the ETH_CI_D is passed.";
+            }
+            leaf is-ssf-reported {
+                type boolean;
+                description "This attribute provisions whether the SSF defect should be reported as fault cause or not.
+                    It models the ETH-LAG_FT_Sk_MI_SSF_Reported defined in G.8021.";
+            }
+            leaf pll-thr {
+                type uint64;
+                description "This attribute provisions the threshold for the number of active ports. If the number of active ports is more than zero but less than the provisioned threshold, a cPLL (Partial Link Loss) is raised. See section 9.7.1.2 of G.8021.
+                    range of type : 0..number of ports";
+            }
+            leaf actor-oper-key {
+                type uint64;
+                config false;
+                description "See 802.1AX:
+                    The current operational value of the Key for the Aggregator. The administrative Key value may differ from the operational Key value for the reasons discussed in 5.6.2.
+                    The meaning of particular Key values is of local significance.
+                    range of type : 16 bit";
+            }
+            leaf actor-system-id {
+                type mac-address;
+                description "See 802.1AX:
+                    A MAC address used as a unique identifier for the System that contains this Aggregator.";
+            }
+            leaf actor-system-priority {
+                type uint64;
+                description "See 802.1AX:
+                    Indicating the priority associated with the Actor’s System ID.
+                    range of type : 2-octet";
+            }
+            leaf collector-max-delay {
+                type uint64;
+                description "See 802.1AX:
+                    The value of this attribute defines the maximum delay, in tens of microseconds, that may be imposed by the Frame Collector between receiving a frame from an Aggregator Parser, and either delivering the frame to its MAC Client or discarding the frame (see IEEE 802.1AX clause 5.2.3.1.1).
+                    range of type : 16-bit";
+            }
+            leaf data-rate {
+                type uint64;
+                config false;
+                description "See 802.1AX:
+                    The current data rate, in bits per second, of the aggregate link. The value is calculated as N times the data rate of a single link in the aggregation, where N is the number of active links.";
+            }
+            leaf partner-oper-key {
+                type uint64;
+                config false;
+                description "See 802.1AX:
+                    The current operational value of the Key for the Aggregator’s current protocol Partner. If the aggregation is manually configured, this Key value will be a value assigned by the local System.
+                    range of type : 16-bit";
+            }
+            leaf partner-system-id {
+                type mac-address;
+                config false;
+                description "See 802.1AX:
+                    A MAC address consisting of the unique identifier for the current protocol Partner of this Aggregator. A value of zero indicates that there is no known Partner. If the aggregation is manually configured, this System ID value will be a value assigned by the local System.";
+            }
+            leaf partner-system-priority {
+                type uint64;
+                config false;
+                description "See 802.1AX:
+                    Indicates the priority associated with the Partner’s System ID. If the aggregation is manually configured, this System Priority value will be a value assigned by the local System.
+                    range of type : 2-octet";
+            }
+            leaf csf-config {
+                type csf-config;
+                description "This attribute models the combination of all CSF related MI signals (MI_CSF_Enable, MI_CSFrdifdi_Enable, MI_CSFdci_Enable) as defined in G.8021.
+                    range of type : true, false";
+            }
+            description "none";
+        }
+        grouping connection-end-point-lp-spec {
+            container termination-spec {
+                uses eth-termination-pac;
+                description "none";
+            }
+            container adapter-spec {
+                uses connection-point-and-adapter-pac;
+                description "none";
+            }
+            uses tapi:extensions-spec;
+            description "none";
+        }
+        grouping eth-termination-pac {
+            container priority-regenerate {
+                uses priority-mapping;
+                description "This attribute models the ETHx/ETH-m _A_Sk_MI_P_Regenerate information defined in G.8021.";
+            }
+            leaf ether-type {
+                type vlan-type;
+                description "This attribute models the ETHx/ETH-m _A_Sk_MI_Etype information defined in G.8021.";
+            }
+            leaf-list filter-config {
+                type mac-address;
+                min-elements 33;
+                max-elements 33;
+                description "This attribute models the ETHx/ETH-m_A_Sk_MI_Filter_Config information defined in G.8021.
+                    It indicates the configured filter action for each of the 33 group MAC addresses for control frames.
+                    The 33 MAC addresses are:
+                    01-80-C2-00-00-10, 
+                    01-80-C2-00-00-00 to 01-80-C2-00-00-0F, and 
+                    01-80-C2-00-00-20 to 01-80-C2-00-00-2F.
+                    The filter action is Pass or Block. 
+                    If the destination address of the incoming ETH_CI_D matches one of the above addresses, the filter process shall perform the corresponding configured filter action. 
+                    If none of the above addresses match, the ETH_CI_D is passed.
+                    range of type : MacAddress: 
+                    01-80-C2-00-00-10, 
+                    01-80-C2-00-00-00 to 
+                    01-80-C2-00-00-0F, and 
+                    01-80-C2-00-00-20 to 
+                    01-80-C2-00-00-2F;
+                    ActionEnum:
+                    PASS, BLOCK";
+            }
+            leaf frametype-config {
+                type frame-type;
+                description "This attribute models the ETHx/ETH-m_A_Sk_MI_Frametype_Config information defined in G.8021.
+                    range of type : see Enumeration";
+            }
+            leaf port-vid {
+                type vid {
+                    range "0..4095";
+                }
+                default "1";
+                description "This attribute models the ETHx/ETH-m _A_Sk_MI_PVID information defined in G.8021.";
+            }
+            leaf priority-code-point-config {
+                type pcp-coding;
+                default "8P0D";
+                description "This attribute models the ETHx/ETH-m _A_Sk_MI_PCP_Config information defined in G.8021.
+                    range of type : see Enumeration";
+            }
+            description "This object class models the Ethernet Flow Termination function located at a layer boundary.";
+        }
+        grouping ety-termination-pac {
+            leaf is-fts-enabled {
+                type boolean;
+                description "This attribute indicates whether Forced Transmitter Shutdown (FTS) is enabled or not. It models the ETYn_TT_So_MI_FTSEnable information.";
+            }
+            leaf is-tx-pause-enabled {
+                type boolean;
+                description "This attribute identifies whether the Transmit Pause process is enabled or not. It models the MI_TxPauseEnable defined in G.8021.";
+            }
+            leaf phy-type {
+                type ety-phy-type;
+                config false;
+                description "This attribute identifies the PHY type of the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.2.";
+            }
+            leaf-list phy-type-list {
+                type ety-phy-type;
+                config false;
+                description "This attribute identifies the possible PHY types that could be supported at the ETY trail termination. See IEEE 802.3 clause 30.3.2.1.3.";
+            }
+            description "none";
+        }
+        container traffic-conditioning-pac {
+            list prio-config-list {
+                config false;
+                min-elements 1;
+                max-elements 8;
+                uses priority-configuration;
+                description "This attribute indicates the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.";
+            }
+            list cond-config-list {
+                config false;
+                min-elements 1;
+                max-elements 8;
+                uses traffic-conditioning-configuration;
+                description "This attribute indicates for the conditioner process the conditioning parameters:
+                    - Queue ID: Indicates the Queue ID
+                    - Committed Information Rate (CIR): number of bits per second
+                    - Committed Burst Size (CBS): number of bytes
+                    - Excess Information Rate (EIR): number of bits per second
+                    - Excess Burst Size (EBS): number of bytes
+                    - Coupling flag (CF): 0 or 1
+                    - Color mode (CM): color-blind and color-aware.";
+            }
+            leaf codirectional {
+                type boolean;
+                config false;
+                description "This attribute indicates the direction of the conditioner. The value of true means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the sink part of the containing CTP. The value of false means that the conditioner (modeled as a TCS Sink according to G.8021) is associated with the source part of the containing CTP.";
+            }
+            description "This object class models the ETH traffic conditioning function as defined in G.8021.
+                Basic attributes: codirectional, condConfigList, prioConfigList";
+        }
+        container traffic-shaping-pac {
+            list prio-config-list {
+                config false;
+                min-elements 1;
+                max-elements 8;
+                uses priority-configuration;
+                description "This attribute configures the Priority Splitter function for the mapping of the Ethernet frame priority (ETH_CI_P) values to the output queue.";
+            }
+            list queue-config-list {
+                config false;
+                min-elements 1;
+                max-elements 8;
+                uses queue-configuration;
+                description "This attribute configures the Queue depth and Dropping threshold parameters of the Queue process. The Queue depth sets the maximum size of the queue in bytes. An incoming ETH_CI traffic unit is dropped if there is insufficient space in the queue to hold the whole unit. The Dropping threshold sets the threshold of the queue. If the queue is filled beyond this threshold, incoming ETH_CI traffic units accompanied by the ETH_CI_DE signal set are dropped.";
+            }
+            leaf sched-config {
+                type scheduling-configuration;
+                config false;
+                description "This attribute configures the scheduler process. The value of this attribute is for further study because it is for further study in G.8021.
+                    Scheduler is a pointer to a Scheduler object, which is to be defined in the future (because in G.8021, this is FFS).
+                    Note that the only significance of the GTCS function defined in G.8021 is the use of a common scheduler for shaping. Given that, G.8052 models the common scheduler feature by having a common value for this attribute.";
+            }
+            leaf codirectional {
+                type boolean;
+                config false;
+                description "This attribute indicates the direction of the shaping function. The value of true means that the shaping (modeled as a TCS Source according to G.8021) is associated with the source part of the containing CTP. The value of false means that the shaping (modeled as a TCS Source according to G.8021) is associated with the sink part of the containing CTP.";
+            }
+            description "This object class models the ETH traffic shaping function as defined in G.8021.
+                Basic attribute: codirectional, prioConfigList, queueConfigList, schedConfig";
+        }
+        grouping node-edge-point-lp-spec {
+            container termination-spec {
+                uses ety-termination-pac;
+                description "none";
+            }
+            uses tapi:extensions-spec;
+            description "none";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        grouping priority-configuration {
+            leaf priority {
+                type uint64 {
+                    range "0..7";
+                }
+                description "none";
+            }
+            leaf queue-id {
+                type uint64 {
+                    range "1..8";
+                }
+                description "none";
+            }
+            description "none";
+        }
+        grouping queue-configuration {
+            leaf queue-id {
+                type uint64;
+                description "This attribute indicates the queue id.";
+            }
+            leaf queue-depth {
+                type uint64;
+                description "This attribute defines the depth of the queue in bytes.";
+            }
+            leaf queue-threshold {
+                type uint64;
+                description "This attribute defines the threshold of the queue in bytes.";
+            }
+            description "none";
+        }
+        grouping traffic-conditioning-configuration {
+            leaf cir {
+                type uint64;
+                description "This attribute indicates the Committed Information Rate in bits/s.";
+            }
+            leaf cbs {
+                type uint64;
+                description "This attribute indicates the Committed Burst Size in bytes.";
+            }
+            leaf eir {
+                type uint64;
+                description "This attribute indicates the Excess Information Rate in bits/s.";
+            }
+            leaf ebs {
+                type uint64;
+                description "This attribute indicates the Excess Burst Size in bytes.";
+            }
+            leaf coupling-flag {
+                type boolean;
+                description "This attribute indicates the coupling flag.";
+            }
+            leaf colour-mode {
+                type colour-mode;
+                description "This attribute indicates the colour mode.";
+            }
+            leaf queue-id {
+                type uint64 {
+                    range "1..8";
+                }
+                description "This attribute indicates the queue id.";
+            }
+            description "none";
+        }
+        typedef mac-address {
+            type string;
+            description "This primitive data type contains an Ethernet MAC address defined by IEEE 802a. The format of the address consists of 12 hexadecimal characters, grouped in pairs and separated by '-' (e.g., 03-27-AC-75-3E-1D).";
+        }
+        grouping priority-mapping {
+            leaf priority0 {
+                type uint64 {
+                    range "0..7";
+                }
+                description "This attribute defines the new priority value for the old priority value 0.";
+            }
+            leaf priority1 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "1";
+                description "This attribute defines the new priority value for the old priority value 1.";
+            }
+            leaf priority2 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "2";
+                description "This attribute defines the new priority value for the old priority value 2.";
+            }
+            leaf priority3 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "3";
+                description "This attribute defines the new priority value for the old priority value 3.";
+            }
+            leaf priority4 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "4";
+                description "This attribute defines the new priority value for the old priority value 4.";
+            }
+            leaf priority5 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "5";
+                description "This attribute defines the new priority value for the old priority value 5.";
+            }
+            leaf priority6 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "6";
+                description "This attribute defines the new priority value for the old priority value 6.";
+            }
+            leaf priority7 {
+                type uint64 {
+                    range "0..7";
+                }
+                default "7";
+                description "This attribute defines the new priority value for the old priority value 7.";
+            }
+            description "This data type provides the priority mapping done in the 'P Regenerate' process defined in G.8021.";
+        }
+        typedef vid {
+            type string;
+            description "This primitive type models the 12 Bit VLAN identifier of a VLAN tag.";
+        }
+        typedef modify-cross-connection-data {
+            type string;
+            description "none";
+        }
+        grouping address-tuple {
+            leaf address {
+                type mac-address;
+                description "This attribute contains the MAC address of the address tuple.";
+            }
+            leaf-list port-list {
+                type mac-address;
+                description "This attribute contains the ports associated to the MAC address in the address tuple.";
+            }
+            description "This data type contains an address tuple consisting of a MAC address and a corresponding port list.";
+        }
+        typedef scheduling-configuration {
+            type string;
+            description "The syntax of this dataType is pending on the specification in G.8021, which is for further study.";
+        }
+        grouping control-frame-filter {
+            leaf c2-00-00-10 {
+                type boolean;
+                description "This attribute identifies the 'All LANs Bridge Management Group Address'.";
+            }
+            leaf c2-00-00-00 {
+                type boolean;
+                description "This attribute identifies the STP/RSTP/MSTP protocol address.";
+            }
+            leaf c2-00-00-01 {
+                type boolean;
+                description "This attribute identifies the IEEE MAC-specific Control Protocols group address (PAUSE protocol).";
+            }
+            leaf c2-00-00-02 {
+                type boolean;
+                description "This attribute identifies the IEEE 802.3 Slow_Protocols_Multicast address (LACP/LAMP or Link OAM protocols).";
+            }
+            leaf c2-00-00-03 {
+                type boolean;
+                description "This attribute identifies the Nearest non-TPMR Bridge group address (Port Authentication protocol).";
+            }
+            leaf c2-00-00-04 {
+                type boolean;
+                description "This attribute identifies the IEEE MAC-specific Control Protocols group address.";
+            }
+            leaf c2-00-00-05 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-06 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-07 {
+                type boolean;
+                description "This attribute identifies the Metro Ethernet Forum E-LMI protocol group address.";
+            }
+            leaf c2-00-00-08 {
+                type boolean;
+                description "This attribute identifies the Provider Bridge Group address.";
+            }
+            leaf c2-00-00-09 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-0a {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-0b {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-0c {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-0d {
+                type boolean;
+                description "This attribute identifies the Provider Bridge MVRP address.";
+            }
+            leaf c2-00-00-0e {
+                type boolean;
+                description "This attribute identifies the Individual LAN Scope group address, Nearest Bridge group address (LLDP protocol).";
+            }
+            leaf c2-00-00-0f {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-20 {
+                type boolean;
+                description "This attribute identifies the Customer and Provider Bridge MMRP address.";
+            }
+            leaf c2-00-00-21 {
+                type boolean;
+                description "This attribute identifies the Customer Bridge MVRP address.";
+            }
+            leaf c2-00-00-22 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-23 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-24 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-25 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-26 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-27 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-28 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-29 {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-2a {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-2b {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-2c {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-2d {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-2e {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            leaf c2-00-00-2f {
+                type boolean;
+                description "Reserved for future standardization.";
+            }
+            description "This data type identifies the filter action for each of the 33 group MAC addresses (control frames).
+                Value 'false' means block: The frame is discarded by the filter process.
+                Value 'true' means pass: The frame is passed unchanged through the filter process.";
+        }
+        grouping bandwidth-report {
+            leaf source-mac-address {
+                type mac-address;
+                description "The sourceMacAddress is the address from the far end.";
+            }
+            leaf port-id {
+                type uint64;
+                description "This attribute returns the far end port identifier.";
+            }
+            leaf nominal-bandwidth {
+                type uint64;
+                description "This attribute returns the configured bandwidth";
+            }
+            leaf current-bandwidth {
+                type uint64;
+                description "This attribute returns the current bandwidth.";
+            }
+            description "Data type for the bandwidth report.";
+        }
+        typedef admin-state {
+            type enumeration {
+                enum lock {
+                    description "none";
+                }
+                enum normal {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef colour-mode {
+            type enumeration {
+                enum colour-blind {
+                    description "none";
+                }
+                enum colour-aware {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef csf-config {
+            type enumeration {
+                enum disabled {
+                    description "This literal covers the following states of the CSF related MI informations:
+                        - MI_CSF_Enable is false
+                        - MI_CSFrdifdi_Enable is false
+                        - MI_CSFdci_Enable is false.";
+                }
+                enum enabled {
+                    description "This literal covers the following states of the CSF related MI informations:
+                        - MI_CSF_Enable is true
+                        - MI_CSFrdifdi_Enable is false
+                        - MI_CSFdci_Enable is false.";
+                }
+                enum enabled-with-rdi-fdi {
+                    description "This literal covers the following states of the CSF related MI informations:
+                        - MI_CSF_Enable is true
+                        - MI_CSFrdifdi_Enable is true
+                        - MI_CSFdci_Enable is false.";
+                }
+                enum enabled-with-rdi-fdi-dci {
+                    description "This literal covers the following states of the CSF related MI informations:
+                        - MI_CSF_Enable is true
+                        - MI_CSFrdifdi_Enable is true
+                        - MI_CSFdci_Enable is true.";
+                }
+                enum enabled-with-dci {
+                    description "This literal covers the following states of the CSF related MI informations:
+                        - MI_CSF_Enable is true
+                        - MI_CSFrdifdi_Enable is false
+                        - MI_CSFdci_Enable is true.";
+                }
+            }
+            description "none";
+        }
+        typedef ety-phy-type {
+            type enumeration {
+                enum other {
+                    description "none";
+                }
+                enum unknown {
+                    description "none";
+                }
+                enum none {
+                    description "none";
+                }
+                enum 2base-tl {
+                    description "none";
+                }
+                enum 10mbit-s {
+                    description "none";
+                }
+                enum 10pass-ts {
+                    description "none";
+                }
+                enum 100base-t4 {
+                    description "none";
+                }
+                enum 100base-x {
+                    description "none";
+                }
+                enum 100base-t2 {
+                    description "none";
+                }
+                enum 1000base-x {
+                    description "none";
+                }
+                enum 1000base-t {
+                    description "none";
+                }
+                enum 10gbase-x {
+                    description "none";
+                }
+                enum 10gbase-r {
+                    description "none";
+                }
+                enum 10gbase-w {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef frame-type {
+            type enumeration {
+                enum admit-only-vlan-tagged-frames {
+                    description "none";
+                }
+                enum admit-only-untagged-and-priority-tagged-frames {
+                    description "none";
+                }
+                enum admit-all-frames {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef oam-period {
+            type enumeration {
+                enum 3-33ms {
+                    description "Default for protection.";
+                }
+                enum 10ms {
+                    description "none";
+                }
+                enum 100ms {
+                    description "none";
+                }
+                enum 1s {
+                    description "none";
+                }
+                enum 10s {
+                    description "none";
+                }
+                enum 1min {
+                    description "none";
+                }
+                enum 10min {
+                    description "none";
+                }
+            }
+            description "Provides the frequency for the OAM PDU insertion.";
+        }
+        typedef pcp-coding {
+            type enumeration {
+                enum 8p0d {
+                    description "none";
+                }
+                enum 7p1d {
+                    description "none";
+                }
+                enum 6p2d {
+                    description "none";
+                }
+                enum 5p3d {
+                    description "none";
+                }
+                enum dei {
+                    description "This enumeration value means that all priorities should be drop eligible.
+                        DEI = Drop Eligibility Indicator";
+                }
+            }
+            description "This enum models the coding of the Priority Code Point as defined in section 'Priority Code Point encoding' of IEEE 802.1Q.";
+        }
+        typedef vlan-type {
+            type enumeration {
+                enum c-tag {
+                    description "0x8100";
+                }
+                enum s-tag {
+                    description "0x88a8";
+                }
+                enum i-tag {
+                    description "88-e7";
+                }
+            }
+            description "This enumeration contains the Ethertypes defined in IEEE 802.1Q.";
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-model.yang
+++ b/xmi2yang tool-v2.0/project/tapi-model.yang
@@ -1,0 +1,16 @@
+module tapi-model {
+    namespace "urn:onf:params:xml:ns:yang:TapiModel";
+    prefix tapi-model;
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+}

--- a/xmi2yang tool-v2.0/project/tapi-notification.yang
+++ b/xmi2yang tool-v2.0/project/tapi-notification.yang
@@ -1,0 +1,379 @@
+module tapi-notification {
+    namespace "urn:onf:params:xml:ns:yang:TapiNotification";
+    prefix tapi-notification;
+    import tapi {
+        prefix tapi;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_notifSubscription" {
+        uses notification-subscription-service;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_notification" {
+        uses notification;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping notification-subscription-service {
+            list notification {
+                key 'uuid';
+                config false;
+                uses notification;
+                description "none";
+            }
+            container notification-channel {
+                uses notification-channel;
+                description "none";
+            }
+            container subscription-filter {
+                uses subscription-filter;
+                description "none";
+            }
+            leaf subscription-state {
+                type subscription-state;
+                description "none";
+            }
+            leaf-list supported-notification-types {
+                type notification-type;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            leaf-list supported-object-types {
+                type object-type;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            uses tapi:service-spec;
+            description "none";
+        }
+        grouping subscription-filter {
+            leaf-list requested-notification-types {
+                type notification-type;
+                config false;
+                description "none";
+            }
+            leaf-list requested-object-types {
+                type object-type;
+                config false;
+                description "none";
+            }
+            leaf-list requested-layer-protocols {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            leaf-list requested-object-identifier {
+                type tapi:universal-id;
+                config false;
+                description "none";
+            }
+            leaf include-content {
+                type boolean;
+                config false;
+                description "Indicates whether the published Notification includes content or just the Notification Id (which enables retrieval of the notification at the later stage)";
+            }
+            description "none";
+        }
+        notification notification {
+            uses notification;
+            description "none";
+        }
+        grouping notification {
+            leaf notification-type {
+                type notification-type;
+                description "none";
+            }
+            leaf target-object-type {
+                type object-type;
+                description "none";
+            }
+            leaf target-object-identifier {
+                type tapi:universal-id;
+                description "none";
+            }
+            list target-object-name {
+                key 'value-name';
+                min-elements 1;
+                uses tapi:name-and-value;
+                description "none";
+            }
+            leaf event-time-stamp {
+                type tapi:date-and-time;
+                description "none";
+            }
+            leaf sequence-number {
+                type uint64;
+                config false;
+                description "A monotonous increasing sequence number associated with the notification.
+                    The exact semantics of how this sequence number is assigned (per channel or subscription or source or system) is left undefined.";
+            }
+            leaf source-indicator {
+                type source-indicator;
+                description "none";
+            }
+            leaf layer-protocol-name {
+                type tapi:layer-protocol-name;
+                description "none";
+            }
+            list changed-attributes {
+                uses name-and-value-change;
+                description "none";
+            }
+            list additional-info {
+                key 'value-name';
+                uses tapi:name-and-value;
+                description "none";
+            }
+            leaf additional-text {
+                type string;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "none";
+        }
+        grouping notification-channel {
+            leaf stream-address {
+                type string;
+                config false;
+                description "The address/location/URI of the channel/stream to which the subscribed notifications are published.
+                    This specifics of this is typically dependent on the implementation protocol & mechanism and hence is typed as a string.";
+            }
+            leaf next-sequence-no {
+                type uint64;
+                config false;
+                description "The sequence number of the next notification that will be published on the channel";
+            }
+            description "none";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        grouping name-and-value-change {
+            leaf value-name {
+                type string;
+                description "The name of the value. The value need not have a name.";
+            }
+            leaf old-value {
+                type string;
+                description "The value";
+            }
+            leaf new-value {
+                type string;
+                description "The value";
+            }
+            description "A scoped name-value triple, including old value and new value";
+        }
+        typedef notification-type {
+            type enumeration {
+                enum object-creation {
+                    description "Not a normal state. The system is unable to determine the correct value.";
+                }
+                enum object-deletion {
+                    description "none";
+                }
+                enum attribute-value-change {
+                    description "none";
+                }
+            }
+            description "The orientation of flow at the Port of a Forwarding entity";
+        }
+        typedef object-type {
+            type enumeration {
+                enum topology {
+                    description "none";
+                }
+                enum node {
+                    description "none";
+                }
+                enum link {
+                    description "none";
+                }
+                enum connection {
+                    description "none";
+                }
+                enum path {
+                    description "none";
+                }
+                enum connectivity-service {
+                    description "none";
+                }
+                enum virtual-network-service {
+                    description "none";
+                }
+                enum path-computation-service {
+                    description "none";
+                }
+                enum node-edge-point {
+                    description "none";
+                }
+                enum service-end-point {
+                    description "none";
+                }
+                enum connection-end-point {
+                    description "none";
+                }
+            }
+            description "The orientation of flow at the Port of a Forwarding entity";
+        }
+        typedef source-indicator {
+            type enumeration {
+                enum resource-operation {
+                    description "none";
+                }
+                enum management-operation {
+                    description "none";
+                }
+                enum unknown {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef subscription-state {
+            type enumeration {
+                enum suspended {
+                    description "none";
+                }
+                enum active {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+
+    /***********************
+    * package interfaces
+    **********************/ 
+        rpc get-supported-notification-types {
+            description "none";
+            output {
+                leaf-list supported-notification-types {
+                    type NotificationType;
+                    min-elements 1;
+                    description "none";
+                }
+                leaf-list supported-object-types {
+                    type ObjectType;
+                    min-elements 1;
+                    description "none";
+                }
+            }
+        }
+        rpc create-notification-subscription-service {
+            description "none";
+            input {
+                container subscription-filter {
+                    uses subscription-filter;
+                    description "none";
+                }
+                leaf subscription-state {
+                    type SubscriptionState;
+                    description "none";
+                }
+            }
+            output {
+                container subscription-service {
+                    uses notification-subscription-service;
+                    description "none";
+                }
+            }
+        }
+        rpc update-notification-subscription-service {
+            description "none";
+            input {
+                leaf subscription-id-or-name {
+                    type string;
+                    description "none";
+                }
+                container subscription-filter {
+                    uses subscription-filter;
+                    description "none";
+                }
+                leaf subscription-state {
+                    type SubscriptionState;
+                    description "none";
+                }
+            }
+            output {
+                container subscription-service {
+                    uses notification-subscription-service;
+                    description "none";
+                }
+            }
+        }
+        rpc delete-notification-subscription-service {
+            description "none";
+            input {
+                leaf subscription-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container subscription-service {
+                    uses notification-subscription-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-notification-subscription-service-details {
+            description "none";
+            input {
+                leaf subscription-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container subscription-service {
+                    uses notification-subscription-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-notification-subscription-service-list {
+            description "none";
+            output {
+                list subscription-service {
+                    uses notification-subscription-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-notification-list {
+            description "none";
+            input {
+                leaf subscription-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf time-period {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                list notification {
+                    uses notification;
+                    description "none";
+                }
+            }
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-och.yang
+++ b/xmi2yang tool-v2.0/project/tapi-och.yang
@@ -1,0 +1,131 @@
+module tapi-och {
+    namespace "urn:onf:params:xml:ns:yang:TapiOch";
+    prefix tapi-och;
+    import tapi {
+        prefix tapi;
+    }
+    import tapi-connectivity {
+        prefix tapi-connectivity;
+    }
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
+        uses connection-end-point-lp-spec;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
+        uses node-edge-point-lp-spec;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping adapter-and-connection-point-pac {
+            leaf monitored-direction {
+                type monitored-direction;
+                config false;
+                description "This attribute indicates the monitored direction.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSource then the value is fixed to SOURCE.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointSink then the value is fixed to SINK.  If the OCh_NonIntrusiveMonitoring instance is contained by OCh_ConnectionTerminationPointBidirectional then there is one instance that is fixed to SOURCE and one instance that is fixed to SINK.";
+            }
+            description "none";
+        }
+        grouping connection-end-point-lp-spec {
+            container adapter-spec {
+                uses adapter-and-connection-point-pac;
+                description "none";
+            }
+            container termination-spec {
+                uses termination-pac;
+                description "none";
+            }
+            uses tapi:extensions-spec;
+            description "none";
+        }
+        grouping termination-pac {
+            container selected-application-identifier {
+                uses application-identifier;
+                description "This attribute indicates the selected Application Identifier that is used by the OCh trail termination function. The syntax of ApplicationIdentifier is a pair {ApplicationIdentifierType, PrintableString}. The value of ApplicationIdentifierType is either STANDARD or PROPRIETARY. The value of PrintableString represents the standard application code as defined in the ITU-T Recommendations or a vendor-specific proprietary code. If the ApplicationIdentifierType is STANDARD the value of PrintableString represents a standard application code as defined in the ITU-T Recommendations. If the ApplicationIdentifierType is PROPRIETARY, the first six characters of the PrintableString must contain the Hexadecimal representation of an OUI assigned to the vendor whose implementation generated the Application Identifier; the remaining octets of the PrintableString are unspecified. The value of this attribute of an object instance has to be one of the values identified in the attribute SupportableApplicationIdentifierList of the same object instance. The values and value ranges of the optical interface parameters of a standard application code must be consistent with those values specified in the ITU-T Recommendation for that application code.";
+            }
+            container nominal-central-frequency-or-wavelength {
+                uses nominal-central-frequency-or-wavelength;
+                description "This attribute indicates the nominal central frequency or wavelength of the optical channel associated with the OCh Trail Termination function. The value of this attribute is a pair {LinkType, Integer}, in which LinkType is DWDM, or CWDM, or NO_WDM. When LinkType is DWDM, the integer represents the nominal central frequency in unit of MHz. When LinkType is CWDM, the integer represents the nominal central wavelength in unit of pm (picometer). When LinkType is NO_WDM, the Integer field is null. For frequency and wavelength, the value shall be within the range of the maximum and minimum central frequencies or wavelengths specified for the corresponding application code used at the OCh Trail Termination.
+                    This attribute is required for the OCh Trial Termination Point Source at the transmitter.  For the OCh Trail Termination Point Sink at the receiver, this attribute may not be needed since the receiver is required to operate at any frequency/wavelength between the maximum and minimum range for the standard application code.
+                    ";
+            }
+            description "none";
+        }
+        grouping pool-property-pac {
+            leaf client-capacity {
+                type uint64;
+                description "none";
+            }
+            leaf max-client-instances {
+                type uint64;
+                description "none";
+            }
+            leaf max-client-size {
+                type uint64;
+                description "none";
+            }
+            description "none";
+        }
+        grouping node-edge-point-lp-spec {
+            container och-pool-property-spec {
+                config false;
+                uses pool-property-pac;
+                description "none";
+            }
+            uses tapi:extensions-spec;
+            description "none";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        grouping application-identifier {
+            leaf application-identifier-type {
+                type string;
+                description "none";
+            }
+            leaf application-identifier-value {
+                type string;
+                description "none";
+            }
+            description "none";
+        }
+        typedef monitored-direction {
+            type enumeration {
+                enum sink {
+                    description "none";
+                }
+                enum source {
+                    description "none";
+                }
+            }
+            description "The enumeration with the options for directionality for nonintrusive monitoring.";
+        }
+        grouping nominal-central-frequency-or-wavelength {
+            leaf link-type {
+                type string;
+                description "none";
+            }
+            leaf nominal-central-frequency-or-wavelength {
+                type string;
+                description "none";
+            }
+            description "none";
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-odu.yang
+++ b/xmi2yang tool-v2.0/project/tapi-odu.yang
@@ -1,0 +1,441 @@
+module tapi-odu {
+    namespace "urn:onf:params:xml:ns:yang:TapiOdu";
+    prefix tapi-odu;
+    import tapi {
+        prefix tapi;
+    }
+    import tapi-connectivity {
+        prefix tapi-connectivity;
+    }
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_connection/TapiConnectivity:_connectionPort/TapiConnectivity:_connectionEndPoint/TapiConnectivity:_layerProtocol/TapiConnectivity:_extensions" {
+        uses connection-end-point-lp-spec;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_topology/TapiTopology:_node/TapiTopology:_ownedNodeEdgePoint/TapiTopology:_layerProtocol/TapiTopology:_extensions" {
+        uses node-edge-point-lp-spec;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping adapter-and-connection-point-pac {
+            leaf adaptation-active {
+                type boolean;
+                config false;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk at the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute indicates whether the adaptation function is activated or not. Valid values are true and false. The value of true means that the adaptation function shall access the access point when it is activated (MI_Active is true). Otherwise, it shall not access the access point.";
+            }
+            leaf aps-enable {
+                type boolean;
+                default "true";
+                description "This attribute is for enabling/disabling the automatic protection switching (APS) capability at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_EN signal to the transport adaptation function.";
+            }
+            leaf aps-level {
+                type uint64;
+                description "This attribute is for configuring the automatic protection switching (APS) level that should operate at the transport adaptation function that is represented by the ODUk_ConnectionTerminationPoint object class. It triggers the MI_APS_LVL signal to the transport adaptation function. The value 0 means path and the values 1 through 6 mean TCM level 1 through 6 respectively.";
+            }
+            leaf k {
+                type oduk-ctp-kbit-rate;
+                config false;
+                description "This attribute specifies the index k that is used to represent a supported bit rate and the different versions of OPUk, ODUk and OTUk.
+                    When the ODU CTP is an instance of lower order ODU of a higher order ODU at the ODUkP/ODU[i]j adaptation function, valid values for the index and number of allowed instances of this object class are limited as specified in Table 14-27/G.798.  The restriction is basically HO index k=1, 2, 3 and LO j=0, 1, 2 with j less than k and optionally i=1 with i less than j.
+                    When the ODU CTP is an instance of lower order ODU of a higher order ODU at the client layer of the ODUkP/ODUj-21_A adaptation function, valid values for the index of this object class is limited by the rule HO index k=2, 3, 4 and LO j=0, 1, 2, 2e, 3, flex with j less than k.
+                    ";
+            }
+            leaf odu-type-and-rate {
+                type uint64;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Source or Sink at the client layer of the ODUkP/ODUj-21 adaptation function. The value of this attribute specifies the type and rate of the adaptation and thus can be used to determine, according to Table 7-10/G.709, the mapping method and, in the case of GMP mapping, the base value and ranges for the parameters Cn and Cm. The value of this attribute is a triplet {j, k, size}, where j = 0, 1, 2, 2e, 3, flex; for the rate of the client ODUj  k = 1, 2, 3, 4; for the rate of the server ODUk size = 1.25G, 2.5G";
+            }
+            leaf-list position-seq {
+                type oduk-tcm-or-gcc-choice;
+                config false;
+                description "This attribute indicates the positions of the TCM and GCC processing functions within the ODUk TP.
+                    The order of the position in the positionSeq attribute together with the signal flow determine the processing sequence of the TCM and GCC functions within the ODUk TP. Once the positions are determined, the signal processing sequence will follow the signal flow for each direction of the signal.
+                    Within the ODUk_CTP, the position order is going from adaptation to connection function. Within the ODUk_TTP, the order is going from connection to adaptation function.
+                    The syntax of the PositionSeq attribute will be a SEQUENCE OF pointers, which point to the contained TCM and GCC function.
+                    The order of TCM and GCC access function in the positionSeq attribute is significant only when there are more than one TCM functions within the ODUk TP and also at least one of them have the TimActDisabled attribute set to FALSE (i.e. AIS is inserted upon TIM).
+                    If a GCC12_TP is contained in an ODUk_TTP and the GCC12_TP is not listed in the PositionSeq attribute of the ODUk_TTP, then the GCC access is at the AP side of the ODUk TT function.
+                    ";
+            }
+            leaf-list tributary-slot-list {
+                type uint64;
+                config false;
+                min-elements 1;
+                description "This attribute contains a set of distinct (i.e. unique) integers (e.g. 2, 3, 5, 9, 15 representing the tributary slots TS2, TS3, TS5, TS9 and TS15) which represents the resources occupied by the Low Order ODUk Link Connection (e.g. carrying an ODUflex with a bit rate of 6.25G). This attribute applies when the LO ODUk_ ConnectionTerminationPoint connects with an HO ODUk_TrailTerminationPoint object. It will not apply if this ODUk_ ConnectionTerminationPoint object directly connects to an OTUk_TrailTerminationPoint object (i.e. OTUk has no trib slots). The upper bound of the integer allowed in this set is a function of the HO-ODUk server layer to which the ODUk connection has been mapped (adapted). Thus, for example, M=8/32/80 for ODU2/ODU3/ODU4 server layers (respectively). Note that the value of this attribute can be changed only in the case of ODUflex and has to be through specific operations (i.e. not be changing the attribute tributarySlotList directly).";
+            }
+            leaf applicable-problems {
+                type oduk-ctp-problem-list;
+                config false;
+                description "This attribute's datatype indicates the potential failure conditions of the entity.   The values are to be used in the inherited currentProblemList.";
+            }
+            leaf expected-msi {
+                type string;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the expected multiplex structure of the adaptation function. ";
+            }
+            leaf accepted-msi {
+                type string;
+                config false;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Sink at the client layer of the ODU3P/ODU12 adaptation function or represents a lower order ODUj CTP Sink at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that represents the accepted multiplex structure of the adaptation function. ";
+            }
+            leaf accepted-payload-type {
+                type string;
+                config false;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODUk CTP Sink at the client layer of the ODUkP/ODU[i]j or ODUkP/ODUj-21 adaptation function. This attribute is a 2-digit Hex code that indicates the new accepted payload type. ";
+            }
+            leaf transmitted-msi {
+                type string;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU1 or ODU2 CTP Source at the client layer of the ODU3P/ODU12 adaptation function, or a lower order ODUj CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. This attribute is a 1-byte field that configures the transmitted multiplex structure identifier of the adaptation function.";
+            }
+            leaf auto-payload-type {
+                type boolean;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The value of true of this attribute configures that the adaptation source function shall fall back to the payload type PT=20 if the conditions specified in 14.3.10.1/G.798 are satisfied. ";
+            }
+            leaf inserted-payload-type {
+                type string;
+                config false;
+                description "This attribute is applicable when the ODUk CTP object instance represents a lower order ODU CTP Source at the client layer of the ODUkP/ODUj-21 adaptation function. The attribute reports the inserted payload type (i.e. TrPT) for the PT byte position of the PSI overhead. Valid values for this attribute are 20 and 21. For more details see 14.3.10.1/G.798. ";
+            }
+            leaf-list current-number-of-tributary-slots {
+                type uint64;
+                config false;
+                min-elements 1;
+                description "This attribute applies only to ODUflex(GFP) connections. It represents the current number of tributary slots allocated to this ODUflex(GFP) connection in the HO-ODU server layer. The value of this parameter determines the bit rate of the ODUflex connection. 
+                    The upper bound of this attribute is dependent on the HO-ODUk server layer. 
+                    When the ODUflex(GFP) connection is initially created, this represents the actual number of tributary slots in use for the connection. When an ODUflex(GFP) connection is undergoing a resize operation, this attribute reflects the desired (resized) number of tributary slots only after the following stages (see G.7044[5] for details):
+                    - After the Bandwidth Resize (BWR) phase completes (In the case of bandwidth increase)
+                    - After the Link Connection Resize (LCR) phase of the ODUflex resize operation (in the case of bandwidth decrease)
+                    This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).
+                    ";
+            }
+            container nominal-bit-rate-and-tolerance {
+                uses oduk-h-nominal-bit-rate-and-tolerance;
+                description "This attribute specifies the nominal clock frequency and its tolerance range. Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.";
+            }
+            description "none";
+        }
+        grouping termination-pac {
+            leaf rate {
+                type string;
+                config false;
+                description "This attribute applies only to ODUflex(CBR) connections only. The value of this attribute is (239/238)* (Bit rate of the CBR client).
+                    ";
+            }
+            leaf dm-source {
+                type boolean;
+                description "This attribute is for configuring the delay measurement process at the trail termination function represented by the subject TTP object class. It models the MI_DM_Source MI signal. If MI_DM_Source is false, then the value of the DMp bit is determined by the RI_DM. If MI_DM_Source is true, then the value of the DMp bit is set to MI_DMValue.";
+            }
+            leaf dm-value {
+                type boolean;
+                description "This attribute is for setting the DMp and DMti bits of the delay measurement process. The value of true sets the DMp and DMti bits to 0 and the value of false to 1.";
+            }
+            leaf acti {
+                type bit-string;
+                config false;
+                description "The Trail Trace Identifier (TTI) information recovered (Accepted) from the TTI overhead position at the sink of a trail.";
+            }
+            leaf deg-m {
+                type uint64;
+                description "This attribute indicates the threshold level for declaring a Degraded Signal defect (dDEG). A dDEG shall be declared if DegM consecutive bad PM Seconds are detected.";
+            }
+            container deg-thr {
+                uses deg-thr;
+                description "This attribute indicates the threshold level for declaring a performance monitoring (PM) Second to be bad. The value of the threshold can be provisioned in terms of number of errored blocks or in terms of percentage of errored blocks. For percentage-based specification, in order to support provision of less than 1%, the specification consists of two fields. The first field indicates the granularity of percentage. For examples, in 1%, in 0.1%, or in 0.01%, etc. The second field indicates the multiple of the granularity. For number of errored block based, the value is a positive integer.";
+            }
+            leaf ex-dapi {
+                type bit-string;
+                description "The Expected Destination Access Point Identifier (ExDAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
+            }
+            leaf ex-sapi {
+                type bit-string;
+                description "The Expected Source Access Point Identifier (ExSAPI), provisioned by the managing system, to be compared with the TTI accepted at the overhead position of the sink for the purpose of checking the integrity of connectivity.";
+            }
+            leaf tim-act-disabled {
+                type boolean;
+                description "This attribute provides the control capability for the managing system to enable or disable the Consequent Action function when detecting Trace Identifier Mismatch (TIM) at the trail termination sink. The value of TRUE means disabled.";
+            }
+            leaf tim-det-mode {
+                type tim-det-mo;
+                description "This attribute indicates the mode of the Trace Identifier Mismatch (TIM) Detection functionallowed values: off, SAPIonly, DAPIonly, SAPIandDAPI";
+            }
+            leaf txti {
+                type bit-string;
+                description "The Trail Trace Identifier (TTI) information, provisioned by the managing system at the termination source, to be placed in the TTI overhead position of the source of a trail for transmission.";
+            }
+            description "none";
+        }
+        grouping connection-end-point-lp-spec {
+            container termination-spec {
+                uses termination-pac;
+                description "none";
+            }
+            container adapter-spec {
+                uses adapter-and-connection-point-pac;
+                description "none";
+            }
+            uses tapi:extensions-spec;
+            description "none";
+        }
+        grouping pool-property-pac {
+            leaf client-capacity {
+                type uint64;
+                description "none";
+            }
+            leaf max-client-instances {
+                type uint64;
+                config false;
+                description "none";
+            }
+            leaf max-client-size {
+                type uint64;
+                config false;
+                description "none";
+            }
+            description "none";
+        }
+        grouping node-edge-point-lp-spec {
+            container odu-pool-property-spec {
+                uses pool-property-pac;
+                description "none";
+            }
+            uses tapi:extensions-spec;
+            description "none";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        typedef bit-string {
+            type string;
+            description "This primitive type defines a bit oriented string.
+                The size of the BitString will be defined in the valueRange property of the attribute; according to ASN.1 (X.680).
+                The semantic of each bit position will be defined in the Documentation field of the attribute.";
+        }
+        grouping deg-thr {
+            leaf deg-thr-value {
+                type string;
+                description "Percentage of detected errored blocks";
+            }
+            leaf deg-thr-type {
+                type string;
+                description "Number of errored blocks";
+            }
+            leaf percentage-granularity {
+                type string;
+                description "none";
+            }
+            description "Degraded Threshold, specify either the percentage or the number of Errored Blocks in the defined interval. 
+                degThrValue when type is PERCENTAGE:
+                percentageGranularity is used to indicate the number of decimal points
+                So if percentageGranularity is 0 a value of 1 in degThrValue would indicate 1%, a value of 10 = 10%, a value of 100 = 100%
+                So if percentageGranularity is 3 (thousandths) a value of 1 in degThrValue would indicate 0.001%, a value of 1000 = 1%, a value of 1000000 = 100%
+                degThrValue when type is NUMBER_ERROR_BLOCKS:
+                Number of Errored Blocks is captured in an integer value.";
+        }
+        typedef oduk-ttp-kbit-rate {
+            type enumeration {
+                enum 1.25-g {
+                    description "none";
+                }
+                enum 2.5-g {
+                    description "none";
+                }
+                enum 10-g {
+                    description "none";
+                }
+                enum 10-g-2e {
+                    description "none";
+                }
+                enum 40-g {
+                    description "none";
+                }
+                enum 100-g {
+                    description "none";
+                }
+                enum flex-cbr {
+                    description "Represents ODUflex connection which carry a CBR client";
+                }
+                enum flex-gfp {
+                    description "Represents ODUflex connection which carry packet traffic";
+                }
+            }
+            description "Provides an enumeration with the meaning of each k value.";
+        }
+        typedef oduk-tcm-or-gcc-choice {
+            type string;
+            description "A data type to constrain the values to particular types of ODUk CTPs.";
+        }
+        typedef tim-det-mo {
+            type enumeration {
+                enum dapi {
+                    description "none";
+                }
+                enum sapi {
+                    description "none";
+                }
+                enum both {
+                    description "none";
+                }
+            }
+            description "List of modes for trace identifier mismatch detection.";
+        }
+        typedef oduk-h-resizing-protocol-status {
+            type enumeration {
+                enum lcr-initiated {
+                    description "none";
+                }
+                enum lcr-failed {
+                    description "none";
+                }
+                enum lcr-completed {
+                    description "none";
+                }
+                enum bwr-initiated {
+                    description "none";
+                }
+                enum bwr-completed {
+                    description "none";
+                }
+            }
+            description "The valid status' of the resizing protocol.";
+        }
+        typedef oduk-ctp-problem-list {
+            type enumeration {
+                enum plm {
+                    description "Payload Mismatch";
+                }
+                enum msim {
+                    description "MultiplexStructureIdentifier Mismatch, per time slot";
+                }
+                enum lof-lom {
+                    description "Loss of Frame, Loss of Multiframe, per time slot";
+                }
+                enum loomfi {
+                    description "Loss of OPU Multiframe Indicator";
+                }
+            }
+            description "The valid list of problems for the entity.";
+        }
+        typedef oduk-ctp-kbit-rate {
+            type enumeration {
+                enum 1.25-g {
+                    description "none";
+                }
+                enum 2.5-g {
+                    description "none";
+                }
+                enum 10-g {
+                    description "none";
+                }
+                enum 10-g-2e {
+                    description "2e represents an approximate bit rate of 10 Gbit/s as a logical wrapper 10GBASE-R";
+                }
+                enum 40-g {
+                    description "none";
+                }
+                enum 100-g {
+                    description "none";
+                }
+                enum flex-cbr {
+                    description "Represents ODUflex connection which carry a CBR client";
+                }
+                enum flex-gfp {
+                    description "Represents ODUflex connection which carry packet traffic";
+                }
+            }
+            description "Provides an enumeration with the meaning of each k value.";
+        }
+        grouping oduk-h-nominal-bit-rate-and-tolerance {
+            leaf tolerance {
+                type uint64;
+                description "tolerance in ppm";
+            }
+            leaf frequency {
+                type string;
+                description "frequency in kilohertz";
+            }
+            description "Valid values for the frequency (in kHz) and tolerance (in ppm) range are given in Table 14-2/G.798 and clause 12.2.5/G.709.";
+        }
+        typedef tcm-mode {
+            type enumeration {
+                enum operational {
+                    description "none";
+                }
+                enum transparent {
+                    description "none";
+                }
+                enum monitor {
+                    description "none";
+                }
+            }
+            description "List of value modes for the sink side of the tandem connection monitoring function.";
+        }
+        typedef oduk-t-tcm-extension {
+            type enumeration {
+                enum normal {
+                    description "none";
+                }
+                enum pass-through {
+                    description "none";
+                }
+                enum erase {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef oduk-t-administration-state {
+            type enumeration {
+                enum locked {
+                    description "none";
+                }
+                enum normal {
+                    description "none";
+                }
+            }
+            description "The list of valid adminstration states.";
+        }
+        typedef oduk-tcm-status {
+            type enumeration {
+                enum no-source-tc {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 0 0, No source Tandem Connection";
+                }
+                enum in-use-without-iae {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 0 1,  In use without IAE (Incoming Alignment Error)";
+                }
+                enum in-use-with-iae {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 1 0, In use with IAE (Incoming Alignment Error)";
+                }
+                enum reserved-1 {
+                    description "TCM byte 3 (bits 6 7 8) -- 0 1 1, Reserved for future international standardization";
+                }
+                enum reserved-2 {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 0 0, Reserved for future international standardization";
+                }
+                enum lck {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 0 1, Maintenance signal: ODUk-LCK";
+                }
+                enum oci {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 1 0, Maintenance signal: ODUk-OCI";
+                }
+                enum ais {
+                    description "TCM byte 3 (bits 6 7 8) -- 1 1 1, Maintenance signal: ODUk-AIS";
+                }
+            }
+            description "See Table 15-5/G.709/Y.1331 ";
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-path-computation.yang
+++ b/xmi2yang tool-v2.0/project/tapi-path-computation.yang
@@ -1,0 +1,279 @@
+module tapi-path-computation {
+    namespace "urn:onf:params:xml:ns:yang:TapiPathComputation";
+    prefix tapi-path-computation;
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    import tapi {
+        prefix tapi;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_path" {
+        uses path;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_pathCompService" {
+        uses path-computation-service;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping path {
+            list telink {
+                key 'local-id';
+                config false;
+                min-elements 1;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            container routing-constraint {
+                config false;
+                uses routing-constraint;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes";
+        }
+        grouping path-comp-service-port {
+            leaf service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf role {
+                type tapi:port-role;
+                config false;
+                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+            }
+            leaf direction {
+                type tapi:port-direction;
+                config false;
+                description "The orientation of defined flow at the EndPoint.";
+            }
+            leaf service-layer {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "The association of the FC to LTPs is made via EndPoints.
+                The EndPoint (EP) object class models the access to the FC function. 
+                The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
+                In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. 
+                It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.
+                The EP replaces the Protection Unit of a traditional protection model. 
+                The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
+        }
+        grouping path-computation-service {
+            leaf-list path {
+                type leafref {
+                    path '/tapi:context/tapi:path/tapi:uuid';
+                }
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            list service-port {
+                key 'local-id';
+                min-elements 2;
+                max-elements 2;
+                uses path-comp-service-port;
+                description "none";
+            }
+            container routing-constraint {
+                uses routing-constraint;
+                description "none";
+            }
+            container objective-function {
+                uses path-objective-function;
+                description "none";
+            }
+            container optimization-constraint {
+                uses path-optimization-constraint;
+                description "none";
+            }
+            uses tapi:service-spec;
+            description "none";
+        }
+        grouping path-objective-function {
+            leaf bandwidth-optimization {
+                type tapi:directive-value;
+                config false;
+                description "none";
+            }
+            leaf concurrent-paths {
+                type tapi:directive-value;
+                config false;
+                description "none";
+            }
+            leaf cost-optimization {
+                type tapi:directive-value;
+                config false;
+                description "none";
+            }
+            leaf link-utilization {
+                type tapi:directive-value;
+                config false;
+                description "none";
+            }
+            leaf resource-sharing {
+                type tapi:directive-value;
+                config false;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "none";
+        }
+        grouping path-optimization-constraint {
+            leaf traffic-interruption {
+                type tapi:directive-value;
+                config false;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "none";
+        }
+        grouping routing-constraint {
+            container requested-capacity {
+                config false;
+                uses tapi-topology:capacity;
+                description "none";
+            }
+            leaf service-level {
+                type string;
+                config false;
+                description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
+            }
+            leaf-list path-layer {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
+                config false;
+                uses tapi-topology:cost-characteristic;
+                description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
+            }
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
+                config false;
+                uses tapi-topology:latency-characteristic;
+                description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
+            }
+            leaf-list include-topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf-list avoid-topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            list include-path {
+                key 'local-id';
+                config false;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            list exclude-path {
+                key 'local-id';
+                config false;
+                uses tapi-topology:te-link;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "none";
+        }
+
+    /***********************
+    * package interfaces
+    **********************/ 
+        rpc compute-p2ppath {
+            description "none";
+            input {
+                list service-port {
+                    min-elements 2;
+                    max-elements 2;
+                    uses path-comp-service-port;
+                    description "none";
+                }
+                container routing-constraint {
+                    uses routing-constraint;
+                    description "none";
+                }
+                container objective-function {
+                    uses path-objective-function;
+                    description "none";
+                }
+            }
+            output {
+                container path-comp-service {
+                    uses path-computation-service;
+                    description "none";
+                }
+            }
+        }
+        rpc optimize-p2ppath {
+            description "none";
+            input {
+                leaf path-id-or-name {
+                    type string;
+                    description "none";
+                }
+                container routing-constraint {
+                    uses routing-constraint;
+                    description "none";
+                }
+                container optimization-constraint {
+                    uses path-optimization-constraint;
+                    description "none";
+                }
+                container objective-function {
+                    uses path-objective-function;
+                    description "none";
+                }
+            }
+            output {
+                container path-comp-service {
+                    uses path-computation-service;
+                    description "none";
+                }
+            }
+        }
+        rpc delete-p2ppath {
+            description "none";
+            input {
+                leaf path-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container path-comp-service {
+                    uses path-computation-service;
+                    description "none";
+                }
+            }
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-topology.yang
+++ b/xmi2yang tool-v2.0/project/tapi-topology.yang
@@ -1,0 +1,670 @@
+module tapi-topology {
+    namespace "urn:onf:params:xml:ns:yang:TapiTopology";
+    prefix tapi-topology;
+    import tapi {
+        prefix tapi;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_topology" {
+        uses topology;
+        description "none";
+    }
+    augment "/Tapi:Context/Tapi:_nwTopologyService" {
+        uses network-topology-service;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping link {
+            list link-port {
+                key 'local-id';
+                config false;
+                min-elements 2;
+                uses link-port;
+                description "none";
+            }
+            leaf-list node {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                }
+                config false;
+                min-elements 2;
+                description "none";
+            }
+            container state {
+                config false;
+                uses tapi:admin-state-pac;
+                description "none";
+            }
+            container transfer-capacity {
+                config false;
+                uses transfer-capacity-pac;
+                description "none";
+            }
+            container transfer-cost {
+                config false;
+                uses transfer-cost-pac;
+                description "none";
+            }
+            container transfer-integrity {
+                config false;
+                uses transfer-integrity-pac;
+                description "none";
+            }
+            container transfer-timing {
+                config false;
+                uses transfer-timing-pac;
+                description "none";
+            }
+            container risk-parameter {
+                config false;
+                uses risk-parameter-pac;
+                description "none";
+            }
+            container validation {
+                config false;
+                uses validation-pac;
+                description "none";
+            }
+            container lp-transition {
+                config false;
+                uses layer-protocol-transition-pac;
+                description "none";
+            }
+            leaf-list layer-protocol-name {
+                type tapi:layer-protocol-name;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            leaf direction {
+                type tapi:forwarding-direction;
+                config false;
+                description "The directionality of the Link. 
+                    Is applicable to simple Links where all LinkEnds are BIDIRECTIONAL (the Link will be BIDIRECTIONAL) or UNIDIRECTIONAL (the Link will be UNIDIRECTIONAL). 
+                    Is not present in more complex cases.";
+            }
+            uses tapi:resource-spec;
+            description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
+        }
+        grouping node {
+            list owned-node-edge-point {
+                key 'uuid';
+                config false;
+                uses node-edge-point;
+                description "none";
+            }
+            leaf-list aggregated-node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf encap-topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            container state {
+                config false;
+                uses tapi:admin-state-pac;
+                description "none";
+            }
+            container transfer-capacity {
+                config false;
+                uses transfer-capacity-pac;
+                description "none";
+            }
+            container transfer-cost {
+                config false;
+                uses transfer-cost-pac;
+                description "none";
+            }
+            container transfer-integrity {
+                config false;
+                uses transfer-integrity-pac;
+                description "none";
+            }
+            container transfer-timing {
+                config false;
+                uses transfer-timing-pac;
+                description "none";
+            }
+            leaf-list layer-protocol-name {
+                type tapi:layer-protocol-name;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
+                At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
+        }
+        grouping topology {
+            list node {
+                key 'uuid';
+                config false;
+                uses node;
+                description "none";
+            }
+            list link {
+                key 'uuid';
+                config false;
+                uses link;
+                description "none";
+            }
+            leaf-list layer-protocol-name {
+                type tapi:layer-protocol-name;
+                config false;
+                min-elements 1;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. 
+                At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
+        }
+        grouping layer-protocol-transition-pac {
+            leaf-list transitioned-layer-protocol-name {
+                type string;
+                min-elements 1;
+                description "Provides the ordered structure of layer protocol transitions encapsulated in the TopologicalEntity. The ordering relates to the LinkPort role.";
+            }
+            leaf-list node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                min-elements 1;
+                description "Lists the LTPs that define the layer protocol transition of the transitional link.";
+            }
+            description "Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. 
+                This abstraction is relevant when considering multi-layer routing. 
+                The layer protocols of the LTP and the order of their application to the signal is still relevant and need to be accounted for. This is derived from the LTP spec details.
+                This Pac provides the relevant abstractions of the LTPs and provides the necessary association to the LTPs involved.
+                Links that included details in this Pac are often referred to as Transitional Links.";
+        }
+        grouping link-port {
+            leaf node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf role {
+                type tapi:port-role;
+                config false;
+                description "Each LinkEnd of the Link has a role (e.g., symmetric, hub, spoke, leaf, root)  in the context of the Link with respect to the Link function. ";
+            }
+            leaf direction {
+                type tapi:port-direction;
+                config false;
+                description "The orientation of defined flow at the LinkEnd.";
+            }
+            uses tapi:local-class;
+            description "The association of the Link to LTPs is made via LinkEnd.
+                The LinkEnd object class models the access to the Link function. 
+                The traffic forwarding between the associated LinkEnds of the Link depends upon the type of Link.  
+                In cases where there is resilience the LinkEnd may convey the resilience role of the access to the Link. 
+                The Link can be considered as a component and the LinkEnd as a Port on that component";
+        }
+        grouping node-edge-point {
+            list layer-protocol {
+                key 'local-id';
+                config false;
+                min-elements 1;
+                uses tapi:layer-protocol;
+                description "none";
+            }
+            leaf-list client-node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf-list mapped-service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                description "none";
+            }
+            container state {
+                config false;
+                uses tapi:admin-state-pac;
+                description "none";
+            }
+            leaf direction {
+                type tapi:termination-direction;
+                config false;
+                description "none";
+            }
+            uses tapi:resource-spec;
+            description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
+                The structure of LTP supports all transport protocols including circuit and packet forms.";
+        }
+        grouping risk-parameter-pac {
+            list risk-characteristic {
+                key 'risk-characteristic-name';
+                config false;
+                min-elements 1;
+                uses risk-characteristic;
+                description "A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.";
+            }
+            description "The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. 
+                The risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.
+                A TopologicalEntity may suffer degradation or failure as a result of a problem in a part of the underlying realization.
+                The realization can be partitioned into segments which have some relevant common failure modes.
+                There is a risk of failure/degradation of each segment of the underlying realization.
+                Each segment is a part of a larger physical/geographical unit that behaves as one with respect to failure (i.e. a failure will have a high probability of impacting the whole unit (e.g. all cables in the same duct).
+                Disruptions to that larger physical/geographical unit will impact (cause failure/errors to) all TopologicalEntities that use any part of that larger physical/geographical entity.
+                Any TopologicalEntity that uses any part of that larger physical/geographical unit will suffer impact and hence each TopologicalEntity shares risk.
+                The identifier of each physical/geographical unit that is involved in the realization of each segment of a Topological entity can be listed in the RiskParameter_Pac of that TopologicalEntity.
+                A segment has one or more risk characteristic.
+                Shared risk between two TopologicalEntities compromises the integrity of any solution that use one of those TopologicalEntity as a backup for the other.
+                Where two TopologicalEntities have a common risk characteristic they have an elevated probability of failing simultaneously compared to two TopologicalEntities that do not share risk characteristics.";
+        }
+        grouping transfer-capacity-pac {
+            container total-potential-capacity {
+                config false;
+                uses capacity;
+                description "An optimistic view of the capacity of the TopologicalEntity assuming that any shared capacity is available to be taken.";
+            }
+            container available-capacity {
+                config false;
+                uses capacity;
+                description "Capacity available to be assigned.";
+            }
+            list capacity-assigned-to-user-view {
+                key 'total-size';
+                config false;
+                uses capacity;
+                description "Capacity already assigned";
+            }
+            leaf capacity-interaction-algorithm {
+                type string;
+                config false;
+                description "A reference to an algorithm that describes how various chunks of allocated capacity interact (e.g. when shared)";
+            }
+            description "The TopologicalEntity derives capacity from the underlying realization. 
+                A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.
+                A TopologicalEntity may be directly used in the view or may be assigned to another view for use.
+                The clients supported by a multi-layer TopologicalEntity may interact such that the resources used by one client may impact those available to another. This is derived from the LTP spec details.
+                Represents the capacity available to user (client) along with client interaction and usage. 
+                A TopologicalEntity may reflect one or more client protocols and one or more members for each profile.";
+        }
+        grouping transfer-cost-pac {
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
+                config false;
+                min-elements 1;
+                uses cost-characteristic;
+                description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
+            }
+            description "The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. 
+                They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity
+                There may be many perspectives from which cost may be considered  for a particular TopologicalEntity and hence many specific costs and potentially cost algorithms. 
+                Using an entity will incur a cost. ";
+        }
+        grouping transfer-integrity-pac {
+            leaf error-characteristic {
+                type string;
+                config false;
+                description "Describes the degree to which the signal propagated can be errored. 
+                    Applies to TDM systems as the errored signal will be propagated and not packet as errored packets will be discarded.";
+            }
+            leaf loss-characteristic {
+                type string;
+                config false;
+                description "Describes the acceptable characteristic of lost packets where loss may result from discard due to errors or overflow.
+                    Applies to packet systems and not TDM (as for TDM errored signals are propagated unless grossly errored and overflow/underflow turns into timing slips).";
+            }
+            leaf repeat-delivery-characteristic {
+                type string;
+                config false;
+                description "Primarily applies to packet systems where a packet may be delivered more than once (in fault recovery for example). 
+                    It can also apply to TDM where several frames may be received twice due to switching in a system with a large differential propagation delay.";
+            }
+            leaf delivery-order-characteristic {
+                type string;
+                config false;
+                description "Describes the degree to which packets will be delivered out of sequence.
+                    Does not apply to TDM as the TDM protocols maintain strict order.";
+            }
+            leaf unavailable-time-characteristic {
+                type string;
+                config false;
+                description "Describes the duration for which there may be no valid signal propagated.";
+            }
+            leaf server-integrity-process-characteristic {
+                type string;
+                config false;
+                description "Describes the effect of any server integrity enhancement process on the characteristics of the TopologicalEntity.";
+            }
+            description "Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.
+                It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.
+                Note that the statement is of total impact to the TopologicalEntity so any partial usage of the TopologicalEntity (e.g. a signal that does not use full capacity) will only suffer its portion of the impact.";
+        }
+        grouping transfer-timing-pac {
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
+                config false;
+                min-elements 1;
+                uses latency-characteristic;
+                description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
+            }
+            description "A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.";
+        }
+        grouping validation-pac {
+            list validation-mechanism {
+                key 'validation-mechanism layer-protocol-adjacency-validated validation-robustness';
+                config false;
+                min-elements 1;
+                uses validation-mechanism;
+                description "Provides details of the specific validation mechanism(s) used to confirm the presence of an intended topologicalEntity.";
+            }
+            description "Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.";
+        }
+        grouping te-link {
+            leaf-list node {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:uuid';
+                }
+                config false;
+                min-elements 2;
+                max-elements 2;
+                description "none";
+            }
+            leaf-list node-edge-point {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi-topology:node/tapi-topology:owned-node-edge-point/tapi-topology:uuid';
+                }
+                config false;
+                max-elements 2;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "The Link object class models effective adjacency between two or more ForwardingDomains (FD). ";
+        }
+        grouping network-topology-service {
+            leaf-list topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            uses tapi:service-spec;
+            description "none";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        grouping capacity {
+            leaf total-size {
+                type fixed-capacity-value;
+                description "Total capacity of the TopologicalEntity in MB/s";
+            }
+            leaf packet-bw-profile-type {
+                type bandwidth-profile-type;
+                description "none";
+            }
+            leaf committed-information-rate {
+                type uint64;
+                description "none";
+            }
+            leaf committed-burst-size {
+                type uint64;
+                description "none";
+            }
+            leaf peak-information-rate {
+                type uint64;
+                description "none";
+            }
+            leaf peak-burst-size {
+                type uint64;
+                description "none";
+            }
+            leaf color-aware {
+                type boolean;
+                description "none";
+            }
+            leaf coupling-flag {
+                type boolean;
+                description "none";
+            }
+            description "Information on capacity of a particular TopologicalEntity.";
+        }
+        grouping cost-characteristic {
+            leaf cost-name {
+                type string;
+                description "The cost characteristic will related to some aspect of the TopologicalEntity (e.g. $ cost, routing weight). This aspect will be conveyed by the costName.";
+            }
+            leaf cost-value {
+                type string;
+                description "The specific cost.";
+            }
+            leaf cost-algorithm {
+                type string;
+                description "The cost may vary based upon some properties of the TopologicalEntity. The rules for the variation are conveyed by the costAlgorithm.";
+            }
+            description "The information for a particular cost characteristic.";
+        }
+        typedef fixed-capacity-value {
+            type enumeration {
+                enum not-applicable {
+                    description "none";
+                }
+                enum 10mbps {
+                    description "none";
+                }
+                enum 100mbps {
+                    description "none";
+                }
+                enum 1gbps {
+                    description "none";
+                }
+                enum 2.4gbps {
+                    description "none";
+                }
+                enum 10gbps {
+                    description "none";
+                }
+                enum 40gbps {
+                    description "none";
+                }
+                enum 100gbps {
+                    description "none";
+                }
+                enum 200gbps {
+                    description "none";
+                }
+                enum 400gbps {
+                    description "none";
+                }
+            }
+            description "The Capacity (Bandwidth) values that are applicable for digital layers. ";
+        }
+        grouping latency-characteristic {
+            leaf fixed-latency-characteristic {
+                type string;
+                config false;
+                description "A TopologicalEntity suffers delay caused by the realization of the servers (e.g. distance related; FEC encoding etc.) along with some client specific processing. This is the total average latency effect of the TopologicalEntity";
+            }
+            leaf jitter-characteristic {
+                type string;
+                config false;
+                description "High frequency deviation from true periodicity of a signal and therefore a small high rate of change of transfer latency.
+                    Applies to TDM systems (and not packet).";
+            }
+            leaf wander-characteristic {
+                type string;
+                config false;
+                description "Low frequency deviation from true periodicity of a signal and therefore a small low rate of change of transfer latency.
+                    Applies to TDM systems (and not packet).";
+            }
+            leaf traffic-property-name {
+                type string;
+                description "The identifier of the specific traffic property to which the queuing latency applies.";
+            }
+            leaf traffic-property-queing-latency {
+                type string;
+                description "The specific queuing latency for the traffic property.";
+            }
+            description "Provides information on latency characteristic for a particular stated trafficProperty.";
+        }
+        grouping risk-characteristic {
+            leaf risk-characteristic-name {
+                type string;
+                description "The name of the risk characteristic. The characteristic may be related to a specific degree of closeness. 
+                    For example a particular characteristic may apply to failures that are localized (e.g. to one side of a road) where as another characteristic may relate to failures that have a broader impact (e.g. both sides of a road that crosses a bridge).
+                    Depending upon the importance of the traffic being routed different risk characteristics will be evaluated.";
+            }
+            leaf-list risk-identifier-list {
+                type string;
+                min-elements 1;
+                description "A list of the identifiers of each physical/geographic unit (with the specific risk characteristic) that is related to a segment of the TopologicalEntity.";
+            }
+            description "The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.";
+        }
+        grouping validation-mechanism {
+            leaf validation-mechanism {
+                type string;
+                description "Name of mechanism used to validate adjacency";
+            }
+            leaf layer-protocol-adjacency-validated {
+                type string;
+                description "State of validatiion";
+            }
+            leaf validation-robustness {
+                type string;
+                description "Quality of validation (i.e. how likely is the stated validation to be invalid)";
+            }
+            description "Identifies the validation mechanism and describes the characteristics of that mechanism";
+        }
+        typedef bandwidth-profile-type {
+            type enumeration {
+                enum not-applicable {
+                    description "none";
+                }
+                enum mef-10.x {
+                    description "none";
+                }
+                enum rfc-2697 {
+                    description "none";
+                }
+                enum rfc-2698 {
+                    description "none";
+                }
+                enum rfc-4115 {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+
+    /***********************
+    * package interfaces
+    **********************/ 
+        rpc get-topology-details {
+            description "none";
+            input {
+                leaf topology-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container topology {
+                    uses topology;
+                    description "none";
+                }
+            }
+        }
+        rpc get-node-details {
+            description "none";
+            input {
+                leaf topology-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf node-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container node {
+                    uses node;
+                    description "none";
+                }
+            }
+        }
+        rpc get-node-edge-point-details {
+            description "none";
+            input {
+                leaf topology-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf node-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf ep-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container node-edge-point {
+                    uses node-edge-point;
+                    description "none";
+                }
+            }
+        }
+        rpc get-link-details {
+            description "none";
+            input {
+                leaf topology-id-or-name {
+                    type string;
+                    description "none";
+                }
+                leaf link-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container link {
+                    uses link;
+                    description "none";
+                }
+            }
+        }
+        rpc get-topology-list {
+            description "none";
+            output {
+                list topology {
+                    uses topology;
+                    description "none";
+                }
+            }
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi-virtual-network.yang
+++ b/xmi2yang tool-v2.0/project/tapi-virtual-network.yang
@@ -1,0 +1,212 @@
+module tapi-virtual-network {
+    namespace "urn:onf:params:xml:ns:yang:TapiVirtualNetwork";
+    prefix tapi-virtual-network;
+    import tapi-topology {
+        prefix tapi-topology;
+    }
+    import tapi {
+        prefix tapi;
+    }
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_vnwService" {
+        uses virtual-network-service;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping virtual-network-constraint {
+            leaf src-service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf sink-service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf-list diversity-exclusion {
+                type leafref {
+                    path '/tapi:context/tapi:vnw-service/tapi-virtual-network:vnw-constraint/tapi-virtual-network:local-id';
+                }
+                description "none";
+            }
+            container requested-capacity {
+                uses tapi-topology:capacity;
+                description "none";
+            }
+            leaf service-level {
+                type string;
+                description "An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability";
+            }
+            leaf-list service-layer {
+                type tapi:layer-protocol-name;
+                description "none";
+            }
+            list cost-characteristic {
+                key 'cost-name cost-value cost-algorithm';
+                uses tapi-topology:cost-characteristic;
+                description "The list of costs where each cost relates to some aspect of the TopologicalEntity.";
+            }
+            list latency-characteristic {
+                key 'traffic-property-name traffic-property-queing-latency';
+                uses tapi-topology:latency-characteristic;
+                description "The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.";
+            }
+            uses tapi:local-class;
+            description "none";
+        }
+        grouping virtual-network-service {
+            leaf topology {
+                type leafref {
+                    path '/tapi:context/tapi:topology/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            list service-port {
+                key 'local-id';
+                min-elements 2;
+                uses virtual-network-service-port;
+                description "none";
+            }
+            list vnw-constraint {
+                key 'local-id';
+                min-elements 1;
+                uses virtual-network-constraint;
+                description "none";
+            }
+            container schedule {
+                uses tapi:time-range;
+                description "none";
+            }
+            container state {
+                uses tapi:admin-state-pac;
+                description "none";
+            }
+            leaf-list layer-protocol-name {
+                type tapi:layer-protocol-name;
+                min-elements 1;
+                description "none";
+            }
+            uses tapi:service-spec;
+            description "The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.
+                At the lowest level of recursion, a FC represents a cross-connection within an NE.";
+        }
+        grouping virtual-network-service-port {
+            leaf service-end-point {
+                type leafref {
+                    path '/tapi:context/tapi:service-end-point/tapi:uuid';
+                }
+                config false;
+                description "none";
+            }
+            leaf role {
+                type tapi:port-role;
+                config false;
+                description "Each EP of the FC has a role (e.g., working, protection, protected, symmetric, hub, spoke, leaf, root)  in the context of the FC with respect to the FC function. ";
+            }
+            leaf direction {
+                type tapi:port-direction;
+                config false;
+                description "The orientation of defined flow at the EndPoint.";
+            }
+            leaf service-layer {
+                type tapi:layer-protocol-name;
+                config false;
+                description "none";
+            }
+            uses tapi:local-class;
+            description "The association of the FC to LTPs is made via EndPoints.
+                The EndPoint (EP) object class models the access to the FC function. 
+                The traffic forwarding between the associated EPs of the FC depends upon the type of FC and may be associated with FcSwitch object instances.  
+                In cases where there is resilience the EndPoint may convey the resilience role of the access to the FC. 
+                It can represent a protected (resilient/reliable) point or a protecting (unreliable working or protection) point.
+                The EP replaces the Protection Unit of a traditional protection model. 
+                The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
+        }
+
+    /***********************
+    * package interfaces
+    **********************/ 
+        rpc create-virtual-network-service {
+            description "none";
+            input {
+                list service-port {
+                    min-elements 2;
+                    uses virtual-network-service-port;
+                    description "none";
+                }
+                container vnw-constraint {
+                    uses virtual-network-constraint;
+                    description "none";
+                }
+                leaf conn-schedule {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container vnw-service {
+                    uses virtual-network-service;
+                    description "none";
+                }
+            }
+        }
+        rpc delete-virtual-network-service {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container vnw-service {
+                    uses virtual-network-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-virtual-network-service-details {
+            description "none";
+            input {
+                leaf service-id-or-name {
+                    type string;
+                    description "none";
+                }
+            }
+            output {
+                container vnw-service {
+                    uses virtual-network-service;
+                    description "none";
+                }
+            }
+        }
+        rpc get-virtual-network-service-list {
+            description "none";
+            output {
+                list vnw-service {
+                    uses virtual-network-service;
+                    description "none";
+                }
+            }
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/tapi.yang
+++ b/xmi2yang tool-v2.0/project/tapi.yang
@@ -1,0 +1,446 @@
+module tapi {
+    namespace "urn:onf:params:xml:ns:yang:Tapi";
+    prefix tapi;
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "none";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    augment "/Tapi:Context/Tapi:_serviceEndPoint" {
+        uses service-end-point;
+        description "none";
+    }
+    /***********************
+    * package object-classes
+    **********************/ 
+        grouping admin-state-pac {
+            leaf administrative-state {
+                type administrative-state;
+                description "none";
+            }
+            leaf operational-state {
+                type operational-state;
+                description "none";
+            }
+            leaf lifecycle-state {
+                type lifecycle-state;
+                description "none";
+            }
+            description "Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.";
+        }
+        grouping global-class {
+            leaf uuid {
+                type universal-id;
+                description "UUID: An identifier that is universally unique
+                    (consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)";
+            }
+            list name {
+                key 'value-name';
+                min-elements 1;
+                uses name-and-value;
+                description "List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.";
+            }
+            list label {
+                key 'value-name';
+                uses name-and-value;
+                description "List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.";
+            }
+            list extensions {
+                key 'extensions-specification';
+                config false;
+                uses extensions-spec;
+                description "none";
+            }
+            description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
+        }
+        grouping layer-protocol {
+            leaf layer-protocol-name {
+                type layer-protocol-name;
+                description "Indicate the specific layer-protocol described by the LayerProtocol entity.";
+            }
+            leaf termination-direction {
+                type termination-direction;
+                description "The overall directionality of the LP. 
+                    - A BIDIRECTIONAL LP will have some SINK and/or SOURCE flowss.
+                    - A SINK LP can only contain elements with SINK flows or CONTRA_DIRECTION_SOURCE flows
+                    - A SOURCE LP can only contain SOURCE flows or CONTRA_DIRECTION_SINK flows";
+            }
+            leaf termination-state {
+                type termination-state;
+                description "Indicates whether the layer is terminated and if so how.";
+            }
+            uses local-class;
+            description "Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. 
+                It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. 
+                Where the client – server relationship is fixed 1:1 and immutable, the layers can be encapsulated in a single LTP instance. Where the is a n:1 relationship between client and server, the layers must be split over two separate instances of LTP. ";
+        }
+        grouping lifecycle-state-pac {
+            leaf lifecycle-state {
+                type lifecycle-state;
+                description "none";
+            }
+            description "Provides state attributes for an entity that has lifeccycle aspects only.";
+        }
+        grouping local-class {
+            leaf local-id {
+                type string;
+                description "none";
+            }
+            list extensions {
+                key 'extensions-specification';
+                config false;
+                uses extensions-spec;
+                description "none";
+            }
+            description "The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. ";
+        }
+        grouping operational-state-pac {
+            leaf operational-state {
+                type operational-state;
+                description "none";
+            }
+            leaf lifecycle-state {
+                type lifecycle-state;
+                description "none";
+            }
+            description "Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.";
+        }
+        grouping time-range {
+            leaf end-time {
+                type date-and-time;
+                description "none";
+            }
+            leaf start-time {
+                type date-and-time;
+                description "none";
+            }
+            description "none";
+        }
+        grouping extensions-spec {
+            description "none";
+        }
+        container context {
+            uses context;
+            description "none";
+        }
+        grouping context {
+            container nw-topology-service {
+                config false;
+                uses service-spec;
+                description "none";
+            }
+            list connectivity-service {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list vnw-service {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list path-comp-service {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list notif-subscription {
+                key 'uuid';
+                uses service-spec;
+                description "none";
+            }
+            list service-end-point {
+                key 'uuid';
+                config false;
+                min-elements 2;
+                uses resource-spec;
+                description "none";
+            }
+            list topology {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            list connection {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            list path {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            list notification {
+                key 'uuid';
+                config false;
+                uses resource-spec;
+                description "none";
+            }
+            uses global-class;
+            description "The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).";
+        }
+        grouping resource-spec {
+            uses global-class;
+            description "none";
+        }
+        grouping service-spec {
+            uses global-class;
+            description "none";
+        }
+        grouping service-end-point {
+            list layer-protocol {
+                key 'local-id';
+                config false;
+                min-elements 1;
+                uses layer-protocol;
+                description "none";
+            }
+            container state {
+                config false;
+                uses lifecycle-state-pac;
+                description "none";
+            }
+            leaf direction {
+                type termination-direction;
+                config false;
+                description "none";
+            }
+            uses resource-spec;
+            description "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
+                The structure of LTP supports all transport protocols including circuit and packet forms.";
+        }
+
+    /***********************
+    * package type-definitions
+    **********************/ 
+        typedef administrative-state {
+            type enumeration {
+                enum locked {
+                    description "Users are administratively prohibited from making use of the resource.";
+                }
+                enum unlocked {
+                    description "Users are allowed to use the resource";
+                }
+            }
+            description "The possible values of the administrativeState.";
+        }
+        typedef date-and-time {
+            type string;
+            description "This primitive type defines the date and time according to the following structure:
+                yyyyMMddhhmmss.s[Z|{+|-}HHMm] where:
+                yyyy    0000..9999    year
+                MM    01..12            month
+                dd        01..31            day
+                hh        00..23            hour
+                mm    00..59            minute
+                ss        00..59            second
+                s        .0...9            tenth of second (set to .0 if EMS or NE cannot support this granularity)
+                Z        Z                indicates UTC (rather than local time)
+                {+|-}    + or -            delta from UTC
+                HH        00..23            time zone difference in hours
+                Mm    00..59            time zone difference in minutes.";
+        }
+        typedef directive-value {
+            type enumeration {
+                enum minimize {
+                    description "none";
+                }
+                enum maximize {
+                    description "none";
+                }
+                enum allow {
+                    description "none";
+                }
+                enum disallow {
+                    description "none";
+                }
+                enum dont-care {
+                    description "none";
+                }
+            }
+            description "none";
+        }
+        typedef forwarding-direction {
+            type enumeration {
+                enum bidirectional {
+                    description "The Fowarding entity supports both BIDIRECTIONAL flows at all Ports (i.e. all Ports have both an INPUT flow and an OUTPUT flow defined)";
+                }
+                enum unidirectional {
+                    description "The Forwarding entity has Ports that are either INPUT or OUTPUT. It has no BIDIRECTIONAL Ports.";
+                }
+                enum undefined-or-unknown {
+                    description "Not a normal state. The system is unable to determine the correct value.";
+                }
+            }
+            description "The directionality of a Forwarding entity.";
+        }
+        typedef layer-protocol-name {
+            type enumeration {
+                enum och {
+                    description "none";
+                }
+                enum odu {
+                    description "none";
+                }
+                enum eth {
+                    description "none";
+                }
+                enum mpls-tp {
+                    description "none";
+                }
+            }
+            description "Provides a controlled list of layer protocol names and indicates the naming authority.
+                Note that it is expected that attributes will be added to this structure to convey the naming authority name, the name of the layer protocol using a human readable string and any particular standard reference.
+                Layer protocol names include:
+                -    Layer 1 (L1): OTU, ODU
+                -    Layer 2 (L2): Carrier Grade Ethernet (ETY, ETH), MPLS-TP (MT)
+                ";
+        }
+        typedef lifecycle-state {
+            type enumeration {
+                enum planned {
+                    description "The resource is planned but is not present in the network.";
+                }
+                enum potential {
+                    description "The supporting resources are present in the network but are shared with other clients; or require further configuration before they can be used; or both.
+                        o    When a potential resource is configured and allocated to a client it is moved to the “installed” state for that client.
+                        o    If the potential resource has been consumed (e.g. allocated to another client) it is moved to the “planned” state for all other clients.";
+                }
+                enum installed {
+                    description "The resource is present in the network and is capable of providing the service expected.";
+                }
+                enum pending-removal {
+                    description "The resource has been marked for removal";
+                }
+            }
+            description "The possible values of the lifecycleState.";
+        }
+        grouping name-and-value {
+            leaf value-name {
+                type string;
+                description "The name of the value. The value need not have a name.";
+            }
+            leaf value {
+                type string;
+                description "The value";
+            }
+            description "A scoped name-value pair";
+        }
+        typedef operational-state {
+            type enumeration {
+                enum disabled {
+                    description "The resource is unable to meet the SLA of the user of the resource. If no (explicit) SLA is defined the resource is disabled if it is totally inoperable and unable to provide service to the user.";
+                }
+                enum enabled {
+                    description "The resource is partially or fully operable and available for use";
+                }
+            }
+            description "The possible values of the operationalState.";
+        }
+        typedef port-direction {
+            type enumeration {
+                enum bidirectional {
+                    description "The Port has both an INPUT flow and an OUTPUT flow defined.";
+                }
+                enum input {
+                    description "The Port only has definition for a flow into the Forwarding entity (i.e. an ingress flow).";
+                }
+                enum output {
+                    description "The Port only has definition for a flow out of the Forwarding entity (i.e. an egress flow).";
+                }
+                enum unidentified-or-unknown {
+                    description "Not a normal state. The system is unable to determine the correct value.";
+                }
+            }
+            description "The orientation of flow at the Port of a Forwarding entity";
+        }
+        typedef port-role {
+            type enumeration {
+                enum symmetric {
+                    description "none";
+                }
+                enum root {
+                    description "none";
+                }
+                enum leaf {
+                    description "none";
+                }
+                enum unknown {
+                    description "none";
+                }
+            }
+            description "The role of an end in the context of the function of the forwarding entity that it bounds";
+        }
+        typedef termination-direction {
+            type enumeration {
+                enum bidirectional {
+                    description "A Termination with both SINK and SOURCE flows.";
+                }
+                enum sink {
+                    description "The flow is up the layer stack from the server side to the client side. 
+                        Considering an example of a Termination function within the termination entity, a SINK flow:
+                        - will arrive at at the base of the termination function (the server side) where it is essentially at an INPUT to the termination component
+                        - then will be decoded and deconstructed 
+                        - then relevant parts of the flow will be sent out of the termination function (the client side) where it is essentially at an OUTPUT from the termination component
+                        A SINK termination is one that only supports a SINK flow.
+                        A SINK termiation can be bound to an OUTPUT Port of a Forwarding entity";
+                }
+                enum source {
+                    description "The flow is down the layer stack from the server side to the client side. 
+                        Considering an example of a Termination function within the termination entity, a SOURCE flow:
+                        - will arrive at at the top of the termination function (the client side) where it is essentially at an INPUT to the termination component
+                        - then will be assembled with various overheads etc and will be coded 
+                        - then coded form of the assembly of flow will be sent out of the termination function (the server side) where it is essentially at an OUTPUT from the termination component
+                        A SOURCE termination is one that only supports a SOURCE flow.
+                        A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity";
+                }
+                enum undefined-or-unknown {
+                    description "Not a normal state. The system is unable to determine the correct value.";
+                }
+            }
+            description "The directionality of a termination entity";
+        }
+        typedef termination-state {
+            type enumeration {
+                enum lp-can-never-terminate {
+                    description "A non-flexible case that can never be terminated.";
+                }
+                enum lt-not-terminated {
+                    description "A flexible termination that can terminate but is currently not terminated.";
+                }
+                enum terminated-server-to-client-flow {
+                    description "A flexible termination that is currently terminated for server to client flow only.";
+                }
+                enum terminated-client-to-server-flow {
+                    description "A flexible termination that is currently terminated for client to server flow only.";
+                }
+                enum terminated-bidirectional {
+                    description "A flexible termination that is currently terminated in both directions of flow.";
+                }
+                enum lt-permenantly-terminated {
+                    description "A non-flexible termination that is always terminated (in both directions of flow for a bidirectional case and in the one direction of flow for both unidirectional cases).";
+                }
+                enum termination-state-unknown {
+                    description "There TerminationState cannot be determined.";
+                }
+            }
+            description "Provides support for the range of behaviours and specific states that an LP can take with respect to termination of the signal.
+                Indicates to what degree the LayerTermination is terminated.";
+        }
+        typedef universal-id {
+            type string;
+            description "The univeral ID value where the mechanism for generation is defned by some authority not directly referenced in the structure.";
+        }
+
+}

--- a/xmi2yang tool-v2.0/project/uml-yang-simple-test-model.yang
+++ b/xmi2yang tool-v2.0/project/uml-yang-simple-test-model.yang
@@ -1,0 +1,94 @@
+module uml-yang-simple-test-model {
+    namespace "urn:onf:params:xml:ns:yang:UmlYangSimpleTestModel";
+    prefix uml-yang-simple-test-model;
+    organization "ONF (Open Networking Foundation) IMP Working Group";
+    contact "WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/>
+        WG List: mailto: <wg list name>@opennetworking.org>,.
+        WG Chair: your-WG-chair
+            <mailto:your-WG-chair@example.com>
+        Editor: your-name
+            <mailto:your-email@example.com>";
+    description "This is a simple test model for the UML -> YANG mapping tool.";
+    revision 2016-12-20 {
+        description "Test revision";
+        reference "Papyrus";
+    }
+    container network-element {
+        list forwarding-domain-list {
+            key 'object-identifier';
+            uses forwarding-domain;
+            description "This navigable relationship models the ...";
+        }
+        leaf attribute1 {
+            type enumeration1;
+            description "This attribute defines the ...
+                Second applied comment.";
+        }
+        description "This object class models the ...";
+    }
+    grouping forwarding-domain {
+        leaf layer-rate {
+            type string;
+            description "This attribute models the ...
+                range of type : <range definition>";
+        }
+        list termination-point-list {
+            key 'object-identifier';
+            uses termination-point;
+            description "This association models the ...";
+        }
+        list forwarding-construct-list {
+            key 'object-identifier';
+            uses forwarding-construct;
+            description "This navigable relationship models the ...";
+        }
+        uses generic-object;
+        description "This object class models the ...";
+    }
+    grouping termination-point {
+        uses generic-object;
+        description "This object class models the ...";
+    }
+    grouping forwarding-construct {
+        leaf-list termination-point-list {
+            type leafref {
+                path '/uml-yang-simple-test-model:network-element/uml-yang-simple-test-model:forwarding-domain-list/uml-yang-simple-test-model:termination-point-list/uml-yang-simple-test-model:object-identifier';
+            }
+            min-elements 2;
+            description "This association models the ...";
+        }
+        leaf forwarding-construct-state {
+            type fc-state;
+            default "PENDING";
+            description "This attribute models the ...";
+        }
+        uses generic-object;
+        description "This object class models the ...";
+    }
+    typedef fc-state {
+        type enumeration {
+            enum pending {
+                description "This literal models the ...";
+            }
+            enum active {
+                description "This literal models the ...";
+            }
+        }
+        description "This enumeration models the ...";
+    }
+    grouping generic-object {
+        leaf object-identifier {
+            type string;
+            description "This attribute defines the generic identifier for all object instances.";
+        }
+        description "This object class models the ...";
+    }
+    typedef enumeration1 {
+        type enumeration {
+            enum single-literal {
+                description "This literal models the ...";
+            }
+        }
+        description "This enumeration defines ...";
+    }
+}


### PR DESCRIPTION
In order to prevent forcing the users to input the "prefix" value for each module when using the tool, the rule has been changed as:

1. If user input the "prefix" value manually, then the generated output prefix will be what the user inputs.
2. If the "prefix" value is kept empty (prefix "" ), then the tool will automatically set the module name as the "prefix".

This should avoid the huge working load when there are many yang files to generate.