### PR TITLE
OpenModelProfile v0.2.6; InterfaceModelProfile v0.0.2

### DIFF
--- a/UmlProfiles/InterfaceModelProfile/InterfaceModel_Profile.profile.notation
+++ b/UmlProfiles/InterfaceModelProfile/InterfaceModel_Profile.profile.notation
@@ -28,12 +28,12 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_53k1CbbyEeaufdfMFhfy_A"/>
       </children>
       <element xmi:type="uml:Stereotype" href="InterfaceModel_Profile.profile.uml#_oOSqILbyEeaufdfMFhfy_A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_53iYwbbyEeaufdfMFhfy_A" x="267" y="171" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_53iYwbbyEeaufdfMFhfy_A" x="280" y="168" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_zp6jcLbzEeaufdfMFhfy_A" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_zp7KgLbzEeaufdfMFhfy_A" type="3"/>
       <element xmi:type="uml:Comment" href="InterfaceModel_Profile.profile.uml#_y92usLbzEeaufdfMFhfy_A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zp6jcbbzEeaufdfMFhfy_A" x="241" y="305" width="245"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zp6jcbbzEeaufdfMFhfy_A" x="241" y="285" width="245"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_pzjbkNjPEea1wr7GsSffog" type="1026" fillColor="15912618" lineColor="12678440">
       <children xmi:type="notation:DecorationNode" xmi:id="_pzjbktjPEea1wr7GsSffog" type="1034"/>
@@ -68,7 +68,7 @@
     <children xmi:type="notation:Shape" xmi:id="_36nD4O1qEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_36nD4u1qEealZpKGxQi2Dw" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_36nD4e1qEealZpKGxQi2Dw" x="302" y="65"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_36nD4e1qEealZpKGxQi2Dw" x="314" y="62"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_37Dv0O1qEealZpKGxQi2Dw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_37Dv0e1qEealZpKGxQi2Dw" showTitle="true"/>
