### PR TITLE
Corrects the 'allOf' overwrite problem

### DIFF
--- a/YangJsonTools/swagger.py
+++ b/YangJsonTools/swagger.py
@@ -350,13 +350,6 @@ def gen_model(children, tree_structure, config=True):
                 # Process the reference to another model.
                 # We differentiate between single and array references.
                 elif attribute.keyword == 'uses':
-
-                    # Check if we are under virtualizer
-                    inVirt = False
-                    for att in child.substmts:
-                        if att.keyword == 'description' and att.arg == 'Container for a single virtualizer':
-                            inVirt = True
-
                     #pending_models.append(attribute.arg)
                     if len(attribute.arg.split(':'))>1:
                         attribute.arg = attribute.arg.split(':')[-1]

--- a/YangJsonTools/swagger.py
+++ b/YangJsonTools/swagger.py
@@ -118,7 +118,7 @@ def print_header(module, fd):
 
 def emit_swagger_spec(ctx, modules, fd, path):
     """ Emits the complete swagger specification for the yang file."""
-
+    
     printed_header = False
     model = OrderedDict()
     definitions = OrderedDict()
@@ -249,7 +249,7 @@ def findModels(ctx, module, children, referenced_models):
     for child in children:
         if hasattr(child, 'substmts'):
              for attribute in child.substmts:
-                if attribute.keyword == 'uses':
+                 if attribute.keyword == 'uses':
                     if len(attribute.arg.split(':'))>1:
                         for i in module.search('import'):
                             subm = ctx.get_module(i.arg)
@@ -291,7 +291,6 @@ def findTypedefs(ctx, module, children, referenced_types):
         if hasattr(child, 'i_children'):
             findTypedefs(ctx, module, child.i_children, referenced_types)
     return referenced_types
-
 
 pending_models = list()
 def gen_model(children, tree_structure, config=True):
@@ -351,6 +350,13 @@ def gen_model(children, tree_structure, config=True):
                 # Process the reference to another model.
                 # We differentiate between single and array references.
                 elif attribute.keyword == 'uses':
+
+                    # Check if we are under virtualizer
+                    inVirt = False
+                    for att in child.substmts:
+                        if att.keyword == 'description' and att.arg == 'Container for a single virtualizer':
+                            inVirt = True
+
                     #pending_models.append(attribute.arg)
                     if len(attribute.arg.split(':'))>1:
                         attribute.arg = attribute.arg.split(':')[-1]
@@ -363,12 +369,17 @@ def gen_model(children, tree_structure, config=True):
                     # it is a extension of another object, which in swagger is defined using the
                     # "AllOf" statement.
                     ref = '#/definitions/' + ref_arg
+
+
                     if not nonRefChildren:
                         referenced = True
                     else:
                         if ref_arg in PARENT_MODELS:
                             PARENT_MODELS[ref_arg]['models'].append(child.arg)
-                        node['allOf'] = []
+                        
+                        # Create new array on the first reference
+                        if 'allOf' not in node:
+                            node['allOf'] = []
                         node['allOf'].append({'$ref': ref})
 
 


### PR DESCRIPTION
This pull request corrects the overwriting issue.
Beforem when the plugin encountered a 'uses' reference, it created an empty array for each time it saw the usage of that keyword. This was made even if a child had multiple references.

So if the YANG model looked something like this:
``` yang
  container virtualizer {
    description "Container for a single virtualizer";
    uses id-name { ... }
    container nodes{ ... }
    uses links; // infra links
    uses metadata;
    leaf version { ... }
  }
```

only the last `` uses metadata`` was included in the output JSON for swagger after running ``pyang -f swagger virtualizer.yang -o virtualizer.json``:
``` json
        "virtualizer_schema": {
            "description": "Container for a single virtualizer",
            "allOf": [
                {
                    "$ref": "#/definitions/metadata"
                },
                {
                    "properties": {
                        "nodes": { ... },
                        "version": { ... }
                    }
                }
            ]
        },

```

instead of:
``` json
        "virtualizer_schema": {
            "description": "Container for a single virtualizer",
            "allOf": [
                {
                    "$ref": "#/definitions/id-name"
                },
                {
                    "$ref": "#/definitions/links"
                },
                {
                    "$ref": "#/definitions/metadata"
                },
                {
                    "properties": {
                        "nodes": { ... },
                        "version": { ... }
                    }
                }
            ]
        },

```