### PR TITLE
Implement <<Specify/Target>> Stereotype

### DIFF
--- a/UmlYangTools/xmi2yang/main.js
+++ b/UmlYangTools/xmi2yang/main.js
@@ -23,6 +23,8 @@ var xmlreader = require('xmlreader'),
     Type = require('./model/yang/type.js'),
     RPC = require('./model/yang/rpc.js'),
     Package = require('./model/yang/package.js'),
+    Specify = require('./model/specify.js'),
+    Abstraction = require('./model/yang/abstraction.js'),
     Augment = require('./model/yang/augment.js');
 
 var Typedef = [];//The array of basic DataType and PrimitiveType
@@ -41,9 +43,8 @@ var isInstantiated = [];//The array of case that the class is composited by the 
 var packages = [];
 var currentFileName;
 var generalization = [];
-var definedBySpec = [];
-var specTarget = [];
-var specReference = [];
+var abstraction=[];
+var specify = [];
 var augment = [];
 var config = {};
 
@@ -78,7 +79,7 @@ function main_Entrance(){
                     }
                     currentFileName = undefined;
                     if(!num){
-                        console.log("There is no .xml file in 'project' directory! Please check your files path");
+                        console.log("There is no .xml file in 'project' directory! Please check your files path")
                     }else{
                         //addKey();//deal with the key for every class
                         //if the class's value of aggregation is opposite,the class don't need to be instantiated individually
@@ -91,11 +92,11 @@ function main_Entrance(){
                             pflag = Class[i].id;
                             var path = addPath(Class[i].id, Class[i]);
 
-                            if(path === undefined){
+                            if(path == undefined){
                                 if(Class[i].key.array){
                                     Class[i].instancePath = Class[i].fileName.split('.')[0] + ":" + Class[i].name + "/" + Class[i].fileName.split('.')[0] + ":" + Class[i].key.join(" ");
                                 }else{
-                                    if(Class[i].key !== ""){
+                                    if(Class[i].key != ""){
                                         Class[i].instancePath = Class[i].fileName.split('.')[0] + ":" + Class[i].name + "/" + Class[i].fileName.split('.')[0] + ":" + Class[i].key;
                                     }else{
                                         Class[i].instancePath = Class[i].fileName.split('.')[0] + ":" + Class[i].name + "/";
@@ -104,7 +105,7 @@ function main_Entrance(){
                             }else{
                                 Class[i].isGrouping = true;
                                 var fileName;
-                                if(Class[i].instancePathFlag === true){
+                                if(Class[i].instancePathFlag == true){
                                     fileName = Class[i].fileName.split(".")[0];
                                 }else{
                                     fileName = path.split("/")[path.split("/").length - 1].split(":")[0];
@@ -112,7 +113,7 @@ function main_Entrance(){
                                 if(Class[i].key.array) {
                                     Class[i].instancePath = path + "/" + fileName + ":" + Class[i].key.join(" ");
                                 }else{
-                                    if(Class[i].key !== "") {
+                                    if(Class[i].key != "") {
                                         Class[i].instancePath = path + "/" + fileName + ":" + Class[i].key;
                                     }else{
                                         Class[i].instancePath = path + "/";
@@ -121,15 +122,15 @@ function main_Entrance(){
                             }
                         }
                         for(var i = 0; i < Class.length; i++){
-                            if(Class[i].type === "DataType" && Class[i].nodeType === "grouping" && Class[i].generalization.length === 0){
-                                if(Class[i].attribute.length === 1){
+                            if(Class[i].type == "DataType" && Class[i].nodeType == "grouping" && Class[i].generalization.length == 0){
+                                if(Class[i].attribute.length == 1){
                                     if(!Class[i].attribute[0].isUses){
                                         Class[i].nodeType = "typedef";
                                         Class[i].type = Class[i].attribute[0].type;
                                         Class[i].attribute = [];
                                         Typedef.push(Class[i]);
                                     }else{
-                                        if(!(Class[i].attribute[0].nodeType === "list" || Class[i].attribute[0].nodeType === "container")){
+                                        if(!(Class[i].attribute[0].nodeType == "list" || Class[i].attribute[0].nodeType == "container")){
                                             var t = datatypeExe(Class[i].attribute[0].type);
                                             switch (t.split(",")[0]){
                                                 case "enumeration":
@@ -138,7 +139,7 @@ function main_Entrance(){
                                                     if(a.length > 0){
                                                         for(var j = 0; j < a.length; j++){
                                                             for(var k = 0; k < Class.length; k++){
-                                                                if(a[j] === Class[k].id){
+                                                                if(a[j] == Class[k].id){
                                                                     Class[i].attribute = Class[i].attribute.concat(Class[k].attribute);
                                                                 }
                                                             }
@@ -160,7 +161,7 @@ function main_Entrance(){
                                 }
                             }
                             for(var j = 0; j < openModelclass.length; j++) {
-                                if(openModelclass[j].id === Class[i].id){
+                                if(openModelclass[j].id == Class[i].id){
                                     if(openModelclass[j].condition){
                                         Class[i].support = openModelclass[j].support;
                                     }
@@ -171,9 +172,10 @@ function main_Entrance(){
                                 }
                             }
                         }
+                       classspec(abstraction);
                         for(var i = 0; i < augment.length; i++){
                             for(var  j = 0; j < yangModule.length; j++){
-                                if(augment[i].fileName === yangModule[j].fileName){
+                                if(augment[i].fileName == yangModule[j].fileName){
                                     yangModule[j].children.push(augment[i]);
                                 }
                             }
@@ -185,9 +187,8 @@ function main_Entrance(){
                             if (yangModule[i].children.length > 0) {
                                 (function () {
                                     try {
-
                                         var st = writeYang(yangModule[i]);//print the module to yang file
-                                        var path = './project/' + yangModule[i].name + '.yang';
+                                        var path = './project/' + yangModule[i].name +  '.yang';
                                         fs.writeFile(path, st, function(error){
                                             if(error){
                                                 console.log(error.stack);
@@ -224,11 +225,11 @@ function readConfig(){
             data = data.replace(/(<br>)*$/g, "");
             config = JSON.parse(data);
             for(var key in config){
-                if(typeof config[key] === "string"){
+                if(typeof config[key] == "string"){
                     config[key] = config[key].replace(/<br>/g, "\r\n");
-                }else if(typeof config[key] === "object"){
+                }else if(typeof config[key] == "object"){
                     for(var keykey in config[key]){
-                        if(typeof config[key][keykey] === "string"){
+                        if(typeof config[key][keykey] == "string"){
                             config[key][keykey] = config[key][keykey].replace(/<br>/g, "\r\n");
                         }
                     }
@@ -244,7 +245,7 @@ function readConfig(){
                     for(var i = 0; i < dateArray.length; i++){
                         dateArray[i] = parseInt(dateArray[i]);
                     }
-                    if(date.match(reg) === null){
+                    if(date.match(reg) == null){
                         console.warn("The revision date is not in the correct format (yyyy-mm-dd), please check the config.txt file.");
                         throw (e1);
                     }
@@ -253,8 +254,8 @@ function readConfig(){
                         throw (e1);
                     }
                     if(dateArray[2] > day[dateArray[1]] || dateArray[2] < 1) {
-                        if (!(dateArray[0] % 4 === 0 && dateArray[1] === 2 && dateArray[2] === 29)) {
-                            console.warn("The revision date is invalid, day is not consistent with month. Please check the config.txt file");
+                        if (!(dateArray[0] % 4 == 0 && dateArray[1] == 2 && dateArray[2] == 29)) {
+                            console.warn("The revision date is invalid, day is not consistent with month. Please check the config.txt file")
                             throw (e1);
                         }
                     }
@@ -271,26 +272,26 @@ function readConfig(){
                         };
                         if (/(y+)/.test(fmt)) fmt = fmt.replace(RegExp.$1, (this.getFullYear() + "").substr(4 - RegExp.$1.length));
                         for (var k in o)
-                            if (new RegExp("(" + k + ")").test(fmt)) fmt = fmt.replace(RegExp.$1, (RegExp.$1.length === 1) ? (o[k]) : (("00" + o[k]).substr(("" + o[k]).length)));
+                            if (new RegExp("(" + k + ")").test(fmt)) fmt = fmt.replace(RegExp.$1, (RegExp.$1.length == 1) ? (o[k]) : (("00" + o[k]).substr(("" + o[k]).length)));
                         return fmt;
-                    };
+                    }
                     var currentData = new Date().Format("yyyy-MM-dd");
                     config.revision.date = currentData;
                 }
                 /*if(!date){
                 }
                 else if(dateArray[1] < 13 && dateArray[2] > day[dateArray[1]]){
-                    if(!(dateArray[0] % 4 === 0 && dateArray[1] === 2 && dateArray[2] === 29)){
+                    if(!(dateArray[0] % 4 == 0 && dateArray[1] == 2 && dateArray[2] == 29)){
                         console.warn("The revision date is invalid, the month is not consistent with data. Please check the config.txt file.")
                         throw (e1);
                     }
                     /!*if(parseInt(date.split("-")[0]) > parseInt(currentData.split("-")[0])){
                         console.warn("The revision date is invalid (later than current date or wrong number), please check the config.txt file.")
                         throw (e1);
-                    }else if(parseInt(date.split("-")[0]) === parseInt(currentData.split("-")[0]) && parseInt(date.split("-")[1]) > parseInt(currentData.split("-")[1])){
+                    }else if(parseInt(date.split("-")[0]) == parseInt(currentData.split("-")[0]) && parseInt(date.split("-")[1]) > parseInt(currentData.split("-")[1])){
                         console.warn("The revision date is invalid (later than current date or wrong number), please check the config.txt file.")
                         throw (e1);
-                    }else if(parseInt(date.split("-")[0]) === parseInt(currentData.split("-")[0]) && parseInt(date.split("-")[1]) === parseInt(currentData.split("-")[1]) && parseInt(date.split("-")[2]) > parseInt(currentData.split("-")[2])){
+                    }else if(parseInt(date.split("-")[0]) == parseInt(currentData.split("-")[0]) && parseInt(date.split("-")[1]) == parseInt(currentData.split("-")[1]) && parseInt(date.split("-")[2]) > parseInt(currentData.split("-")[2])){
                         console.warn("The revision date is invalid (later than current date or wrong number), please check the config.txt file.")
                         throw (e1);
                     }*!/
@@ -317,11 +318,11 @@ function addPath(id, Class){
     var path,
         temp;
     for(var i = 0; i < isInstantiated.length; i++){
-        if(id === isInstantiated[i].id){
+        if(id == isInstantiated[i].id){
             if(isInstantiated[i].tpath){
                 path = isInstantiated[i].tpath;
             }else {
-                if (isInstantiated[i].pnode === pflag) {
+                if (isInstantiated[i].pnode == pflag) {
                     console.warn("Warning:xmi:id=" + pflag + " and xmi:id=" + isInstantiated[i].id + " have been found cross composite!");
                     return path;
                 }
@@ -338,9 +339,9 @@ function addPath(id, Class){
                 Class.instancePathFlag = false;
             }
             for(var j = 0; j < augment.length; j++){
-                if(augment[j].uses === path.split('/')[0].split(":")[1]){
-                    if(Class.instancePathFlag !== false){
-                        Class.instancePathFlag == true; // [sko] shall it be " = " only?
+                if(augment[j].uses == path.split('/')[0].split(":")[1]){
+                    if(Class.instancePathFlag != false){
+                        Class.instancePathFlag == true;
                     }
                     path = path.replace(path.split('/')[0], augment[j].name);
                     break;
@@ -349,11 +350,11 @@ function addPath(id, Class){
             return path;
         }
     }
-    if(i === isInstantiated.length){
+    if(i == isInstantiated.length){
         for(var j = 0; j < augment.length; j++){
-            if(augment[j].usesId === id && Class.fileName === augment[j].fileName){
-                if(Class.instancePathFlag !== false){
-                    Class.instancePathFlag == true; // [sko] shall it be " = " only?
+            if(augment[j].usesId == id && Class.fileName == augment[j].fileName){
+                if(Class.instancePathFlag != false){
+                    Class.instancePathFlag == true;
                 }
                 path = augment[j].name;
                 break;
@@ -370,7 +371,7 @@ function addKey(){
         if (Class[i].generalization.length !== 0) {
             for(var j = 0; j < Class[i].generalization.length; j++){
                 for(var k = 0; k < Class.length; k++){
-                    if(Class[k].id === Class[i].generalization[j]){
+                    if(Class[k].id == Class[i].generalization[j]){
                         if(Class[k].isAbstract && Class[k].key.length !== 0){
                             //Array.prototype.push.apply(Class[i].key, Class[k].key);
                             //Class[i].key = Class[i].key.concat(Class[k].key);
@@ -386,11 +387,11 @@ function addKey(){
         if(Class[i].key.length > 0){
             Class[i].key = Class[i].key.join(" ");
         }
-        //if(flag === 0 && Class[i].config){
+        //if(flag == 0 && Class[i].config){
           //  Class[i].key = "localId";
         //}
        /*for(var j = 0; j < keylist.length; j++){
-           if(keylist[j].id === Class[i].name){
+           if(keylist[j].id == Class[i].name){
                Class[i].key = keylist[j].name;
                break;
            }
@@ -399,18 +400,18 @@ function addKey(){
 }
 
 function buildGeneralization(Class){
-    var gen = {};
+    var gen = new Object();
     for(var i = 0; i < Class.length; i++){
         for(var j = 0; j < Class[i].generalization.length; j++){
             for(var k = 0; k < Class.length; k++){
-                if(Class[i].generalization[j] === Class[k].id){
+                if(Class[i].generalization[j] == Class[k].id){
                     for(var m = 0; m < generalization.length; m++){
-                        if(generalization[m].class1.id === Class[i].id && generalization[m].class2.id === Class[k].id && generalization[m].class1.fileName === Class[i].fileName && generalization[m].class2.fileName === Class[k].fileName){
+                        if(generalization[m].class1.id == Class[i].id && generalization[m].class2.id == Class[k].id && generalization[m].class1.fileName == Class[i].fileName && generalization[m].class2.fileName == Class[k].fileName){
                             break;
                         }
                     }
-                    if(m === generalization.length){
-                        var gen = {};
+                    if(m == generalization.length){
+                        var gen = new Object();
                         gen.class1 = Class[i];
                         gen.class2 = Class[k];
                         generalization.push(gen);
@@ -427,21 +428,21 @@ function inheritKey(general) {
         newnode,
         newkey,
         newkeyid;
-    if(general.class2.key.length !== 0){
-        keyLength = general.class2.key instanceof Array ? general.class2.key.length : 1;
+    if(general.class2.key.length != 0){
+        general.class2.key instanceof Array ? keyLength = general.class2.key.length : keyLength = 1;
         for(var i = 0; i < keyLength; i++){
-            newkey = keyLength === 1 ? general.class2.key : general.class2.key[i];
-            newkeyid = keyLength === 1 ? general.class2.keyid : general.class2.keyid[i];
+            keyLength == 1 ? newkey = general.class2.key : general.class2.key[i];
+            keyLength == 1 ? newkeyid = general.class2.keyid : general.class2.keyid[i];
             if(general.class2.key instanceof Array){
                 newkey = general.class2.key[0];
                 newkeyid = general.class2.keyid[0];
             }
             for(var j = 0; j < general.class1.key.length; j++){
-                if(newkeyid === general.class1.keyid[j]){
+                if(newkeyid == general.class1.keyid[j]){
                     break;
                 }
             }
-            if(j === general.class1.key.length){
+            if(j == general.class1.key.length){
                 general.class1.key.push(newkey);
                 general.class1.keyid.push(newkeyid);
                 inherit(general.class1, newkey, newkeyid);
@@ -453,13 +454,13 @@ function inheritKey(general) {
 
 function inherit(Class, key, keyid){
     for(var i = 0; i < generalization.length; i++){
-        if(generalization[i].class2.id === Class.id && generalization[i].class2.fileName === Class.fileName){
+        if(generalization[i].class2.id == Class.id && generalization[i].class2.fileName == Class.fileName){
             for(var j = 0; j < generalization[i].class1.key.length; j++){
-                if(keyid === generalization[i].class1.keyid[j]){
+                if(keyid == generalization[i].class1.keyid[j]){
                     break;
                 }
             }
-            if(j === generalization[i].class1.key.length){
+            if(j == generalization[i].class1.key.length){
                 generalization[i].class1.key.push(key);
                 generalization[i].class1.keyid.push(keyid);
                 inherit(generalization[i].class1, key, keyid);
@@ -474,20 +475,20 @@ function crossRefer(mod){
     for(var i = 0; i < mod.length; i++){
         for(var j = 0; j < mod[i].import.length; j++){
             for(var k = i + 1; k < mod.length; k++){
-                if(mod[k].name === mod[i].import[j]){
+                if(mod[k].name == mod[i].import[j]){
                     for(var q = 0; q < mod[k].import.length; q++){
-                        if(mod[k].import[q] === mod[i].name){
+                        if(mod[k].import[q] == mod[i].name){
                             console.warn("Warning:module " + mod[i].name + " and module " + mod[k].name + " have been found cross reference!");
                             flag = 1;
                             break;
                         }
                     }
                 }
-                if(flag === 1){
+                if(flag == 1){
                     break;
                 }
             }
-            if(flag === 1){
+            if(flag == 1){
                 break;
             }
         }
@@ -538,7 +539,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];      //newxmi: the array in OpenModel_Profile:OpenModelAttribute
                             var len = xmi[key].array ? xmi[key].array.length : 1;     //OpenModel_Profile:the number of array object in OpenModelAttribute
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 parseOpenModelatt(obj);
                             }
                             break;
@@ -546,7 +547,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 parseOpenModelclass(obj);
                             }
                             break;
@@ -554,7 +555,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 parseOpenModelnotification(obj);
                             }
                             break;
@@ -562,7 +563,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 parseOpenModelatt(obj);
                             }
                             break;
@@ -570,7 +571,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 //createLifecycle(obj, "current");
                                 createLifecycle(obj, "Preliminary");
                             }
@@ -579,7 +580,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 createLifecycle(obj, "current");
                             }
                             break;
@@ -587,7 +588,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 createLifecycle(obj, "obsolete");
                             }
                             break;
@@ -595,7 +596,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 createLifecycle(obj, "deprecated");
                             }
                             break;
@@ -603,7 +604,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 //createLifecycle(obj, "deprecated");
                                 createLifecycle(obj, "Experimental");
                             }
@@ -612,7 +613,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 createLifecycle(obj, "Example");
                             }
                             break;
@@ -620,7 +621,7 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
                                 //createLifecycle(obj, "deprecated");
                                 createLifecycle(obj, "LikelyToChange");
                             }
@@ -629,8 +630,8 @@ function parseModule(filename){                     //XMLREADER read xml files
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
-                                if(obj.attributes().passedByRef === "false"){
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
+                                if(obj.attributes()["passedByRef"] == "false"){
                                     obj.psBR = false;
                                 }else{
                                     obj.psBR = true;
@@ -643,25 +644,35 @@ function parseModule(filename){                     //XMLREADER read xml files
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
                                 obj = len === 1 ? newxmi : newxmi[i];
-                                specTarget.push(obj.attributes().base_StructuralFeature);
+
+                                parseSpec(obj);/*specify.push(obj.attributes().base_Abstraction);
+                                target.push(obj.attributes().target);*/
+                            }
+                            break;
+                       /* case "Target":
+                            newxmi = xmi[key].array ? xmi[key].array : xmi[key];
+                            var len = xmi[key].array ? xmi[key].array.length : 1;
+                            for(var i = 0; i < len; i++){
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
+                                SpecTarget.push(obj.attributes()["base_StructuralFeature"]);
                             }
                             break;
                         case "SpecReference":
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
-                                specReference.push(obj.attributes().base_StructuralFeature);
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
+                                specReference.push(obj.attributes()["base_StructuralFeature"]);
                             }
                             break;
                         case "DefinedBySpec":
                             newxmi = xmi[key].array ? xmi[key].array : xmi[key];
                             var len = xmi[key].array ? xmi[key].array.length : 1;
                             for(var i = 0; i < len; i++){
-                                obj = len === 1 ? newxmi : newxmi[i];
-                                definedBySpec.push(obj.attributes().base_StructuralFeature);
+                                len == 1 ? obj = newxmi : obj = newxmi[i];
+                                definedBySpec.push(obj.attributes()["base_StructuralFeature"]);
                             }
-                            break;
+                            break;*/
                         default :
                             break;
                     }
@@ -682,8 +693,8 @@ function parseModule(filename){                     //XMLREADER read xml files
                             break;
                     }
                 }
-                if(flag === 0){
-                    console.log("Can not find the tag 'uml:Package' or 'uml:Model' of" + filename + "! Please check out the xml file");
+                if(flag == 0){
+                    console.log("Can not find the tag 'uml:Package' or 'uml:Model' of" + filename + "! Please check out the xml file")
                 }
             }
             else{
@@ -714,7 +725,7 @@ function parseUmlModel(xmi){                    //parse umlmodel
     mainmod = mainmod.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9\d]+$/g, "");   //remove the special character in the end
     mainmod = mainmod.replace(/[^\w\.-]+/g, '_');                     //not "A-Za-z0-9"->"_"
     modName.push(mainmod);
-    if (xmi.ownedComment) {
+    if (xmi["ownedComment"]) {
         comment = parseComment(xmi);
         /*if(xmi['ownedComment'].array){
             //comment += xmi['ownedComment'].array[0].body.text();
@@ -732,7 +743,7 @@ function parseUmlModel(xmi){                    //parse umlmodel
     var namespace = "";
     namespace = config.namespace + modName.join("-");
     var prefix;
-    if(config.prefix === "" || config.prefix === null){
+    if(config.prefix == "" || config.prefix == null){
         prefix = modName.join("-");
     }else{
         prefix = config.prefix;
@@ -776,7 +787,7 @@ function parsePackage(xmi){
         xmi.attributes().name?mainmod=xmi.attributes().name:console.error("ERROR:The attribute 'name' of tag 'xmi:id=" + xmi.attributes()["xmi:id"] + "' in " + filename + " is empty!");
         mainmod=mainmod.replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9\d]+$/g, "");   //remove the special character in the end
         mainmod=mainmod.replace(/[^\w\.-]+/g, '_');                     //not "A-Za-z0-9"->"_"
-        if (xmi.ownedComment) {
+        if (xmi["ownedComment"]) {
             comment = parseComment(xmi);
             /*if(xmi['ownedComment'].array){
                 comment += xmi['ownedComment'].array[0].body.text();
@@ -817,10 +828,10 @@ function parsePackage(xmi){
 function parseOpenModelatt(xmi){
     var flag = 0;
     var id;
-    if(xmi.attributes().base_StructuralFeature){
-        id = xmi.attributes().base_StructuralFeature
-    }else if(xmi.attributes().base_Parameter){
-        id = xmi.attributes().base_Parameter
+    if(xmi.attributes()["base_StructuralFeature"]){
+        id = xmi.attributes()["base_StructuralFeature"]
+    }else if(xmi.attributes()["base_Parameter"]){
+        id = xmi.attributes()["base_Parameter"]
     }
     else{
         return;
@@ -842,7 +853,7 @@ function parseOpenModelatt(xmi){
     }
     var vr;
     //if(xmi.attributes()["valueRange"]&&xmi.attributes()["valueRange"]!="NA"&&xmi.attributes()["valueRange"]!="See data type"){
-    if(xmi.attributes()["valueRange"] && xmi.attributes()["valueRange"] !== "null" && xmi.attributes()["valueRange"] !== "NA" && xmi.attributes()["valueRange"] !== "See data type" && xmi.attributes()["valueRange"] !== "See data type."){
+    if(xmi.attributes()["valueRange"] && xmi.attributes()["valueRange"] != "null" && xmi.attributes()["valueRange"] != "NA" && xmi.attributes()["valueRange"] != "See data type" && xmi.attributes()["valueRange"] != "See data type."){
 
         vr = xmi.attributes()["valueRange"];
         flag = 1;
@@ -891,10 +902,10 @@ function parseOpenModelatt(xmi){
 function parseOpenModelclass(xmi){
     var flag = 0;
     var id;
-    if(xmi.attributes().base_Class){
-        id = xmi.attributes().base_Class
-    }else if(xmi.attributes().base_Operation){
-        id = xmi.attributes().base_Operation;
+    if(xmi.attributes()["base_Class"]){
+        id = xmi.attributes()["base_Class"]
+    }else if(xmi.attributes()["base_Operation"]){
+        id = xmi.attributes()["base_Operation"];
     }
     else{
         return;
@@ -916,7 +927,7 @@ function parseOpenModelclass(xmi){
         ato = true;
         flag = 1;
     }
-    if(xmi.attributes()["condition"] && xmi.attributes()["condition"] !== "none"){
+    if(xmi.attributes()["condition"] && xmi.attributes()["condition"] != "none"){
         cond = xmi.attributes()["condition"];
         if(xmi.attributes()["support"]){
             sup = xmi.attributes()["support"];
@@ -959,26 +970,39 @@ function parseOpenModelnotification(xmi){
     openModelnotification.push(id);
 }
 
+function parseSpec(xmi) {
+    var id;
+    if(xmi.attributes()["base_Abstraction"]){
+        id = xmi.attributes()["base_Abstraction"];
+    }
+    var target;
+    if(xmi.attributes()["target"]){
+        target = xmi.attributes()["target"];
+    }
+    var tempspec = new Specify(id,target,currentFileName);
+    specify.push(tempspec);
+}
+
 function createLifecycle(xmi, str){              //创建lifecycle
     var id;
     var nodetype;
-    if(xmi.attributes().base_Parameter){
-        id = xmi.attributes().base_Parameter;
+    if(xmi.attributes()["base_Parameter"]){
+        id = xmi.attributes()["base_Parameter"];
         nodetype = "attribute";
-    }else if(xmi.attributes().base_StructuralFeature){
-        id = xmi.attributes().base_StructuralFeature;
+    }else if(xmi.attributes()["base_StructuralFeature"]){
+        id = xmi.attributes()["base_StructuralFeature"];
         nodetype = "attribute";
-    }else if(xmi.attributes().base_Operation){
-        id = xmi.attributes().base_Operation;
+    }else if(xmi.attributes()["base_Operation"]){
+        id = xmi.attributes()["base_Operation"];
         nodetype = "class";
-    }else if(xmi.attributes().base_Class){
-        id = xmi.attributes().base_Class;
+    }else if(xmi.attributes()["base_Class"]){
+        id = xmi.attributes()["base_Class"];
         nodetype = "class";
-    }else if(xmi.attributes().base_DataType){
-        id = xmi.attributes().base_DataType;
+    }else if(xmi.attributes()["base_DataType"]){
+        id = xmi.attributes()["base_DataType"];
         nodetype = "class";
-    }else if(xmi.attributes().base_Element){
-        id = xmi.attributes().base_Element;
+    }else if(xmi.attributes()["base_Element"]){
+        id = xmi.attributes()["base_Element"];
         nodetype = "attribute";   //attribute or class
     }else{
         return;
@@ -1039,7 +1063,7 @@ function createElement(xmi){
                     var namespace="\"urn:ONF:"+modName.join("-")+"\"";
 
                     var comment = "";
-                    if (xmi.ownedComment) {
+                    if (xmi["ownedComment"]) {
                         if(xmi['ownedComment'].array){
                             //comment="";
                             comment += xmi['ownedComment'].array[0].body.text();
@@ -1085,6 +1109,9 @@ function createElement(xmi){
                         case "uml:Signal":
                             createClass(obj, "notification");
                             break;
+                        case "uml:Abstraction":
+                            createAbstraction(obj);
+                            break;
                         default:
                             break;
                     }
@@ -1115,12 +1142,12 @@ function createClass(obj, nodeType) {
             path = modName.join("-");
         }*/
         path = modName.join("-");
-        if (obj.ownedComment) {
+        if (obj["ownedComment"]) {
             var comment = parseComment(obj);
 
             /*var len;
             var comment = "";
-            obj.ownedComment.array ? len = obj.ownedComment.array.length : len = 1;
+            obj["ownedComment"].array ? len = obj["ownedComment"].array.length : len = 1;
             if(obj['ownedComment'].array){
                 comment = "";
                 comment += obj['ownedComment'].array[0].body.text();
@@ -1147,11 +1174,6 @@ function createClass(obj, nodeType) {
         if (obj.attributes().isAbstract == "true") {
             node.isAbstract = true;
         }
-        if(node.isAbstract == true){
-            if(node.name.indexOf("-g")==-1){
-                node.name+="-g";
-            }
-        }
         if (obj['generalization']) {
             var len;
             obj['generalization'].array ? len = obj['generalization'].array.length : len = 1;
@@ -1176,12 +1198,12 @@ function createClass(obj, nodeType) {
                 var att;
                 len == 1 ? att = obj['ownedAttribute'] : att = obj['ownedAttribute'].array[i];
                 var id = att.attributes()["xmi:id"];
-                var specTargetFlag = false;
-                var specReferenceFlag = false;
-                var definedBySpecFlag = false;
-                for(var j = 0; j < specTarget.length; j++){
-                    if(id == specTarget[j]){
-                        specTargetFlag = true;
+               // var SpecTargetFlag = false;
+               // var specReferenceFlag = false;
+               ///var definedBySpecFlag = false;
+                /*for(var j = 0; j < SpecTarget.length; j++){
+                    if(id == SpecTarget[j]){
+                        SpecTargetFlag = true;
                         Grouping.push(node.id);
                         var name ;
                         if(att.defaultValue) {
@@ -1207,7 +1229,7 @@ function createClass(obj, nodeType) {
                         definedBySpecFlag = true;
                         break;
                     }
-                }
+                }*/
                 //r is the value of "type"
                 var r = node.buildAttribute(att);
                 if (r !== "basicType") {
@@ -1286,14 +1308,14 @@ function createClass(obj, nodeType) {
 //                if (definedBySpecFlag == true) {
 //                    node.attribute[i].isDefinedBySpec = true;
 //                }
-                if(specTargetFlag == true) { // && node.name !== "ExtensionsSpec"){
+               /* if(SpecTargetFlag == true) { // && node.name != "ExtensionsSpec"){
                     node.attribute[i].isSpecTarget = true;
                     node.isSpec = true;
                 }
-                if(specReferenceFlag == true) { // && node.name !== "ExtensionsSpec"){
+                if(specReferenceFlag == true) { // && node.name != "ExtensionsSpec"){
                     node.attribute[i].isSpecReference = true;
                     node.isSpec = true;
-                }
+                }*/
                 //search the "keyId",if r is the value of "keyId",add this node to keyList
                 /*for (var j = 0; j <keyId.length; j++) {
                     if (r == keylist[j].id) {
@@ -1318,7 +1340,6 @@ function createClass(obj, nodeType) {
                 node.nodeType = "typedef";
             }else{
                 node.nodeType="grouping";
-
             }
         }
         if (nodeType == "typedef") {
@@ -1402,8 +1423,10 @@ function createClass(obj, nodeType) {
         //if(node.key == undefined){
         //    node.key = "localId";
         //}
-            //node.Gname = node.name;//removed the "G_" prefix
-
+        /*if(node.nodeType == "grouping"){
+            //node.name = "G_" + node.name;
+            node.Gname = node.name;//removed the "G_" prefix
+        }*/
         Class.push(node);
         return;
     }
@@ -1443,6 +1466,48 @@ function createAssociation(obj) {
     }
 }
 
+function createAbstraction(obj){
+    var id = obj.attributes()["xmi:id"];
+    var client="",
+        supplier="",
+        clientid,
+        comment="",
+        temp,
+        supplierid,
+        supplierfilename;
+    if(obj.attributes()["client"]){
+        clientid = obj.attributes()["client"];
+    }else{
+        console.log("Warning: The client of " + id + " does not exist!");
+    }
+    if (obj.ownedComment) {
+        comment = parseComment(obj);
+    }
+   /* if (obj.supplier) {
+        supplierid=obj.supplier.attributes().href.split('#')[1];
+        supplierfilename=obj.supplier.attributes().href.split('.')[0];
+    }*/
+      for(var i=0;i<specify.length;i++){
+            if(specify[i].id==id){
+                var tar=specify[i].target;
+            }
+        }
+        var temptar=tar.substring(1);
+        var temparr=temptar.split("/");
+        for(var j=0;j<temparr.length;j++){
+            var temp=temparr[j].split(":");
+            var tempsup="/"+temp[0]+":"+temp[2];
+            supplier+=tempsup;
+        }
+
+       /* var num=tar.indexOf(":");
+        supplier=tar.substring(num+1);*/
+       //supplier=tar.split(':')[1].toLocaleLowerCase()+tar.split(':')[2].toLocaleLowerCase();
+
+    temp=new Abstraction(id,clientid,supplier,comment,currentFileName);
+    abstraction.push(temp);
+}
+
 function parseComment(xmi){
     var comment = "";
     if(xmi['ownedComment'].array){
@@ -1458,6 +1523,38 @@ function parseComment(xmi){
         console.log("The comment of xmi:id=\"" + xmi.attributes()["xmi:id"] + "\" is undefined!");
     }
     return comment;
+}
+
+function classspec(abstraction){
+    var client=[],clientid,clientname;
+    var    supplier,supplierfilename,comment;
+    for(var i = 0; i < abstraction.length; i++) {
+        for (var j = 0; j < Class.length; j++) {
+            if (abstraction[i].clientid == Class[j].id && abstraction[i].fileName == Class[j].fileName) {
+                //client.push(Class[j]);
+                clientid = abstraction[i].id;
+                clientname = Class[j].name;
+            }
+            //supplierfilename = abstraction[i].supplierfilename;
+            supplier = abstraction[i].supplier;
+            currentFileName = abstraction[i].fileName;
+            comment = abstraction[i].comment;
+        }
+
+        var newaug = new Augment(clientid, clientname, supplier, comment, currentFileName);
+        augment.push(newaug);
+        comment="";
+    }
+    /*var sameclient=[];
+     for(var k=0;k<supplier.length;k++){
+     for(var m=k+1;m<supplier.length;m++){
+     if(supplier[k].id==supplier[m].id){
+     sameclient.push(client[k]);
+     sameclient.push(client[m]);
+     }
+
+     }
+     }*/
 }
 
 function obj2yang(ele){
@@ -1503,7 +1600,7 @@ function obj2yang(ele){
             obj = new RPC(ele[i].name, ele[i].description, ele[i].support, ele[i].status, ele[i].fileName);
         }
         else if(ele[i].nodeType == "notification"){
-            obj = new Node(ele[i].name+'-g', ele[i].description, "grouping", undefined, undefined, ele[i].id, undefined, undefined, ele[i].support, ele[i].status, ele[i].fileName);
+            obj = new Node(ele[i].name, ele[i].description, "grouping", undefined, undefined, ele[i].id, undefined, undefined, ele[i].support, ele[i].status, ele[i].fileName);
         }else{
             obj = new Node(ele[i].name, ele[i].description, "grouping", ele[i]["max-elements"], ele[i]["max-elements"], ele[i].id, ele[i].config, ele[i].isOrdered, ele[i].support, ele[i].status, ele[i].fileName);
             obj.isAbstract = ele[i].isAbstract;
@@ -1551,10 +1648,6 @@ function obj2yang(ele){
         if(ele[i].generalization.length !== 0) {
             for(var j = 0; j < ele[i].generalization.length; j++){
                 for(var k = 0; k < Class.length; k++){
-                   /* var tempname=Class[k].name;
-                    if(Class[k].nodeType=="grouping"){
-                        Class[k].name+="-g";
-                    }*/
                     if(Class[k].id == ele[i].generalization[j]){
                         /*var Gname;
                         Class[k].Gname !== undefined ? Gname = Class[k].Gname : Gname = Class[k].name;*/
@@ -1576,7 +1669,6 @@ function obj2yang(ele){
                         }
                         break;
                     }
-                    //Class[k].name=tempname;
                 }
             }
         }
@@ -1612,7 +1704,7 @@ function obj2yang(ele){
                     if(openModelAtt[k].id == ele[i].attribute[j].id){
                         units = openModelAtt[k].units;
                         vr = openModelAtt[k].valueRange;
-                        if(openModelAtt[k].condition !== undefined){
+                        if(openModelAtt[k].condition != undefined){
                             for(var m = 0; m < feat.length; m++){
                                 if(feat[m].name == openModelAtt[k].condition && feat[m].fileName == openModelAtt[k].fileName){
                                     break;
@@ -1674,20 +1766,20 @@ function obj2yang(ele){
                             }
                             else {
                                 if(ele[i].attribute[j].isleafRef){
-                                    if(Class[k].instancePath[0] === "/"){
+                                    if(Class[k].instancePath[0] == "/"){
                                         ele[i].attribute[j].type = "leafref+path '" + Class[k].instancePath + "'";
                                     }else{
                                         ele[i].attribute[j].type = "leafref+path '/" + Class[k].instancePath + "'";
                                     }
                                     //add element "import" to module
                                     /*for (var t = 0; t < yangModule.length; t++) {
-                                        if (ele[i].fileName === yangModule[t].fileName) {
+                                        if (ele[i].fileName == yangModule[t].fileName) {
                                             for (var f = 0; f < yangModule[t].import.length; f++) {
-                                                if (yangModule[t].import[f] === Class[k].fileName.split('.')[0]) {
+                                                if (yangModule[t].import[f] == Class[k].fileName.split('.')[0]) {
                                                     break;
                                                 }
                                             }
-                                            if (f === yangModule[t].import.length) {
+                                            if (f == yangModule[t].import.length) {
                                                 yangModule[t].import.push(Class[k].fileName.split('.')[0]);
                                                 break;
                                             }
@@ -1697,10 +1789,10 @@ function obj2yang(ele){
                                     /*if(Class[k].isAbstract){
                                         ele[i].attribute[j].type="string";
                                     }*/
-                                    if(ele[i].attribute[j].nodeType === "list"){
+                                    if(ele[i].attribute[j].nodeType == "list"){
                                         ele[i].attribute[j].nodeType = "leaf-list";
                                     }
-                                    else if(ele[i].attribute[j].nodeType === "container"){
+                                    else if(ele[i].attribute[j].nodeType == "container"){
                                         ele[i].attribute[j].nodeType = "leaf";
                                     }
                                     break;
@@ -1708,7 +1800,7 @@ function obj2yang(ele){
                                 else{
                                     var Gname;
                                     Class[k].Gname !== undefined ? Gname = Class[k].Gname : Gname = Class[k].name;
-                                    if (ele[i].fileName === Class[k].fileName) {
+                                    if (ele[i].fileName == Class[k].fileName) {
                                         if(Class[k].support){
                                             ele[i].attribute[j].isUses = new Uses(Gname, Class[k].support)
                                         }else{
@@ -1731,21 +1823,21 @@ function obj2yang(ele){
                         }
                     }
                     //didn't find the "class"
-                    if(k === Class.length){
-                        ele[i].attribute[j].nodeType === "list" ? ele[i].attribute[j].nodeType = "leaf-list" : ele[i].attribute[j].nodeType = "leaf";
+                    if(k == Class.length){
+                        ele[i].attribute[j].nodeType == "list" ? ele[i].attribute[j].nodeType = "leaf-list" : ele[i].attribute[j].nodeType = "leaf";
                         ele[i].attribute[j].type = "string";
                     }
                 }
-                if(ele[i].attribute[j].type.split("+")[0] === "leafref"){
+                if(ele[i].attribute[j].type.split("+")[0] == "leafref"){
                     ele[i].attribute[j].type = new Type("leafref", ele[i].attribute[j].id, ele[i].attribute[j].type.split("+")[1], vr, "", "", units, ele[i].fileName);
-                }else if(ele[i].attribute[j].nodeType === "leaf" || ele[i].attribute[j].nodeType === "leaf-list"){
+                }else if(ele[i].attribute[j].nodeType == "leaf" || ele[i].attribute[j].nodeType == "leaf-list"){
                     ele[i].attribute[j].type = new Type(ele[i].attribute[j].type, ele[i].attribute[j].id, undefined, vr, "", "", units, ele[i].fileName);
                 }/*else{
                  ele[i].attribute[j].type = new Type(ele[i].attribute[j].type, ele[i].attribute[j].id, undefined, vr, "", "", units, ele[i].fileName);
                 }*/
-                if(ele[i].attribute[j].type.range !== undefined){
+                if(ele[i].attribute[j].type.range != undefined){
                     var regex  = /[^0-9/./*]/;
-                    if(regex.test(ele[i].attribute[j].type.range) === true){
+                    if(regex.test(ele[i].attribute[j].type.range) == true){
                         if(ele[i].attribute[j].type.range.indexOf('*') !== -1){
                             ele[i].attribute[j].type.range = this.range.replace('*', "max");
                         }
@@ -1758,20 +1850,16 @@ function obj2yang(ele){
                         }
                     }
                 }
-                if(ele[i].attribute[j].isSpecTarget === false && ele[i].attribute[j].isSpecReference === false
+                /*if(ele[i].attribute[j].isSpecTarget === false && ele[i].attribute[j].isSpecReference === false
                   && ele[i].attribute[j].isDefinedBySpec === false){
                     obj.buildChild(ele[i].attribute[j], ele[i].attribute[j].nodeType);//create the subnode to obj
-                }/*else{
+                }*//*else{
                     obj.children.push("");
                 }*/
-                if(obj.nodeType=="grouping"){
-                if(obj.name.indexOf("-g")==-1){
-                    obj.name+="-g";
-                }
-            }}
+            }
         }
         //create the object of "typedef"
-        if(ele[i].nodeType === "typedef"){
+        if(ele[i].nodeType == "typedef"){
             obj.nodeType = "typedef";
             if(ele[i].attribute[0]){
                 obj.buildChild(ele[i].attribute[0], "typedef");
@@ -1780,18 +1868,18 @@ function obj2yang(ele){
             }
         }
         //create "rpc"
-        if(ele[i].nodeType === "rpc"){
+        if(ele[i].nodeType == "rpc"){
             for (var j = 0; j < ele[i].attribute.length; j++) {
                 var pValue = ele[i].attribute[j];
                 for(var k = 0; k < Typedef.length; k++){
-                    if(Typedef[k].id === pValue.type){
-                        if(pValue.nodeType === "list"){
+                    if(Typedef[k].id == pValue.type){
+                        if(pValue.nodeType == "list"){
                             pValue.nodeType = "leaf-list";
                         }else{
                             pValue.nodeType = "leaf";
                         }
                         pValue.isUses = false;
-                        if(Typedef[k].fileName === ele[i].fileName){
+                        if(Typedef[k].fileName == ele[i].fileName){
                             pValue.type = Typedef[k].name;
                         }else{
                             pValue.type = Typedef[k].fileName.split('.')[0] + ":" + Typedef[k].name;
@@ -1801,18 +1889,18 @@ function obj2yang(ele){
                     }
                 }
                 for(var k = 0; k < openModelAtt.length; k++){
-                    if(openModelAtt[k].id === ele[i].attribute[j].id){
+                    if(openModelAtt[k].id == ele[i].attribute[j].id){
                         //units = openModelAtt[k].units;
                         //vr = openModelAtt[k].valueRange;
                         pValue.units = openModelAtt[k].units;
                         pValue.valueRange = openModelAtt[k].valueRange;
                         if(openModelAtt[k].condition){
                             for(var m = 0; m < feat.length; m++){
-                                if(feat[m].name === openModelAtt[k].condition && feat[m].fileName === openModelAtt[k].fileName){
+                                if(feat[m].name == openModelAtt[k].condition && feat[m].fileName == openModelAtt[k].fileName){
                                     break;
                                 }
                             }
-                            if(m === feat.length){
+                            if(m == feat.length){
                                 feat.push(createFeature(openModelAtt[k], ele[i].path));
                                 ele[i].attribute[j].support = feat[feat.length - 1].name;
                             }else{
@@ -1831,25 +1919,25 @@ function obj2yang(ele){
                 if(pValue.isUses){
                     var name = pValue.type;
                     for(var k = 0; k < Class.length; k++){
-                        if(Class[k].id === name){
+                        if(Class[k].id == name){
                             pValue.isAbstract = Class[k].isAbstract;
                             if(Class[k].type !== "Class"){
                                 pValue.isGrouping = true;
                             }
-                            /*if(pValue.nodeType === "list"){
+                            /*if(pValue.nodeType == "list"){
                                 pValue.key = Class[k].key;
                                 pValue.keyid = Class[k].keyid;
                             }*/
                             //recursion
-                            if(i === k){
+                            if(i == k){
                                 pValue.type = "leafref+path '/" + Class[k].instancePath.split(":")[1] + "'";
                                 if(Class[k].isGrouping){
                                     pValue.type = "string";
                                 }
-                                if(pValue.nodeType === "list"){
+                                if(pValue.nodeType == "list"){
                                     pValue.nodeType = "leaf-list";
                                 }
-                                else if(pValue.nodeType === "container"){
+                                else if(pValue.nodeType == "container"){
                                     pValue.nodeType = "leaf";
                                 }
                                 break;
@@ -1857,7 +1945,7 @@ function obj2yang(ele){
                             /*else {
                                  if(pValue.isleafRef){
                                     var p = Class[k].instancePath.split(":")[0];
-                                    if(ele[i].path === p){
+                                    if(ele[i].path == p){
                                         pValue.type = "leafref+path '/" + Class[k].instancePath.split(":")[1] + "'";
                                     }else{
                                         pValue.type = "leafref+path '/" + Class[k].instancePath + "'";
@@ -1868,10 +1956,10 @@ function obj2yang(ele){
                                         pValue.type = "string";
                                      }
                                      //
-                                    if(pValue.nodeType === "list"){
+                                    if(pValue.nodeType == "list"){
                                         pValue.nodeType = "leaf-list";
                                     }
-                                    else if(pValue.nodeType === "container"){
+                                    else if(pValue.nodeType == "container"){
                                         pValue.nodeType = "leaf";
                                     }
                                     break;
@@ -1879,7 +1967,7 @@ function obj2yang(ele){
                             else {
                                 var Gname;
                                 Class[k].Gname !== undefined ? Gname = Class[k].Gname : Gname = Class[k].name;
-                                if (ele[i].fileName === Class[k].fileName) {
+                                if (ele[i].fileName == Class[k].fileName) {
                                     if (Class[k].support) {
                                         pValue.isUses = new Uses(Gname, Class[k].support)
                                     } else {
@@ -1908,8 +1996,8 @@ function obj2yang(ele){
                         }
                         //}
                     }
-                    if(k === Class.length){
-                        pValue.nodeType === "list" ? ele[i].attribute[j].nodeType = "leaf-list" : pValue.nodeType = "leaf";
+                    if(k == Class.length){
+                        pValue.nodeType == "list" ? ele[i].attribute[j].nodeType = "leaf-list" : pValue.nodeType = "leaf";
                         pValue.type = "string";
                     }
                 }
@@ -1917,9 +2005,9 @@ function obj2yang(ele){
             }
         }
         //decide whether a "container" is "list"
-        if(obj.nodeType === "container") {
+        if(obj.nodeType == "container") {
             for (var k = 0; k < association.length; k++) {
-                if (ele[i].id === association[k].name) {
+                if (ele[i].id == association[k].name) {
                     obj.nodeType = "list";
                     if(association[k].upperValue){
                         obj["max-elements"] = association[k].upperValue;
@@ -1931,10 +2019,10 @@ function obj2yang(ele){
                     break;
                 }
             }
-            /*if(ele[i].key.length !== 0){
+            /*if(ele[i].key.length != 0){
                 obj.nodeType = "list";
             }*/
-            if(k === association.length){
+            if(k == association.length){
                 obj["ordered-by"] = undefined;
             }
             //obj.nodeType = "list";//
@@ -1942,28 +2030,27 @@ function obj2yang(ele){
         //add the "obj" to module by attribute "path"
         var newobj;
         var flag = true;
-        if(ele[i].nodeType === "notification"){
+        if(ele[i].nodeType == "notification"){
             //var a;
             newobj = new Node(ele[i].name, undefined, "notification", undefined, undefined, obj.id, obj.config, obj["ordered-by"], undefined, undefined, ele[i].fileName);
             //newobj.uses.push(obj.name);
             newobj.uses.push(obj.name);
             
-        } else if(ele[i].name === "Context") {
-        //else if(ele[i].isAbstract === false && ele[i].nodeType === "grouping"){
+        } else if(ele[i].name == "Context") {
+        //else if(ele[i].isAbstract == false && ele[i].nodeType == "grouping"){
             flag=false;
             newobj = new Node(ele[i].name, undefined, "container", undefined, undefined, obj.id, obj.config, obj["ordered-by"], undefined, undefined, ele[i].fileName);
             newobj.key = obj.key;
             newobj.keyid = obj.keyid;
             //newobj.uses.push(obj.name);
             newobj.uses.push(obj.name);
-            if(obj.nodeType !== "grouping"){
+            if(obj.nodeType != "grouping"){
                 newobj.nodeType = obj.nodeType;
                 obj.nodeType = "grouping";
-
             }
             //decide whether a "container" is "list"
             for (var k = 0; k < association.length; k++) {
-                if (ele[i].id === association[k].name) {
+                if (ele[i].id == association[k].name) {
                     newobj.nodeType = "list";
                     if(association[k].upperValue){
                         newobj["max-elements"] = association[k].upperValue;
@@ -1978,22 +2065,16 @@ function obj2yang(ele){
             if(newobj.nodeType !== "list"){
                 newobj["ordered-by"] = undefined;
             }
-
             console.info ("******* Top-Level Object: " + newobj.name + " Type:" + newobj.nodeType)
         }
         if(flag && !ele[i].isGrouping){
             obj.name = ele[i].name;
         }
-        if(obj.nodeType=="grouping"){
-            if(obj.name.indexOf("-g")==-1){
-                obj.name+="-g";
-            }
-        }
-        if(ele[i].path === ""){
+        if(ele[i].path == ""){
             for(var t = 0; t < yangModule.length; t++){
-                if(ele[i].fileName === yangModule[t].fileName){
-                	if (ele[i].name === "Context" || ele[i].nodeType === "notification") {
-                    //if ((ele[i].isAbstract === false && ele[i].nodeType === "grouping") || ele[i].nodeType === "notification") {
+                if(ele[i].fileName == yangModule[t].fileName){
+                	if (ele[i].name == "Context" || ele[i].nodeType == "notification") {
+                    //if ((ele[i].isAbstract == false && ele[i].nodeType == "grouping") || ele[i].nodeType == "notification") {
                         yangModule[t].children.push(newobj);
                     }
                     /*if (feat.length) {
@@ -2006,15 +2087,15 @@ function obj2yang(ele){
         }
 
         for(var t = 0; t < packages.length; t++) {
-            if (packages[t].path === "") {
+            if (packages[t].path == "") {
                 tempPath = packages[t].name;
             } else {
                 tempPath = packages[t].path + "-" + packages[t].name
             }
-            if (tempPath === ele[i].path && packages[t].fileName === ele[i].fileName) {
+            if (tempPath == ele[i].path && packages[t].fileName == ele[i].fileName) {
                 //create a new node if "ele" needs to be instantiate
-            	if (ele[i].name === "Context" || ele[i].nodeType === "notification") {
-                //if ((ele[i].isAbstract === false && ele[i].nodeType === "grouping") || ele[i].nodeType === "notification") {
+            	if (ele[i].name == "Context" || ele[i].nodeType == "notification") {
+                //if ((ele[i].isAbstract == false && ele[i].nodeType == "grouping") || ele[i].nodeType == "notification") {
                     packages[t].children.push(newobj)
                 }
                 /*if (feat.length) {
@@ -2022,27 +2103,32 @@ function obj2yang(ele){
                     packages[t].children = packages[t].children.concat(feat);
                 }*/
                 packages[t].children.push(obj);
+                /*for(var j = 0; j < augment.length; j++){
+                    if(augment[j].fileName === ele[i].fileName&& augment[j].id === ele[i].id){
+                        packages[t].children = packages[t].children.concat(augment[j]);
+                    }
+                }*/
                 break;
             }
         }
     }
     if(feat.length){
         for(var i = 0; i < feat.length; i++){
-            if(feat[i].path === ""){
+            if(feat[i].path == ""){
                 for(var j = 0; j < yangModule.length; j++){
-                    if(feat[i].fileName === yangModule[j].fileName){
+                    if(feat[i].fileName == yangModule[j].fileName){
                         yangModule[j].children.push(feat[i]);
                         break;
                     }
                 }
             }else{
                 for(var j = 0; j < packages.length; j++) {
-                    if (packages[j].path === "") {
+                    if (packages[j].path == "") {
                         tempPath = packages[j].name;
                     }else {
                         tempPath = packages[j].path + "-" + packages[j].name;
                     }
-                    if (tempPath === feat[i].path && packages[j].fileName === feat[i].fileName) {
+                    if (tempPath == feat[i].path && packages[j].fileName == feat[i].fileName) {
                         packages[j].children.push(feat[i]);
                         break;
                     }
@@ -2058,15 +2144,15 @@ function createFeature(obj, path){
     var feat = new Feature(obj.id, obj.condition, path, "",obj.fileName);
     return feat;
 }
-
+//判断datatype
 function datatypeExe(id){
     for(var i = 0; i < Class.length; i++){
         if(Class[i].id = id){
-            if(Class[i].attribute.length === 1 && Class[i].generalization.length === 0){
-                if(Class[i].nodeType === "enumeration"){
+            if(Class[i].attribute.length == 1 && Class[i].generalization.length == 0){
+                if(Class[i].nodeType == "enumeration"){
                     return "enumeration," + i;
                 }
-                if(Class[i].attribute[0].isUses === false){
+                if(Class[i].attribute[0].isUses == false){
                     return "typedef," + Class[i].attribute[0].type;
                 }else{
                     datatypeExe(Class[i].attribute[0].type);
@@ -2080,13 +2166,13 @@ function datatypeExe(id){
 
 /*function importMod(ele,obj){
     for (var t = 0; t < yangModule.length; t++) {
-        if (ele.path === yangModule[t].name) {
+        if (ele.path == yangModule[t].name) {
             for (var f = 0; f < yangModule[t].import.length; f++) {
-                if (yangModule[t].import[f] === obj.path) {
+                if (yangModule[t].import[f] == obj.path) {
                     break;
                 }
             }
-            if (f === yangModule[t].import.length) {
+            if (f == yangModule[t].import.length) {
                 yangModule[t].import.push(obj.path);
                 break;
             }

--- a/UmlYangTools/xmi2yang/model/ObjectClass.js
+++ b/UmlYangTools/xmi2yang/model/ObjectClass.js
@@ -20,51 +20,53 @@ function Class(name, id, type, comment, nodeType, path, config, isOrdered, fileN
     this.path = path;
     this.nodeType = nodeType;
     this.description = comment;
-    this.Gname = undefined;
-    this.support = undefined;
-    this.status = undefined;
+    this.Gname;
+    this.support;
+    this.status;
     this.generalization = [];
     this.instancePath = "";
-    this.instancePathFlag = undefined;
+    this.instancePathFlag;
     this.isGrouping = false;
     this.isAbstract = false;//"class" is abstract
     this.isSpec = false;
     this.config = config;
     this.isOrdered = isOrdered;
     this.fileName = fileName;
-    this.association = undefined;
+    this.association;
     this.attribute = [];
     this.key = [];
     this.keyid = [];
     
 }
 Class.prototype.isEnum = function(){
-    return this.type === "Enumeration";
+    var result;
+    this.type == "Enumeration" ? result = true : result = false;
+    return result;
 };
 Class.prototype.buildEnum = function(obj) {
     var node = new Type("enumeration");
     node.fileName = this.fileName;
-    var literal = obj.ownedLiteral;
+    var literal = obj["ownedLiteral"];
     var enumComment;
     var enumValue;
     var enumNode;
-    if(literal === undefined){
+    if(literal == undefined){
         return;
     }
-    if (literal.array !== undefined) {
+    if (literal.array != undefined) {
         // More than one enumerated value
         for (var i = 0; i < literal.array.length; i++) {
             enumValue = literal.array[i].attributes().name;
             //enumValue = "enum " + literal.array[i].attributes().name;
             enumComment = "";
-            if(literal.array[i].ownedComment){
-                if (literal.array[i].ownedComment.array) {
-                    enumComment = literal.array[i].ownedComment.array[0].body.text();
-                    for (var j = 1; j < literal.array[i].ownedComment.array.length; j++) {
-                        enumComment += "\r\n" + literal.array[i].ownedComment.array[j].body.text();
+            if(literal.array[i]["ownedComment"]){
+                if (literal.array[i]["ownedComment"].array) {
+                    enumComment = literal.array[i]["ownedComment"].array[0].body.text();
+                    for (var j = 1; j < literal.array[i]["ownedComment"].array.length; j++) {
+                        enumComment += "\r\n" + literal.array[i]["ownedComment"].array[j].body.text();
                     }
                 } else {
-                    enumComment = literal.array[i].ownedComment.body.text();
+                    enumComment = literal.array[i]["ownedComment"].body.text();
                 }
             }
             enumValue = enumValue.replace(/[^\w\.-]+/g, '_');
@@ -77,17 +79,17 @@ Class.prototype.buildEnum = function(obj) {
         //node.children.push("enum " + literal.attributes().name);
         enumValue = literal.attributes().name;
         //enumValue = "enum " + literal.array[i].attributes().name;
-        if(literal.ownedComment){
+        if(literal["ownedComment"]){
             enumComment = "";
-            if (literal.ownedComment.array) {
-                for (var j = 0; j < literal.ownedComment.array.length; j++) {
-                    if(literal.ownedComment.array[j].hasOwnProperty("body") && literal.ownedComment.array[j].body.hasOwnProperty("text")){
-                        enumComment += literal.ownedComment.array[j].body.text() + "\r\n";
+            if (literal["ownedComment"].array) {
+                for (var j = 0; j < literal["ownedComment"].array.length; j++) {
+                    if(literal["ownedComment"].array[j].hasOwnProperty("body") && literal["ownedComment"].array[j].body.hasOwnProperty("text")){
+                        enumComment += literal["ownedComment"].array[j].body.text() + "\r\n";
                     }
                 }
                 enumComment = enumComment.replace(/\r\n$/g, "");
-            } else if(literal.ownedComment.hasOwnProperty("body") && literal.ownedComment.body.hasOwnProperty("text")){
-                enumComment = literal.ownedComment.body.text();
+            } else if(literal["ownedComment"].hasOwnProperty("body") && literal["ownedComment"].body.hasOwnProperty("text")){
+                enumComment = literal["ownedComment"].body.text();
             }else{
                 console.log("The comment of xmi:id=\"" + literal.attributes()["xmi:id"] + "\" is undefined!");
             }
@@ -108,47 +110,45 @@ Class.prototype.buildEnum = function(obj) {
         }
         console.log("d");
     }*/
-};
-
+}
 Class.prototype.buildAttribute = function(att){
     var id = att.attributes()['xmi:id'];
     var name;
-    if (att.attributes().name) {
-      name = att.attributes().name;
-    } else {
-      console.log("ERROR:The attribute 'name' of tag 'xmi:id=" + att.attributes()["xmi:id"] + "' in this file is empty!");
-    }
+    att.attributes().name ? name = att.attributes().name : console.log("ERROR:The attribute 'name' of tag 'xmi:id=" + att.attributes()["xmi:id"] + "' in this file is empty!");
     if(name){
         name=name.replace(/^[^A-Za-z|_]+|[^A-Za-z|_\d]+$/g, "");
         name=name.replace(/[^\w\.-]+/g, '_');
     }
     var comment = "";
-    if(att.ownedComment){
-        if(att.ownedComment.array){
-            for(var i = 0; i < att.ownedComment.array.length; i++){
-                if(att.ownedComment.array[i].hasOwnProperty("body") && att.ownedComment.array[i].body.hasOwnProperty("text")){
-                    comment += att.ownedComment.array[i].body.text() + "\r\n";
+    if(att['ownedComment']){
+        if(att['ownedComment'].array){
+            for(var i = 0; i < att['ownedComment'].array.length; i++){
+                if(att['ownedComment'].array[i].hasOwnProperty("body") && att['ownedComment'].array[i].body.hasOwnProperty("text")){
+                    comment += att['ownedComment'].array[i].body.text() + "\r\n";
                 }
             }
             comment = comment.replace(/\r\n$/g, "");
-        }else if(att.ownedComment.hasOwnProperty("body") && att.ownedComment.body.hasOwnProperty("text")){
-            comment = att.ownedComment.body.text();
+        }else if(att['ownedComment'].hasOwnProperty("body") && att['ownedComment'].body.hasOwnProperty("text")){
+            comment = att['ownedComment'].body.text();
         }else{
             console.log("The comment of xmi:id=\"" + att.attributes()["xmi:id"] + "\" is undefined!");
 
         }
     }
-    var association = att.attributes().association ? att.attributes().association : null;
-    var isReadOnly = att.attributes().isReadOnly ? att.attributes().isReadOnly : false;
-    var isOrdered = att.attributes().isOrdered ? att.attributes().isOrdered : false;
+    var association;
+    att.attributes().association ? association = att.attributes().association : association = null;
+    var isReadOnly;
+    att.attributes().isReadOnly ? isReadOnly = att.attributes().isReadOnly : isReadOnly = false;
+    var isOrdered;
+    att.attributes().isOrdered ? isOrdered = att.attributes().isOrdered : isOrdered = false;
     var type;
     var isLeaf;
     if(att.attributes().type){
         type = att.attributes().type;
         isLeaf = false;
     }
-    else if(att.type){
-        type = att.type.attributes();
+    else if(att['type']){
+        type = att['type'].attributes();
         if (type['xmi:type'] == 'uml:PrimitiveType') {
             type = type.href.split('#')[1].toLocaleLowerCase() ;
             isLeaf = true;
@@ -197,8 +197,8 @@ Class.prototype.buildOperate = function(para){
     if(para.attributes().type){
         type = para.attributes().type;
         isLeaf = false;
-    }else if(para.type){
-        type = para.type.attributes();
+    }else if(para['type']){
+        type = para['type'].attributes();
         isLeaf = true;
         if (type['xmi:type'] == 'uml:PrimitiveType') {
             type = type.href.split('#')[1].toLocaleLowerCase() ;
@@ -211,24 +211,27 @@ Class.prototype.buildOperate = function(para){
         isLeaf = true;
     }
     var comment = "";
-    //para.ownedComment ? comment = att.ownedComment.body.text() : comment = null;
-    if(para.ownedComment){
-        if(para.ownedComment.array){
-            for(var i = 0; i < para.ownedComment.array.length; i++){
-                if(para.ownedComment.array[i].hasOwnProperty("body") && para.ownedComment.array[i].body.hasOwnProperty("text")){
-                    comment += para.ownedComment.array[i].body.text() + "\r\n";
+    //para['ownedComment'] ? comment = att['ownedComment'].body.text() : comment = null;
+    if(para["ownedComment"]){
+        if(para['ownedComment'].array){
+            for(var i = 0; i < para['ownedComment'].array.length; i++){
+                if(para['ownedComment'].array[i].hasOwnProperty("body") && para['ownedComment'].array[i].body.hasOwnProperty("text")){
+                    comment += para['ownedComment'].array[i].body.text() + "\r\n";
                 }
             }
             comment = comment.replace(/\r\n$/g, "");
-        }else if(para.ownedComment.hasOwnProperty("body") && para.ownedComment.body.hasOwnProperty("text")){
-            comment = para.ownedComment.body.text();
+        }else if(para['ownedComment'].hasOwnProperty("body") && para['ownedComment'].body.hasOwnProperty("text")){
+            comment = para['ownedComment'].body.text();
         }else{
             console.log("The comment of xmi:id=\"" + para.attributes()["xmi:id"] + "\" is undefined!");
         }
     }
-    var association = para.attributes().association ? para.attributes().association : null;
-    var isReadOnly = para.attributes().isReadOnly ? para.attributes().isReadOnly : false;
-    var isOrdered = para.attributes().isOrdered ? para.attributes().isOrdered : false;
+    var association;
+    para.attributes().association ? association = para.attributes().association : association=null;
+    var isReadOnly;
+    para.attributes().isReadOnly ? isReadOnly = para.attributes().isReadOnly : isReadOnly = false;
+    var isOrdered;
+    para.attributes().isOrdered ? isOrdered =para.attributes().isOrdered : isOrdered = false;
     var parameter = new Attribute(id, name, type, comment, association, isReadOnly, isOrdered, this.fileName);
     parameter.giveValue(para);
     parameter.giveNodeType(isLeaf);

--- a/UmlYangTools/xmi2yang/model/OpenModelObject.js
+++ b/UmlYangTools/xmi2yang/model/OpenModelObject.js
@@ -15,7 +15,7 @@ function OpenModelObject(id, type, vr, cond, sup, inv, avcNot, dNot, cNot, passB
     this.type = type;
     this.valueRange = vr;
     this.condition = cond;
-    this.status = undefined;
+    this.status;
     this.support = sup;
     this.isInvariant = inv;
     this.key = key;
@@ -24,8 +24,8 @@ function OpenModelObject(id, type, vr, cond, sup, inv, avcNot, dNot, cNot, passB
     this.objectCreationNotification = cNot;
     this.passedByReference = passBR;
     this["operation exceptions"] = opex;
-    this.isOperationIdempotent = opid;
-    this.isAtomic = ato;
+    this["isOperationIdempotent"] = opid;
+    this["isAtomic"] = ato;
     this.units = units;
     this.fileName = fileName;
 }

--- a/UmlYangTools/xmi2yang/model/OwnedAttribute.js
+++ b/UmlYangTools/xmi2yang/model/OwnedAttribute.js
@@ -18,31 +18,31 @@ function ownedAttribute(id, name, type, comment, assoc, isReadOnly, isOrdered, f
     this.description = comment;
     this.association = assoc;
     this.config = !isReadOnly;
-    this.nodeType = undefined;
-    this.defaultValue = undefined;
+    this.nodeType;
+    this.defaultValue;
     this.isUses = false;
-    this.status = undefined;
+    this.status;
     this.isAbstract = false;
-    this.rpcType = undefined;
-    this.key = undefined;
-    this.keyid = undefined;
-    this.path = undefined;
-    this.support = undefined;
+    this.rpcType;
+    this.key;
+    this.keyid;
+    this.path;
+    this.support;
     this.isleafRef = true;
     this.isSpecTarget = false;
     this.isSpecReference = false;
     this.isDefinedBySpec = false;
     this.isOrdered = isOrdered;
-    this['min-elements'] = undefined;
-    this['max-elements'] = undefined;
+    this['min-elements'];
+    this['max-elements'];
     this.fileName = fileName;
 }
 
 ownedAttribute.prototype.giveValue = function(obj){
     var value;
     if(obj.defaultValue){
-        if(obj.defaultValue.value === undefined){
-            value = obj.defaultValue.attributes().value ? obj.defaultValue.attributes().value : null;
+        if(obj.defaultValue.value == undefined){
+            obj.defaultValue.attributes().value ? value = obj.defaultValue.attributes().value : value = null;
             /*if(obj.defaultValue.attributes().value){
                 value = obj.defaultValue.attributes().value;
             }
@@ -50,7 +50,7 @@ ownedAttribute.prototype.giveValue = function(obj){
                 value = null;
             }*/
         }else{
-            value = obj.defaultValue.value.attributes()['xsi:nil'];
+            value = obj.defaultValue.value.attributes()['xsi:nil']
         }
         if(value == "--"){
             value = null;
@@ -62,8 +62,10 @@ ownedAttribute.prototype.giveValue = function(obj){
     if(value != "NA"){
         this.defaultValue = value;
     }
-    this['min-elements'] = obj.lowerValue ? obj.lowerValue.attributes().value : null;
-    this['max-elements'] = obj.upperValue ? obj.upperValue.attributes().value : null;
+    obj["lowerValue"] ? value = obj["lowerValue"].attributes().value : value = null;
+    this['min-elements'] = value;
+    obj["upperValue"] ? value = obj["upperValue"].attributes().value : value = null;
+    this['max-elements'] = value;
 };
 ownedAttribute.prototype.giveNodeType = function(isLeaf){
     var isList;

--- a/UmlYangTools/xmi2yang/model/specify.js
+++ b/UmlYangTools/xmi2yang/model/specify.js
@@ -1,0 +1,10 @@
+/**
+ * Created by Administrator on 2017/3/29.
+ */
+function Specify(id, target,fileName){
+    this.id = id;
+    this.target=target;
+    this.fileName = fileName;
+}
+
+module.exports = Specify;

--- a/UmlYangTools/xmi2yang/model/yang/abstraction.js
+++ b/UmlYangTools/xmi2yang/model/yang/abstraction.js
@@ -1,0 +1,20 @@
+/**
+ * Created by Administrator on 2017/3/28.
+ */
+function Abstration(id,clientid,supplier, comment, fileName) {
+    this.id = id;
+    this.clientid = clientid;
+    this.supplier = supplier;
+    //this.supplierfilename=supplierfilename;
+    this.comment=comment;
+    this.fileName = fileName;
+}
+module.exports = Abstration;
+/*
+for(var i = 0; i < augment.length; i++){
+    for(var  j = 0; j < yangModule.length; j++){
+        if(augment[i].fileName === yangModule[j].fileName){
+            yangModule[j].children.push(augment[i]);
+        }
+    }
+}*/

--- a/UmlYangTools/xmi2yang/model/yang/augment.js
+++ b/UmlYangTools/xmi2yang/model/yang/augment.js
@@ -12,11 +12,11 @@
  ****************************************************************************************************/
 var Util = require('./util.js');
 
-function Augment(name, id, uses, usesId, comment, fileName) {
-    this.name = name;
+function Augment( id,client,  supplier, comment, fileName) {
+    this.client = client;
     this.id = id;
-    this.uses = uses;
-    this.usesId = usesId;
+    //this.supplierfilename = supplierfilename;
+    this.supplier =Util.yangifyName(supplier);
     this.description = comment;
     this.fileName = fileName;
 }
@@ -27,14 +27,12 @@ Augment.prototype.writeNode = function (layer){
     while (k-- > 0) {
         PRE += '\t';
     }
-    if(!this.name){
+    /*if(!this.supplier){
         console.warn("Warning: the default value of xmi:id=" + this.id + " does not exist! Please recheck your uml!");
         return "";
-    }
-
-
+    }*/
     var name;
-    name = "augment \"" + this.name + "\"";
+    name = "augment \"" + this.supplier + "\"";
     var description;
     if(!this.description){
         this.description = "none";
@@ -46,48 +44,51 @@ Augment.prototype.writeNode = function (layer){
     description = this.description ? PRE + "\tdescription \"" + this.description + "\";\r\n" : "";
 
     var uses = "";
-    if (typeof this.uses == "string") {
-        if(parseInt(this.uses[0]) != -1 && parseInt(this.uses[0]) >= 0){
-            var first = this.uses[0];
+    if (typeof this.client == "string") {
+        if(parseInt(this.client) != -1 && parseInt(this.client) >= 0){
+            var first = this.client[0];
             switch (first){
                 case '0' :
-                    this.uses = this.uses.replace(/^0/g, "Zero");
+                    this.client = this.client.replace(/^0/g, "Zero");
                     break;
                 case '1' :
-                    this.uses = this.uses.replace(/^1/g, "One");
+                    this.client= this.client.replace(/^1/g, "One");
                     break;
                 case '2' :
-                    this.uses = this.uses.replace(/^2/g, "Two");
+                    this.client = this.client.replace(/^2/g, "Two");
                     break;
                 case '3' :
-                    this.uses = this.uses.replace(/^3/g, "Three");
+                    this.client= this.client.replace(/^3/g, "Three");
                     break;
                 case '4' :
-                    this.uses = this.uses.replace(/^4/g, "Four");
+                    this.client = this.client.replace(/^4/g, "Four");
                     break;
                 case '5' :
-                    this.uses = this.uses.replace(/^5/g, "Five");
+                    this.client = this.client.replace(/^5/g, "Five");
                     break;
                 case '6' :
-                    this.uses = this.uses.replace(/^6/g, "Six");
+                    this.client = this.client.replace(/^6/g, "Six");
                     break;
                 case '7' :
-                    this.uses = this.uses.replace(/^7/g, "Seven");
+                    this.client = this.client.replace(/^7/g, "Seven");
                     break;
                 case '8' :
-                    this.uses = this.uses.replace(/^8/g, "Eight");
+                    this.client = this.client.replace(/^8/g, "Eight");
                     break;
                 case '9' :
-                    this.uses = this.uses.replace(/^9/g, "Nine");
+                    this.client = this.client.replace(/^9/g, "Nine");
                     break;
             }
         }
-        uses = PRE + "\tuses " + this.uses + ";\r\n";
+        uses = PRE + "\tuses " + this.client + ";\r\n";
     }
+
+        uses=PRE +"\tuses "+this.client+ ";\r\n";
+
     var s;
     s = PRE + name + " {\r\n" +
         Util.yangifyName(uses) +
-        description + PRE + "}\r\n";
+        PRE+ "}\r\n";
     return s;
 };
 module.exports = Augment;

--- a/UmlYangTools/xmi2yang/model/yang/module.js
+++ b/UmlYangTools/xmi2yang/model/yang/module.js
@@ -11,6 +11,7 @@
  *
  ****************************************************************************************************/
 var Util = require('./util.js');
+var augment=require('./augment.js');
 
 function Module(name, namespace, imp, pref, org, contact, revis, descrp, fileName) {
     this.name = Util.yangifyName(name);
@@ -125,9 +126,32 @@ Module.prototype.writeNode = function (layer) {
         if(sub !== undefined){
             this.children[this.children.length - 1] = sub;
         }
+     /*   for (var i = 0; i < this.children.length; i++) {
+            for (var j = 0; j < this.children.length; j++) {
+            if(this.children[i].name == "object-classes"&&this.children[j].name == "augment") {
+
+                if(i<j){
+                    this.children[i+1]=this.children[j];
+                    for(var k=i+1;k<j;k++){
+                        this.children[k+1] = this.children[k];
+
+                    }
+                }else if(i>j){
+                    this.children[i]=this.children[j];
+                    for(var k=j+1;k<i+1;k++){
+                        this.children[k-1] = this.children[k];
+
+                    }
+                }
+            }
+            }
+        }*/
         for (var i = 0; i < this.children.length; i++) {
+
             st += this.children[i].writeNode(layer + 1);
-        }
+            }
+
+
     }
     st = PRE + name + " {\r\n" +
         namespace +

--- a/UmlYangTools/xmi2yang/model/yang/node.js
+++ b/UmlYangTools/xmi2yang/model/yang/node.js
@@ -39,19 +39,19 @@ function Node(name, descrip, type, maxEle, minEle, id, config, isOrdered, featur
 Node.prototype.buildChild = function (att, type) {
     if(type == "leaf" || type == "leaf-list"){
         //translate the "integer" to "uint32"
-       var t;
+        var t;
         /*if(typeof att.type == "object"){
-            t = att.type.name;
-        }else if(typeof type == "string"){
-            t = att.type;
-        }
-        switch(t){
-            case "integer":
-                att.type = "uint64";
-                break;
-            default:
-                break;
-        }*/
+         t = att.type.name;
+         }else if(typeof type == "string"){
+         t = att.type;
+         }
+         switch(t){
+         case "integer":
+         att.type = "uint64";
+         break;
+         default:
+         break;
+         }*/
         if(typeof att.type == "object"){
             if(att.type.name == "integer"){
                 att.type.name = "uint64";
@@ -109,7 +109,7 @@ Node.prototype.buildChild = function (att, type) {
             break;
         case "typedef":
             //obj = new Type(att.type, att.id,undefined,undefined,undefined, att.description, undefined, att.fileName);
-	    obj = new Type(att.type, att.id, undefined, att.valueRange, undefined, att.description, att.units, att.fileName);
+            obj = new Type(att.type, att.id, undefined, att.valueRange, undefined, att.description, att.units, att.fileName);
             break;
         case "enum":
             this.name = this.name.replace(/[^\w\.-]+/g,'_');
@@ -126,14 +126,14 @@ Node.prototype.buildUses = function (att) {
 
 };
 /*Node.prototype.nameExe = function (name) {
-    if(this.nodeType=="grouping"){
-        name=this.name+"-g";
-    }
-return name;
-};
-Node.prototype.writename = function (name) {
-    this.name=name;
-};*/
+ if(this.nodeType=="grouping"){
+ name=this.name+"-g";
+ }
+ return name;
+ };
+ Node.prototype.writename = function (name) {
+ this.name=name;
+ };*/
 //create yang element string
 Node.prototype.writeNode = function (layer) {
     var PRE = '';
@@ -144,9 +144,9 @@ Node.prototype.writeNode = function (layer) {
     var status="";
     var descript = "";
 
-   /* if(this.nodeType == "grouping"){
-        this.name+="-g";
-    }*/
+     if(this.nodeType == "grouping"){
+     this.name+="-g";
+     }
 
     switch (this.status){
         case "Experimental":
@@ -164,21 +164,21 @@ Node.prototype.writeNode = function (layer) {
         case "current":
         case "obsolete":
         case "deprecated":
-           status = this.status ? PRE + "\tstatus " + this.status + ";\r\n" : "";
+            status = this.status ? PRE + "\tstatus " + this.status + ";\r\n" : "";
             break;
         default:
             break;
     }
     //if the nodetype of child node of list is list,then the nodetype of father node change to container
     /*if(this.nodeType == "list"){
-        var temp;
-        for(temp = 0; temp < this.children.length; temp++){
-            if(this.children[temp].nodeType == "list")
-                break;
-        }
-        if(temp < this.children.length)
-            this.nodeType = "container";
-    }*/
+     var temp;
+     for(temp = 0; temp < this.children.length; temp++){
+     if(this.children[temp].nodeType == "list")
+     break;
+     }
+     if(temp < this.children.length)
+     this.nodeType = "container";
+     }*/
 
     if(parseInt(this.name[0]) != -1 && parseInt(this.name[0]) >= 0 && this.nodeType != "enum"){
         var first = this.name[0];
@@ -215,7 +215,7 @@ Node.prototype.writeNode = function (layer) {
                 break;
         }
     }
-    
+
     var name = this.nodeType + " " + Util.yangifyName(this.name);
     if(!this.description){
         this.description = "none";
@@ -228,16 +228,16 @@ Node.prototype.writeNode = function (layer) {
     descript = this.description ? PRE + "\tdescription \"" + this.description + "\";\r\n" : "";
     var order="";
     /*if(this["ordered-by"] != undefined && this.nodeType == "list"){
-        if(this["ordered-by"] == true){
-            order = PRE + "\tordered-by user" + ";\r\n";
-        }else{
-            order = PRE + "\tordered-by system" + ";\r\n";
-        }
-    }*/
+     if(this["ordered-by"] == true){
+     order = PRE + "\tordered-by user" + ";\r\n";
+     }else{
+     order = PRE + "\tordered-by system" + ";\r\n";
+     }
+     }*/
     if(this["ordered-by"] === true && this.nodeType === "list"){
         order = PRE + "\tordered-by user" + ";\r\n";
     }
-    
+
     var maxele;
     var minele;
     var defvalue;
@@ -251,10 +251,10 @@ Node.prototype.writeNode = function (layer) {
     }
 
     /*if (this.nodeType == "container" && this.config || this.nodeType == "list" && this.config) {
-        conf = PRE + "\tconfig " + this.config + ";\r\n";
-    } else {
-        conf = "";
-    }*/
+     conf = PRE + "\tconfig " + this.config + ";\r\n";
+     } else {
+     conf = "";
+     }*/
     if((this.nodeType === "container" || this.nodeType === "list")&&(this.config === false)){
         conf = PRE + "\tconfig " + this.config + ";\r\n";
     }
@@ -273,8 +273,8 @@ Node.prototype.writeNode = function (layer) {
             console.warn("Warning: There is no key in the node " + this.name + " in \'" + this.fileName + "\'!");
         }
         /*if (typeof this.key=="string") {
-            Key = PRE + "\tkey '" + this.key + "';\r\n";
-        }*/
+         Key = PRE + "\tkey '" + this.key + "';\r\n";
+         }*/
 
     } else {
         maxele = "";
@@ -288,7 +288,7 @@ Node.prototype.writeNode = function (layer) {
                 this.uses[i].writeNode(layer + 1);
             }else{
                 if(parseInt(this.uses[i][0]) != -1 && parseInt(this.uses[i][0]) >= 0){
-                    
+
                     switch (this.uses[i][0]){
                         case '0' :
                             this.uses[i] = this.uses[i].replace(/^0/g, "Zero");
@@ -330,47 +330,47 @@ Node.prototype.writeNode = function (layer) {
         }
     }
     else if (typeof this.uses == "string") {
-            if (parseInt(this.uses[0]) != -1 && parseInt(this.uses[0]) >= 0) {
-                switch (this.uses[0]) {
-                    case '0' :
-                        this.uses = this.uses.replace(/^0/g, "Zero");
-                        break;
-                    case '1' :
-                        this.uses = this.uses.replace(/^1/g, "One");
-                        break;
-                    case '2' :
-                        this.uses = this.uses.replace(/^2/g, "Two");
-                        break;
-                    case '3' :
-                        this.uses = this.uses.replace(/^3/g, "Three");
-                        break;
-                    case '4' :
-                        this.uses = this.uses.replace(/^4/g, "Four");
-                        break;
-                    case '5' :
-                        this.uses = this.uses.replace(/^5/g, "Five");
-                        break;
-                    case '6' :
-                        this.uses = this.uses.replace(/^6/g, "Six");
-                        break;
-                    case '7' :
-                        this.uses = this.uses.replace(/^7/g, "Seven");
-                        break;
-                    case '8' :
-                        this.uses = this.uses.replace(/^8/g, "Eight");
-                        break;
-                    case '9' :
-                        this.uses = this.uses.replace(/^9/g, "Nine");
-                        break;
-                }
+        if (parseInt(this.uses[0]) != -1 && parseInt(this.uses[0]) >= 0) {
+            switch (this.uses[0]) {
+                case '0' :
+                    this.uses = this.uses.replace(/^0/g, "Zero");
+                    break;
+                case '1' :
+                    this.uses = this.uses.replace(/^1/g, "One");
+                    break;
+                case '2' :
+                    this.uses = this.uses.replace(/^2/g, "Two");
+                    break;
+                case '3' :
+                    this.uses = this.uses.replace(/^3/g, "Three");
+                    break;
+                case '4' :
+                    this.uses = this.uses.replace(/^4/g, "Four");
+                    break;
+                case '5' :
+                    this.uses = this.uses.replace(/^5/g, "Five");
+                    break;
+                case '6' :
+                    this.uses = this.uses.replace(/^6/g, "Six");
+                    break;
+                case '7' :
+                    this.uses = this.uses.replace(/^7/g, "Seven");
+                    break;
+                case '8' :
+                    this.uses = this.uses.replace(/^8/g, "Eight");
+                    break;
+                case '9' :
+                    this.uses = this.uses.replace(/^9/g, "Nine");
+                    break;
             }
-            if(this.uses.indexOf("-g")==-1){
-                this.uses+="-g";
-            }
-            uses = PRE + "\tuses " + this.uses +";\r\n";
-        } else if (typeof this.uses[i] === "object") { // [sko] i out of scope; can this line and the next be deleted?
-            this.uses[i].writeNode(layer + 1);
         }
+        if(this.uses.indexOf("-g")==-1){
+            this.uses+="-g";
+        }
+        uses = PRE + "\tuses " + this.uses +";\r\n";
+    } else if (typeof this.uses[i] === "object") { // [sko] i out of scope; can this line and the next be deleted?
+        this.uses[i].writeNode(layer + 1);
+    }
 
     var feature = "";
     if(this["if-feature"] && this.nodeType !== "grouping"){
@@ -379,9 +379,10 @@ Node.prototype.writeNode = function (layer) {
     var child = "";
     if (this.children) {
         this.children.map(function(item) {
-          child += item.writeNode(layer + 1);
+            child += item.writeNode(layer + 1);
         });
     }
+
     var s;
     if(this.nodeType == "enum" && !this.description){
         s = PRE + name + ";\r\n";

--- a/UmlYangTools/xmi2yang/model/yang/uses.js
+++ b/UmlYangTools/xmi2yang/model/yang/uses.js
@@ -68,7 +68,7 @@ uses.prototype.writeNode = function(layer){
     if(!this.description){
         this.description = "none";
     }
-    
+
     if (typeof this.description == 'string') {
         this.description = this.description.replace(/\r+\n+/g, '\r\n' + PRE + '\t\t');
         this.description = this.description.replace(/\"/g, "\'");


### PR DESCRIPTION
Implement the <<Specify/Target>> sterotype.

<<target>> mapping rule is same as Karthik proposed:
The format/ grammer of the target value string is [/<ModelName>:<ClassName>:<_attributeName>]+
To translate this string to yang, drop the <ClassName> portion (since yang XPATH only uses “<module-name>:<attribute-name>”)

@karthik-sethuraman  @bzeuner  Please help review if the logic is right, thanks.