@@ -114,7 +114,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_zqSW4bbzEeaufdfMFhfy_A"/>
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zqSW4rbzEeaufdfMFhfy_A" points="[0, 0, -362, -203]$[312, 175, -50, -28]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0eaigLbzEeaufdfMFhfy_A" id="(0.49795918367346936,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0eaigLbzEeaufdfMFhfy_A" id="(0.5020408163265306,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0ebwoLbzEeaufdfMFhfy_A" id="(0.5714285714285714,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_wY9pUNjPEea1wr7GsSffog" type="1022" source="_wYiLgNjPEea1wr7GsSffog" target="_pzjbkNjPEea1wr7GsSffog">

--- a/UmlProfiles/InterfaceModelProfile/InterfaceModel_Profile.profile.uml
+++ b/UmlProfiles/InterfaceModelProfile/InterfaceModel_Profile.profile.uml
@@ -1,6 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <uml:Profile xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_UbM6ILbyEeaufdfMFhfy_A" name="InterfaceModel_Profile">
   <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vXgnYOMXEeaVnpsnjRW9Pg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+    <contents xmi:type="ecore:EPackage" xmi:id="_2oL94O-HEeaFytHm7I89bw" name="InterfaceModel_Profile" nsURI="http:///schemas/InterfaceModel_Profile/_2oF3QO-HEeaFytHm7I89bw/1" nsPrefix="InterfaceModel_Profile">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oOaJe-HEeaFytHm7I89bw" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2oOaJu-HEeaFytHm7I89bw" key="Version" value="0.0.2"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2oOaJ--HEeaFytHm7I89bw" key="Comment" value="Updates:&#xD;&#xA;Augment stereotype deleted.&#xD;&#xA;name property added to RootElement stereotype."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2oOaKO-HEeaFytHm7I89bw" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2oOaKe-HEeaFytHm7I89bw" key="Date" value="2017-02-10"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_2oOaKu-HEeaFytHm7I89bw" key="Author" value=""/>
+      </eAnnotations>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_2oL94e-HEeaFytHm7I89bw" name="RootElement">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oL94u-HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_oOSqILbyEeaufdfMFhfy_A"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_2oL94--HEeaFytHm7I89bw" name="base_Class" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oL95e-HEeaFytHm7I89bw" name="name" ordered="false">
+          <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oL95--HEeaFytHm7I89bw" name="multiplicity" ordered="false" lowerBound="1" defaultValueLiteral="1..1">
+          <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oL96e-HEeaFytHm7I89bw" name="description" ordered="false">
+          <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+        </eStructuralFeatures>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_2oL96--HEeaFytHm7I89bw" name="InterfaceModelAttribute">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oL97O-HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_ECvBANcqEea1ncO03M1x2w"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oL97e-HEeaFytHm7I89bw" name="attributeValueChangeNotification" ordered="false" lowerBound="1" eType="_2oMk9e-HEeaFytHm7I89bw" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oL97--HEeaFytHm7I89bw" name="bitLength" ordered="false" eType="_2oMk-u-HEeaFytHm7I89bw" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oMk8e-HEeaFytHm7I89bw" name="encoding" ordered="false" eType="_2oMlAe-HEeaFytHm7I89bw" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_2oMk8--HEeaFytHm7I89bw" name="base_Property" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Property"/>
+        </eStructuralFeatures>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_2oMk9e-HEeaFytHm7I89bw" name="NotificationDefinition">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oMk9u-HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_CgjnINcrEea1ncO03M1x2w"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk9--HEeaFytHm7I89bw" name="NA"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk-O-HEeaFytHm7I89bw" name="NO" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk-e-HEeaFytHm7I89bw" name="YES" value="2"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_2oMk-u-HEeaFytHm7I89bw" name="BitLength">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oMk---HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_bU64oNcrEea1ncO03M1x2w"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk_O-HEeaFytHm7I89bw" name="NA"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk_e-HEeaFytHm7I89bw" name="LENGTH_8_BIT" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk_u-HEeaFytHm7I89bw" name="LENGTH_16_BIT" value="2"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMk_--HEeaFytHm7I89bw" name="LENGTH_32_BIT" value="3"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMlAO-HEeaFytHm7I89bw" name="LENGTH_64_BIT" value="4"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_2oMlAe-HEeaFytHm7I89bw" name="Encoding">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oMlAu-HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_bU8t0NcrEea1ncO03M1x2w"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMlA--HEeaFytHm7I89bw" name="NA"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMlBO-HEeaFytHm7I89bw" name="BASE_64" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMlBe-HEeaFytHm7I89bw" name="HEX" value="2"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_2oMlBu-HEeaFytHm7I89bw" name="OCTET" value="3"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_2oMlB--HEeaFytHm7I89bw" name="InterfaceModelClass">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oMlCO-HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_cmVzYNjPEea1wr7GsSffog"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oMlCe-HEeaFytHm7I89bw" name="objectCreationNotification" ordered="false" lowerBound="1" eType="_2oMk9e-HEeaFytHm7I89bw" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_2oMlC--HEeaFytHm7I89bw" name="objectDeletionNotification" ordered="false" lowerBound="1" eType="_2oMk9e-HEeaFytHm7I89bw" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_2oMlDe-HEeaFytHm7I89bw" name="base_Class" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+        </eStructuralFeatures>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_2oMlD--HEeaFytHm7I89bw" name="PassedByReference">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_2oMlEO-HEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_lVAMoNjPEea1wr7GsSffog"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_2oMlEe-HEeaFytHm7I89bw" name="base_Parameter" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Parameter"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_2oMlE--HEeaFytHm7I89bw" name="base_Property" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Property"/>
+        </eStructuralFeatures>
+      </eClassifiers>
+    </contents>
     <contents xmi:type="ecore:EPackage" xmi:id="_vXh1gOMXEeaVnpsnjRW9Pg" name="InterfaceModel_Profile" nsURI="http:///schemas/InterfaceModel_Profile/_vXgAUOMXEeaVnpsnjRW9Pg/0" nsPrefix="InterfaceModel_Profile">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vXjDoeMXEeaVnpsnjRW9Pg" source="PapyrusVersion">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_vXjDouMXEeaVnpsnjRW9Pg" key="Version" value="0.0.1"/>
@@ -81,7 +152,8 @@
   </eAnnotations>
   <ownedComment xmi:type="uml:Comment" xmi:id="_2CeJAO3XEeaQNdpg-LmPpw" annotatedElement="_UbM6ILbyEeaufdfMFhfy_A">
     <body>Updates in v0.0.2:&#xD;
-Augment stereotype deleted.</body>
+Augment stereotype deleted.&#xD;
+name property added to RootElement stereotype.</body>
   </ownedComment>
   <packageImport xmi:type="uml:PackageImport" xmi:id="_UgS1gLbyEeaufdfMFhfy_A">
     <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>

--- a/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.notation
+++ b/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.notation
@@ -148,7 +148,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhOAwqqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3mqiLEeSly6b4dPxjLg" x="176" y="-328" height="225"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3mqiLEeSly6b4dPxjLg" x="113" y="-328" height="225"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I3m6iLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I3nKiLEeSly6b4dPxjLg" type="1034">
@@ -173,7 +173,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vhXxwqqxEeSqFPhVNQ1oeg"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_JVMFMHBhEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3o6iLEeSly6b4dPxjLg" x="-40" y="-328" height="79"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W3I3o6iLEeSly6b4dPxjLg" x="-96" y="-328" height="79"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_W3I3rKiLEeSly6b4dPxjLg" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <children xmi:type="notation:DecorationNode" xmi:id="_W3I3raiLEeSly6b4dPxjLg" type="1034">
@@ -322,12 +322,12 @@
     <children xmi:type="notation:Shape" xmi:id="_oqcLAKiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_oqcLAqiUEeSly6b4dPxjLg" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_nd89oHBjEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqcLAaiUEeSly6b4dPxjLg" x="-55" y="-80" width="224" height="37"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oqcLAaiUEeSly6b4dPxjLg" x="-111" y="-80" width="224" height="37"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_pTpgEKiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_pTpgEqiUEeSly6b4dPxjLg" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_sTEScHBjEd6FKu9XX1078A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pTpgEaiUEeSly6b4dPxjLg" x="267" y="-80" width="217" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pTpgEaiUEeSly6b4dPxjLg" x="245" y="-80" width="217" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_p4130KiUEeSly6b4dPxjLg" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_p4130qiUEeSly6b4dPxjLg" type="3"/>
@@ -395,7 +395,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xbaMkZPEeW32YsOmT7W0Q"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_74KP4EZPEeW32YsOmT7W0Q"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xKUcUZPEeW32YsOmT7W0Q" x="600" y="-328" height="91"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8xKUcUZPEeW32YsOmT7W0Q" x="608" y="-328" height="91"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_XnHqQEZQEeW32YsOmT7W0Q" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_XnIRUEZQEeW32YsOmT7W0Q" source="ShadowFigure">
@@ -409,7 +409,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_XnI4ZEZQEeW32YsOmT7W0Q" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_DyUDAEZQEeW32YsOmT7W0Q"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XnHqQUZQEeW32YsOmT7W0Q" x="627" y="-80" width="220" height="41"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XnHqQUZQEeW32YsOmT7W0Q" x="635" y="-80" width="220" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_6E4ssEZVEeW32YsOmT7W0Q" type="1026" fontHeight="8" fillColor="15912618" lineColor="14263149">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6E560EZVEeW32YsOmT7W0Q" source="ShadowFigure">
@@ -498,12 +498,12 @@
     <children xmi:type="notation:Shape" xmi:id="_cRYskJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_cRYskpDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_cRXecJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cRYskZDkEeW51dNDZIXIMA" x="72" y="-368" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cRYskZDkEeW51dNDZIXIMA" x="17" y="-364" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_pAzlgJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_pAzlgZDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_pAy-cJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pAzlgpDkEeW51dNDZIXIMA" x="400" y="-368" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pAzlgpDkEeW51dNDZIXIMA" x="368" y="-364" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_q_HsUZDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_q_ITYJDkEeW51dNDZIXIMA" type="3"/>
@@ -523,7 +523,7 @@
     <children xmi:type="notation:Shape" xmi:id="_0RnLYJDkEeW51dNDZIXIMA" type="1002">
       <children xmi:type="notation:DecorationNode" xmi:id="_0RnLYZDkEeW51dNDZIXIMA" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_0RmkUJDkEeW51dNDZIXIMA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0RnLYpDkEeW51dNDZIXIMA" x="760" y="-368" width="66" height="22"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0RnLYpDkEeW51dNDZIXIMA" x="768" y="-368" width="66" height="22"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_N507MFfkEeak-v4LxEsCQw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_N507MVfkEeak-v4LxEsCQw" showTitle="true"/>
@@ -663,7 +663,7 @@
     <children xmi:type="notation:Shape" xmi:id="_GsgSQO1oEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_Gsg5UO1oEealZpKGxQi2Dw" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GsgSQe1oEealZpKGxQi2Dw" x="10" y="-432"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GsgSQe1oEealZpKGxQi2Dw" x="-46" y="-432"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Gs23kO1oEealZpKGxQi2Dw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Gs23ke1oEealZpKGxQi2Dw" showTitle="true"/>
@@ -676,7 +676,7 @@
     <children xmi:type="notation:Shape" xmi:id="_WZa3EO1oEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_WZa3Eu1oEealZpKGxQi2Dw" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Signal"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WZa3Ee1oEealZpKGxQi2Dw" x="690" y="-432"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WZa3Ee1oEealZpKGxQi2Dw" x="698" y="-432"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_WZ9CkO1oEealZpKGxQi2Dw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_WZ9Cke1oEealZpKGxQi2Dw" showTitle="true"/>
@@ -728,7 +728,7 @@
     <children xmi:type="notation:Shape" xmi:id="_odZZ4O1oEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_odaA8O1oEealZpKGxQi2Dw" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#StructuralFeature"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_odZZ4e1oEealZpKGxQi2Dw" x="328" y="-432"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_odZZ4e1oEealZpKGxQi2Dw" x="303" y="-432"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_od4iEO1oEealZpKGxQi2Dw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_od4iEe1oEealZpKGxQi2Dw" showTitle="true"/>
@@ -1528,23 +1528,12 @@
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yeBdkEeatXPvf_dRw8w" x="267" y="369" width="217" height="41"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_1C8yeRdkEeatXPvf_dRw8w" type="1002">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZeiaEO96EeaFytHm7I89bw" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Zepu0O96EeaFytHm7I89bw" key="fillColor" value="true"/>
+      </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_1C8yehdkEeatXPvf_dRw8w" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_htBYgL7YEeGcHtJ-koFuEQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8yexdkEeatXPvf_dRw8w" x="495" y="369" width="193" height="41"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_1C8yiBdkEeatXPvf_dRw8w" type="1002" fontName="Segoe UI" fillColor="10265827" lineColor="0">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8yiRdkEeatXPvf_dRw8w" source="ShadowFigure">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8yihdkEeatXPvf_dRw8w" key="ShadowFigure_Value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8yixdkEeatXPvf_dRw8w" source="displayNameLabelIcon">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8yjBdkEeatXPvf_dRw8w" key="displayNameLabelIcon_value" value="false"/>
-      </eAnnotations>
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8yjRdkEeatXPvf_dRw8w" source="QualifiedName">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_1C8yjhdkEeatXPvf_dRw8w" key="QualifiedNameDepth" value="1000"/>
-      </eAnnotations>
-      <children xmi:type="notation:DecorationNode" xmi:id="_1C8yjxdkEeatXPvf_dRw8w" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_JvB8AKqzEeSqFPhVNQ1oeg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8ykBdkEeatXPvf_dRw8w" x="-49" y="-15" width="414"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_1C8y4hdkEeatXPvf_dRw8w" type="1026" fontHeight="8" fillColor="15912618" lineColor="12678440">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y4xdkEeatXPvf_dRw8w" source="ShadowFigure">
@@ -1574,7 +1563,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y9hdkEeatXPvf_dRw8w"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_aUYHcEZgEeWzOqfPW42hmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y9xdkEeatXPvf_dRw8w" x="-205" y="624" width="109" height="57"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8y9xdkEeatXPvf_dRw8w" x="-240" y="640" width="109" height="57"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_1C8y-BdkEeatXPvf_dRw8w" type="1002" fontName="Segoe UI" lineColor="0">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_1C8y-RdkEeatXPvf_dRw8w" source="ShadowFigure">
@@ -1588,7 +1577,7 @@
       </eAnnotations>
       <children xmi:type="notation:DecorationNode" xmi:id="_1C8y_xdkEeatXPvf_dRw8w" type="3"/>
       <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_Uyzf0EZhEeWzOqfPW42hmw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8zABdkEeatXPvf_dRw8w" x="-261" y="712" width="221"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1C8zABdkEeatXPvf_dRw8w" x="-296" y="728" width="221"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_uWAUcBgvEeavBLLlfRT9gQ" type="1026" fillColor="15912618" lineColor="12678440">
       <children xmi:type="notation:DecorationNode" xmi:id="_uWBikBgvEeavBLLlfRT9gQ" type="1034"/>
@@ -1655,11 +1644,6 @@
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_aJ-ukNjjEea1wr7GsSffog"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bxKu0djjEea1wr7GsSffog" x="384" y="-80" width="121" height="56"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_OuXKYNjkEea1wr7GsSffog" type="1002" fillColor="10265827">
-      <children xmi:type="notation:DecorationNode" xmi:id="_OuXxcNjkEea1wr7GsSffog" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_NTIigNjkEea1wr7GsSffog"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OuXKYdjkEea1wr7GsSffog" x="385" width="391"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_1gQMsN2EEeavRZOd5ikktA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_1gQMsd2EEeavRZOd5ikktA" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1gQMs92EEeavRZOd5ikktA" name="BASE_ELEMENT">
@@ -1668,7 +1652,7 @@
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gQMst2EEeavRZOd5ikktA" x="584" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_3-NI4N5gEeaGLqqeTEyVEQ" type="1026" fillColor="15912618">
+    <children xmi:type="notation:Shape" xmi:id="_3-NI4N5gEeaGLqqeTEyVEQ" type="1026" fillColor="15912618" lineColor="12678440">
       <children xmi:type="notation:DecorationNode" xmi:id="_3-NI4t5gEeaGLqqeTEyVEQ" type="1034"/>
       <children xmi:type="notation:BasicCompartment" xmi:id="_3-Nv8N5gEeaGLqqeTEyVEQ" type="1071">
         <children xmi:type="notation:Shape" xmi:id="_c1qpIO1lEealZpKGxQi2Dw" type="3002">
@@ -1687,7 +1671,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3-Nv-d5gEeaGLqqeTEyVEQ"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_1j1YMN5gEeaGLqqeTEyVEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3-NI4d5gEeaGLqqeTEyVEQ" x="-11" y="612" height="105"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3-NI4d5gEeaGLqqeTEyVEQ" x="242" y="640" height="65"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_cHlx4N5hEeaGLqqeTEyVEQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_cHlx4d5hEeaGLqqeTEyVEQ" showTitle="true"/>
@@ -1696,11 +1680,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cHlx4t5hEeaGLqqeTEyVEQ" x="876" y="600"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_3MdWsO1lEealZpKGxQi2Dw" type="1002" fillColor="10265827">
-      <children xmi:type="notation:DecorationNode" xmi:id="_3Mek0O1lEealZpKGxQi2Dw" type="3"/>
-      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_vxINkO1lEealZpKGxQi2Dw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3MdWse1lEealZpKGxQi2Dw" x="162" y="507" width="730"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_EynYcO1oEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_EypNoO1oEealZpKGxQi2Dw" type="1084"/>
@@ -1783,7 +1762,7 @@
     <children xmi:type="notation:Shape" xmi:id="_aER_QO1oEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_aESmUO1oEealZpKGxQi2Dw" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Realization"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aER_Qe1oEealZpKGxQi2Dw" x="-202" y="528"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aER_Qe1oEealZpKGxQi2Dw" x="-237" y="544"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_aExHc-1oEealZpKGxQi2Dw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_aExHdO1oEealZpKGxQi2Dw" showTitle="true"/>
@@ -1796,7 +1775,7 @@
     <children xmi:type="notation:Shape" xmi:id="_he8aAO1oEealZpKGxQi2Dw" type="1031">
       <children xmi:type="notation:DecorationNode" xmi:id="_he9BEO1oEealZpKGxQi2Dw" type="1084"/>
       <element xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Abstraction"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_he8aAe1oEealZpKGxQi2Dw" x="8" y="516"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_he8aAe1oEealZpKGxQi2Dw" x="262" y="544"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_hfgasO1oEealZpKGxQi2Dw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_hfgase1oEealZpKGxQi2Dw" showTitle="true"/>
@@ -1805,6 +1784,21 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hfgasu1oEealZpKGxQi2Dw" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZX3JUO-FEeaFytHm7I89bw" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ZX4XcO-FEeaFytHm7I89bw" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_JvB8AKqzEeSqFPhVNQ1oeg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZX3JUe-FEeaFytHm7I89bw" x="-240" y="-46" width="597"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_uuaQIO-FEeaFytHm7I89bw" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_uuaQIu-FEeaFytHm7I89bw" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_NTIigNjkEea1wr7GsSffog"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uuaQIe-FEeaFytHm7I89bw" x="-240" y="72" width="745"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_PzTNYO-GEeaFytHm7I89bw" type="1002">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PzTNYu-GEeaFytHm7I89bw" type="3"/>
+      <element xmi:type="uml:Comment" href="OpenModel_Profile.profile.uml#_vxINkO1lEealZpKGxQi2Dw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PzTNYe-GEeaFytHm7I89bw" x="-64" y="728" width="753"/>
     </children>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_1C8zExdkEeatXPvf_dRw8w"/>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_1C9Y4BdkEeatXPvf_dRw8w" name="diagram_compatibility_version" stringValue="1.1.0"/>
@@ -1847,16 +1841,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y_hdkEeatXPvf_dRw8w" id="(0.41450777202072536,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9Y_xdkEeatXPvf_dRw8w" id="(0.76,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_1C9ZFBdkEeatXPvf_dRw8w" type="1022" source="_1C8yiBdkEeatXPvf_dRw8w" target="_1C8yTBdkEeatXPvf_dRw8w" lineColor="0">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__92VEBhUEeavBLLlfRT9gQ" source="PapyrusCSSForceValue">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__928IBhUEeavBLLlfRT9gQ" key="routing" value="true"/>
-      </eAnnotations>
-      <styles xmi:type="notation:FontStyle" xmi:id="_1C9ZFRdkEeatXPvf_dRw8w" fontName="Segoe UI"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1C9ZFhdkEeatXPvf_dRw8w" points="[-250, 0, 40, 113]$[-250, -113, 40, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9ZFxdkEeatXPvf_dRw8w" id="(0.9330024813895782,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1C9ZGBdkEeatXPvf_dRw8w" id="(0.08,1.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_1C9ZIxdkEeatXPvf_dRw8w" type="1022" source="_1C8y-BdkEeatXPvf_dRw8w" target="_1C8y4hdkEeatXPvf_dRw8w" routing="Rectilinear" lineColor="0">
       <styles xmi:type="notation:FontStyle" xmi:id="_1C9ZJBdkEeatXPvf_dRw8w" fontName="Segoe UI"/>
       <element xsi:nil="true"/>
@@ -1888,13 +1872,6 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gaMvcNjjEea1wr7GsSffog" id="(0.3619047619047619,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gaMvcdjjEea1wr7GsSffog" id="(0.66,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_Ouz2UNjkEea1wr7GsSffog" type="1022" source="_OuXKYNjkEea1wr7GsSffog" target="_bxKu0NjjEea1wr7GsSffog">
-      <styles xmi:type="notation:FontStyle" xmi:id="_Ouz2UdjkEea1wr7GsSffog"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ouz2UtjkEea1wr7GsSffog" points="[0, 0, -436, 52]$[384, -46, -52, 6]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIN00NjkEea1wr7GsSffog" id="(0.19473684210526315,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PIN00djkEea1wr7GsSffog" id="(0.45454545454545453,1.0)"/>
-    </edges>
     <edges xmi:type="notation:Connector" xmi:id="_1gQMtN2EEeavRZOd5ikktA" type="StereotypeCommentLink" source="_bxKu0NjjEea1wr7GsSffog" target="_1gQMsN2EEeavRZOd5ikktA">
       <styles xmi:type="notation:FontStyle" xmi:id="_1gQMtd2EEeavRZOd5ikktA"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_1gQMud2EEeavRZOd5ikktA" name="BASE_ELEMENT">
@@ -1914,13 +1891,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cHlx5t5hEeaGLqqeTEyVEQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cHlx595hEeaGLqqeTEyVEQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cHlx6N5hEeaGLqqeTEyVEQ"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_3N6IMO1lEealZpKGxQi2Dw" type="1022" source="_3MdWsO1lEealZpKGxQi2Dw" target="_3-NI4N5gEeaGLqqeTEyVEQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_3N6IMe1lEealZpKGxQi2Dw"/>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3N6IMu1lEealZpKGxQi2Dw" points="[0, 0, -744, -628]$[710, 600, -34, -28]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7y3hIO1lEealZpKGxQi2Dw" id="(0.0,0.6038647342995169)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7y3hIe1lEealZpKGxQi2Dw" id="(1.0,0.3904761904761905)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_EzEEZO1oEealZpKGxQi2Dw" type="StereotypeCommentLink" source="_EynYcO1oEealZpKGxQi2Dw" target="_EzEEYO1oEealZpKGxQi2Dw">
       <styles xmi:type="notation:FontStyle" xmi:id="_EzEEZe1oEealZpKGxQi2Dw"/>
@@ -2078,6 +2048,27 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hgGQku1oEealZpKGxQi2Dw" points="[-33, -28, 691, 600]$[-724, -628, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iocYsO1oEealZpKGxQi2Dw" id="(0.4928571428571429,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iocYse1oEealZpKGxQi2Dw" id="(0.5,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZY3O4O-FEeaFytHm7I89bw" type="1022" source="_ZX3JUO-FEeaFytHm7I89bw" target="_1C8yTBdkEeatXPvf_dRw8w">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZY3O4e-FEeaFytHm7I89bw"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZY3O4u-FEeaFytHm7I89bw" points="[0, 0, -444, 166]$[394, -147, -50, 19]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jEPIAO-FEeaFytHm7I89bw" id="(1.0,0.1568627450980392)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jEPvEO-FEeaFytHm7I89bw" id="(0.0,0.8)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_uvOIcO-FEeaFytHm7I89bw" type="1022" source="_uuaQIO-FEeaFytHm7I89bw" target="_bxKu0NjjEea1wr7GsSffog">
+      <styles xmi:type="notation:FontStyle" xmi:id="_uvOIce-FEeaFytHm7I89bw"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uvOIcu-FEeaFytHm7I89bw" points="[0, 0, -444, 52]$[384, -45, -60, 7]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xMSAwO-FEeaFytHm7I89bw" id="(0.8805369127516779,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xMSn0O-FEeaFytHm7I89bw" id="(0.4297520661157025,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_P0HswO-GEeaFytHm7I89bw" type="1022" source="_PzTNYO-GEeaFytHm7I89bw" target="_3-NI4N5gEeaGLqqeTEyVEQ">
+      <styles xmi:type="notation:FontStyle" xmi:id="_P0Hswe-GEeaFytHm7I89bw"/>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P0Hswu-GEeaFytHm7I89bw" points="[0, 0, -59, -664]$[54, 612, -5, -52]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UFieoO-GEeaFytHm7I89bw" id="(0.4847277556440903,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UFjFsO-GEeaFytHm7I89bw" id="(0.7071428571428572,1.0)"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml
+++ b/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml
@@ -2,6 +2,272 @@
 <xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ProfileLifecycle_Profile="http:///schemas/ProfileLifecycle_Profile/_HtHgsNctEea1ncO03M1x2w/0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmlns:umlnotationext="http://www.eclipse.org/papyrus/umlnotation" xsi:schemaLocation="http:///schemas/ProfileLifecycle_Profile/_HtHgsNctEea1ncO03M1x2w/0 ../ProfileLifecycleProfile/ProfileLifecycle_Profile.profile.uml#_HtLyIdctEea1ncO03M1x2w">
   <uml:Profile xmi:id="_m1xqsHBgEd6FKu9XX1078A" name="OpenModel_Profile" metamodelReference="_m2EloXBgEd6FKu9XX1078A">
     <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_m2rCkXBgEd6FKu9XX1078A" source="http://www.eclipse.org/uml2/2.0.0/UML">
+      <contents xmi:type="ecore:EPackage" xmi:id="_QKgFEO-JEeaFytHm7I89bw" name="OpenModel_Profile" nsURI="http:///schemas/OpenModel_Profile/_QKfeAO-JEeaFytHm7I89bw/18" nsPrefix="OpenModel_Profile">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKkWge-JEeaFytHm7I89bw" source="PapyrusVersion">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QKkWgu-JEeaFytHm7I89bw" key="Version" value="0.2.6"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QKkWg--JEeaFytHm7I89bw" key="Comment" value="Updates:&#xD;&#xA;SpecifiedComposite, DefinedBySpec and SpecReference stereotypes deleted.&#xD;&#xA;target added to Specify stereotype.&#xD;&#xA;Cond stereotype extending relationship metaclass.&#xD;&#xA;Descriptions for StrictComposite, ExtendedComposite and Specify stereotypes updated."/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QKkWhO-JEeaFytHm7I89bw" key="Copyright" value=""/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QKkWhe-JEeaFytHm7I89bw" key="Date" value="2017-02-10"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_QKkWhu-JEeaFytHm7I89bw" key="Author" value=""/>
+        </eAnnotations>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgFEe-JEeaFytHm7I89bw" name="OpenModelAttribute">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFEu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_36ZCQHBgEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgFE--JEeaFytHm7I89bw" name="base_StructuralFeature" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StructuralFeature"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFFe-JEeaFytHm7I89bw" name="partOfObjectKey" ordered="false" lowerBound="1" defaultValueLiteral="0">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Integer"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFF--JEeaFytHm7I89bw" name="uniqueSet" ordered="false" upperBound="-1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Integer"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFGe-JEeaFytHm7I89bw" name="isInvariant" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFG--JEeaFytHm7I89bw" name="settingTime" ordered="false" lowerBound="1" eType="_QKgFK--JEeaFytHm7I89bw" defaultValueLiteral="ANYTIME"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFHe-JEeaFytHm7I89bw" name="settingActor" ordered="false" lowerBound="1" upperBound="3" eType="_QKgFL--JEeaFytHm7I89bw" defaultValueLiteral="UNDERLYING_SYSTEM"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFH--JEeaFytHm7I89bw" name="valueRange" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFIe-JEeaFytHm7I89bw" name="unsigned" ordered="false" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFI--JEeaFytHm7I89bw" name="counter" ordered="false" eType="_QKgFNO-JEeaFytHm7I89bw" defaultValueLiteral="NA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFJe-JEeaFytHm7I89bw" name="unit" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFJ--JEeaFytHm7I89bw" name="support" ordered="false" lowerBound="1" eType="_QKgFOu-JEeaFytHm7I89bw" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFKe-JEeaFytHm7I89bw" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgFK--JEeaFytHm7I89bw" name="SettingTime">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFLO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_d9ctkOFREeaZZuNj8jMn0Q"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFLe-JEeaFytHm7I89bw" name="ANYTIME"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFLu-JEeaFytHm7I89bw" name="CREATION_ONLY" value="1"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgFL--JEeaFytHm7I89bw" name="SettingActor">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFMO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_g5vfkOFREeaZZuNj8jMn0Q"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFMe-JEeaFytHm7I89bw" name="CLIENT_DIRECTLY"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFMu-JEeaFytHm7I89bw" name="CLIENT_INDIRECTLY" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFM--JEeaFytHm7I89bw" name="UNDERLYING_SYSTEM" value="2"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgFNO-JEeaFytHm7I89bw" name="Counter">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFNe-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_NtRBsFfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFNu-JEeaFytHm7I89bw" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFN--JEeaFytHm7I89bw" name="COUNTER" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFOO-JEeaFytHm7I89bw" name="GAUGE" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFOe-JEeaFytHm7I89bw" name="ZERO_COUNTER" value="3"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgFOu-JEeaFytHm7I89bw" name="SupportQualifier">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFO--JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_tIP_UL7QEeGcHtJ-koFuEQ"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFPO-JEeaFytHm7I89bw" name="MANDATORY"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFPe-JEeaFytHm7I89bw" name="OPTIONAL" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFPu-JEeaFytHm7I89bw" name="CONDITIONAL_MANDATORY" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFP--JEeaFytHm7I89bw" name="CONDITIONAL_OPTIONAL" value="3"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgFQO-JEeaFytHm7I89bw" name="CONDITIONAL" value="4"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgFQe-JEeaFytHm7I89bw" name="OpenModelClass">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFQu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_JVMFMHBhEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgFQ--JEeaFytHm7I89bw" name="base_Class" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFRe-JEeaFytHm7I89bw" name="support" ordered="false" lowerBound="1" eType="_QKgFOu-JEeaFytHm7I89bw" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFR--JEeaFytHm7I89bw" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgFSe-JEeaFytHm7I89bw" name="OpenModelOperation">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFSu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_FRG9AHBnEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgFS--JEeaFytHm7I89bw" name="base_Operation" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Operation"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFTe-JEeaFytHm7I89bw" name="isOperationIdempotent" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFT--JEeaFytHm7I89bw" name="isAtomic" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFUe-JEeaFytHm7I89bw" name="support" ordered="false" lowerBound="1" eType="_QKgFOu-JEeaFytHm7I89bw" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFU--JEeaFytHm7I89bw" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgFVe-JEeaFytHm7I89bw" name="OpenModelParameter">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgFVu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_jG59cHEqEd6SxZ5y0DIogw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgFV--JEeaFytHm7I89bw" name="base_Parameter" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Parameter"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgFWe-JEeaFytHm7I89bw" name="valueRange" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsIO-JEeaFytHm7I89bw" name="support" ordered="false" lowerBound="1" eType="_QKgFOu-JEeaFytHm7I89bw" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsIu-JEeaFytHm7I89bw" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgsJO-JEeaFytHm7I89bw" name="NotificationDefinition">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsJe-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_HgbRQBGqEd-nT5bmeQ1LHg"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsJu-JEeaFytHm7I89bw" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsJ--JEeaFytHm7I89bw" name="NO" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsKO-JEeaFytHm7I89bw" name="YES" value="2"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsKe-JEeaFytHm7I89bw" name="Names">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsKu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_jiSAMI7kEeGyB5ASrrNdIA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsK--JEeaFytHm7I89bw" name="base_Association" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsLe-JEeaFytHm7I89bw" name="Choice">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsLu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_27D5AL7XEeGcHtJ-koFuEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsL--JEeaFytHm7I89bw" name="base_DataType" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//DataType"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsMe-JEeaFytHm7I89bw" name="base_Class" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsM--JEeaFytHm7I89bw" name="Exception">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsNO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_el7rwL7YEeGcHtJ-koFuEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsNe-JEeaFytHm7I89bw" name="base_DataType" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//DataType"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsN--JEeaFytHm7I89bw" name="NamedBy">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsOO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_3E1eYPNAEeGLMdrUcsEncQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsOe-JEeaFytHm7I89bw" name="base_Dependency" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Dependency"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsO--JEeaFytHm7I89bw" name="StrictComposite">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsPO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_vQjMkJ2BEeSDYd59zPupRA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsPe-JEeaFytHm7I89bw" name="base_Association" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsP--JEeaFytHm7I89bw" name="Cond">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsQO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_h7id0J2CEeSDYd59zPupRA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsQe-JEeaFytHm7I89bw" name="condition" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsQ--JEeaFytHm7I89bw" name="base_Relationship" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Relationship"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsRe-JEeaFytHm7I89bw" name="Experimental">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsRu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_FU4UgJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsR--JEeaFytHm7I89bw" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsSe-JEeaFytHm7I89bw" name="LikelyToChange">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsSu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_HmOsEJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsS--JEeaFytHm7I89bw" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsTe-JEeaFytHm7I89bw" name="Preliminary">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsTu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_LEgJwJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsT--JEeaFytHm7I89bw" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsUe-JEeaFytHm7I89bw" name="Obsolete">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsUu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_M6xu4J2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsU--JEeaFytHm7I89bw" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsVe-JEeaFytHm7I89bw" name="Example">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsVu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_OwwZEJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsV--JEeaFytHm7I89bw" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsWe-JEeaFytHm7I89bw" name="Faulty">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsWu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_QGmKoJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsW--JEeaFytHm7I89bw" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsXe-JEeaFytHm7I89bw" name="OpenModelInterface">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsXu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_oKbrsKiIEeSJmIxGbzx9kA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsX--JEeaFytHm7I89bw" name="base_Interface" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Interface"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsYe-JEeaFytHm7I89bw" name="support" ordered="false" lowerBound="1" eType="_QKgFOu-JEeaFytHm7I89bw" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsY--JEeaFytHm7I89bw" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsZe-JEeaFytHm7I89bw" name="OpenModelNotification">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsZu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_74KP4EZPEeW32YsOmT7W0Q"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsZ--JEeaFytHm7I89bw" name="triggerConditionList" ordered="false" lowerBound="1" upperBound="-1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsae-JEeaFytHm7I89bw" name="support" ordered="false" lowerBound="1" eType="_QKgFOu-JEeaFytHm7I89bw" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsa--JEeaFytHm7I89bw" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsbe-JEeaFytHm7I89bw" name="base_Signal" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Signal"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsb--JEeaFytHm7I89bw" name="PruneAndRefactor">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgscO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_aUYHcEZgEeWzOqfPW42hmw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsce-JEeaFytHm7I89bw" name="base_Realization" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Realization"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsc--JEeaFytHm7I89bw" name="Deprecated">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsdO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_ma6wEJDeEeW51dNDZIXIMA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsde-JEeaFytHm7I89bw" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsd--JEeaFytHm7I89bw" name="Mature">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgseO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_wvWWABdhEeatXPvf_dRw8w"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsee-JEeaFytHm7I89bw" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgse--JEeaFytHm7I89bw" name="Reference">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsfO-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_949Q4FfpEeak-v4LxEsCQw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsfe-JEeaFytHm7I89bw" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsf--JEeaFytHm7I89bw" name="reference" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgsge-JEeaFytHm7I89bw" name="BitLength">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsgu-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_M9B3kFfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsg--JEeaFytHm7I89bw" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgshO-JEeaFytHm7I89bw" name="LENGTH_8_BIT" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgshe-JEeaFytHm7I89bw" name="LENGTH_16_BIT" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgshu-JEeaFytHm7I89bw" name="LENGTH_32_BIT" value="3"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsh--JEeaFytHm7I89bw" name="LENGTH_64_BIT" value="4"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_QKgsiO-JEeaFytHm7I89bw" name="Encoding">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsie-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_OZ1z0FfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsiu-JEeaFytHm7I89bw" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsi--JEeaFytHm7I89bw" name="BASE_64" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsjO-JEeaFytHm7I89bw" name="HEX" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_QKgsje-JEeaFytHm7I89bw" name="OCTET" value="3"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgsju-JEeaFytHm7I89bw" name="ExtendedComposite" eSuperTypes="_QKgsO--JEeaFytHm7I89bw">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsj--JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_aJ-ukNjjEea1wr7GsSffog"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_QKgske-JEeaFytHm7I89bw" name="Specify">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_QKgsku-JEeaFytHm7I89bw" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_1j1YMN5gEeaGLqqeTEyVEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_QKgsk--JEeaFytHm7I89bw" name="base_Abstraction" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Abstraction"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_QKgsle-JEeaFytHm7I89bw" name="target" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+      </contents>
       <contents xmi:type="ecore:EPackage" xmi:id="_jEQtEOMXEeaVnpsnjRW9Pg" name="OpenModel_Profile" nsURI="http:///schemas/OpenModel_Profile/_jELNgOMXEeaVnpsnjRW9Pg/17" nsPrefix="OpenModel_Profile">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jEjoAeMXEeaVnpsnjRW9Pg" source="PapyrusVersion">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jEjoAuMXEeaVnpsnjRW9Pg" key="Version" value="0.2.5"/>
@@ -6715,7 +6981,8 @@
       <body>Updates in v0.2.6:&#xD;
 SpecifiedComposite, DefinedBySpec and SpecReference stereotypes deleted.&#xD;
 target added to Specify stereotype.&#xD;
-Cond stereotype extending relationship metaclass.</body>
+Cond stereotype extending relationship metaclass.&#xD;
+Descriptions for StrictComposite, ExtendedComposite and Specify stereotypes updated.</body>
     </ownedComment>
     <packageImport xmi:type="uml:PackageImport" xmi:id="_m2EloHBgEd6FKu9XX1078A">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vp7j5XBnEd6FKu9XX1078A" source="uml2.extensions">
@@ -6797,7 +7064,7 @@ Values CLIENT_DIRECTLY, CLIENT_INDIRECTLY and UNDERLYING_SYSTEM are not mutually
         </ownedComment>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_yhhRwOFVEeaZZuNj8jMn0Q" value="1"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_yhp0oOFVEeaZZuNj8jMn0Q" value="3"/>
-        <defaultValue xmi:type="uml:InstanceValue" xmi:id="_KEz5wOFSEeaZZuNj8jMn0Q" type="_g5vfkOFREeaZZuNj8jMn0Q"/>
+        <defaultValue xmi:type="uml:InstanceValue" xmi:id="_KEz5wOFSEeaZZuNj8jMn0Q" type="_g5vfkOFREeaZZuNj8jMn0Q" instance="_zBvmwOFREeaZZuNj8jMn0Q"/>
       </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_sUuCwHEoEd6SxZ5y0DIogw" name="valueRange" visibility="public">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4YIfjHEqEd6SxZ5y0DIogw" source="uml2.extensions">
@@ -7708,13 +7975,13 @@ Example: When an operation is going to create an object instance which does alre
     </packagedElement>
     <packagedElement xmi:type="uml:Stereotype" xmi:id="_aJ-ukNjjEea1wr7GsSffog" name="ExtendedComposite">
       <ownedComment xmi:type="uml:Comment" xmi:id="_NTIigNjkEea1wr7GsSffog" annotatedElement="_aJ-ukNjjEea1wr7GsSffog">
-        <body>This steoreotype indicates a more restrictive form of &quot;StrictComposite&quot; where the &quot;extending&quot; classes will never be explictly instantiated, but that the attributes defined by the “extending” class will be transferred to the class being “extended” at runtime, much like the UML “Generalization” relationship. In other words the &quot;extending&quot; classes are essentially carrying attributes of the “extended” class in a grouping-pack and often referred to as &quot;pacs&quot;.</body>
+        <body>This steoreotype indicates a more restrictive form of &quot;StrictComposite&quot; where the &quot;extending&quot; classes will never be explictly instantiated, but that the attributes defined by the “extending” class will be transferred to the class being “extended” at runtime, much like the UML “Generalization” relationship. In other words the &quot;extending&quot; classes are essentially carrying attributes of the “extended” class in a grouping-pack and often referred to as &quot;_Pacs&quot;.</body>
       </ownedComment>
       <generalization xmi:type="uml:Generalization" xmi:id="_gZMp4NjjEea1wr7GsSffog" general="_vQjMkJ2BEeSDYd59zPupRA"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Stereotype" xmi:id="_1j1YMN5gEeaGLqqeTEyVEQ" name="Specify">
       <ownedComment xmi:type="uml:Comment" xmi:id="_vxINkO1lEealZpKGxQi2Dw" annotatedElement="_1j1YMN5gEeaGLqqeTEyVEQ">
-        <body>The “Specify” stereotype is applied on the UML “Abstraction” relationship to indicate that the definition of the more abstract “supplier” class in the abstraction relationship is augmented by the “client” class definition at runtime. Furthermore there is a potential for a &quot;supplier&quot; class definition to be augmented by more than one &quot;client&quot; class definitions. In others words, one of the “client” specification class adds-to and expands the runtime-definition of the “supplier” class. This also implies that the “supplier&quot; class cannot be aware of the existence of “client” specification classes at design time. Since the “Specify” relationship is defined to support runtime code/schema generation and dependency injection, a stereotype-property “target” is defined to point to the actual node being augmented within the object/instance schema. The &quot;target&quot; value should be in the following format:&#xD;
+        <body>The “Specify” stereotype is applied on the UML “Abstraction” relationship to indicate that the definition of the more abstract entity class in the abstraction relationship is augmented by the &quot;specification&quot; class definition at runtime. Furthermore there is a potential for an entity class definition to be augmented by more than one &quot;specification&quot; class definitions. In others words, one of the specification classes adds-to and expands the runtime-definition of the entity class. This also implies that the entity class cannot be aware of the existence of specification classes at design time. Since the “Specify” relationship is defined to support runtime code/schema generation and dependency injection, a stereotype-property “target” is defined to point to the actual node being augmented within the object/instance schema. The &quot;target&quot; value should be in the following format:&#xD;
 [/&lt;ModelName>:&lt;ClassName>]+:&lt;AttributeName>. &#xD;
 Example: TopologyContext in TapiTopology augments Context in TapiCommon&#xD;
 target=/TapiCommon:Context:_context&#xD;


### PR DESCRIPTION
OpenModelProfile updates:
SpecifiedComposite, DefinedBySpec and SpecReference stereotypes deleted.
target added to Specify stereotype.
Cond stereotype extending relationship metaclass.
Descriptions for StrictComposite, ExtendedComposite and Specify
stereotypes updated.

InterfaceModelProfile updates:
Augment stereotype deleted.
name property added to RootElement stereotype.