### PR TITLE
No units within type

### DIFF
--- a/UmlYangTools/xmi2yang/model/yang/type.js
+++ b/UmlYangTools/xmi2yang/model/yang/type.js
@@ -70,7 +70,7 @@ type.prototype.writeNode = function (layer) {
         name += ";";
     }*/
     var s = "";
-    if(this.path || this.range || this.length || this.children.length || this.units){
+    if(this.path || this.range || this.length || this.children.length){
         s = " {\r\n";
         var regex  = /[^0-9/./*]/;
         if(this.range){

--- a/UmlYangTools/xmi2yang/model/yang/type.js
+++ b/UmlYangTools/xmi2yang/model/yang/type.js
@@ -112,17 +112,7 @@ type.prototype.writeNode = function (layer) {
             s += Util.yangifyName(this.path) + ";\r\n";
         }
 
-
-
-        var units;
-        if(this.units){
-            units = PRE + "\tunits \"" + this.units + "\";\r\n";
-        }else{
-            units = "";
-        }
-
-        s = s +
-            units + PRE + "}";
+        s = s + PRE + "}";
     }
     else{
         s=";";


### PR DESCRIPTION
Current implementation adds a "units" statement within a "type" statement.
This pull request should slove the issue.

## Example before pull request:
 ```
[...]
           leaf duplex-distance {
                type uint64 {
                    units "kHz";
                }
                units "kHz";
                default "-1";
                config false;
                description "Distance between transmitted and received frequency.";
            }
[...]
 ```

## Example after pull request:
 ```
[...]
           leaf duplex-distance {
                type uint64;
                units "kHz";
                default "-1";
                config false;
                description "Distance between transmitted and received frequency.";
            }
[...]
 ```