### PR TITLE
Solves issue, enums without own items, just generalizations

### DIFF
--- a/UmlYangTools/xmi2yang/main.js
+++ b/UmlYangTools/xmi2yang/main.js
@@ -1530,6 +1530,10 @@ function obj2yang(ele){
             if(ele[i].generalization.length > 0){
                 for(var j = 0; j < ele[i].generalization.length; j++) {
                     for (var k = 0; k < Typedef.length; k++) {
+                        if (!ele[i].attribute || !ele[i].attribute[0]) {
+                            var newEnum = new Type("enumeration");
+                            ele[i].attribute = [newEnum];
+                        }
                         if(ele[i].generalization[j] == Typedef[k].id){
                             ele[i].attribute[0].children = Typedef[k].attribute[0].children.concat(ele[i].attribute[0].children);
                             break;


### PR DESCRIPTION
The current implementation causes an error for the enums "RouteSelectionReason" and "SwitchStateReason" of CoreModel 1.2, because the "attribute" is an empty list ( attribute: [] ) in this case.

The proposed solutions creates an enum-type, if it is missing.

--
{
  name: 'RouteSelectionReason',
  id: '_cswHkCi-EeaGGvAxxSe1uA',
  type: 'Enumeration',
  path: 'CoreNetworkModel-TypeDefinitions-Resilience',
  nodeType: 'enumeration',
  description: 'The cause of the current route selection.',
  generalization: [ '_yIKvsMOGEeWwZ527PhfFSA', '_sthcgCi-EeaGGvAxxSe1uA' ],
  instancePath: 'CoreModel:RouteSelectionReason/',
  isGrouping: false,
  isAbstract: false,
  isSpec: false,
  config: true,
  isOrdered: false,
  fileName: 'CoreModel.xml',
  attribute: [],
  key: [],
  keyid: [],
  status: 'Preliminary' }

{
  name: 'SwitchStateReason',
  id: '_zRKlICi9EeaGGvAxxSe1uA',
  type: 'Enumeration',
  path: 'CoreNetworkModel-TypeDefinitions-Resilience',
  nodeType: 'enumeration',
  description: 'Explains the reason for the current switch state.',
  generalization: [ '_e-7DYMOFEeWwZ527PhfFSA', '_sthcgCi-EeaGGvAxxSe1uA' ],
  instancePath: 'CoreModel:SwitchStateReason/',
  isGrouping: false,
  isAbstract: false,
  isSpec: false,
  config: true,
  isOrdered: false,
  fileName: 'CoreModel.xml',
  attribute: [],
  key: [],
  keyid: [],
  status: 'Preliminary' }
