### PR TITLE
OpenModel Profile v0.2.10 and OpenInterfaceModelProfile v0.0.7

### DIFF
--- a/UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.notation
+++ b/UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.notation
@@ -92,7 +92,7 @@
     <edges xmi:type="notation:Connector" xmi:id="_viDyUP_mEeaI0OG3Zoa57Q" type="1013" source="_53iYwLbyEeaufdfMFhfy_A" target="_vho7kP_mEeaI0OG3Zoa57Q">
       <styles xmi:type="notation:FontStyle" xmi:id="_viDyUf_mEeaI0OG3Zoa57Q"/>
       <element xmi:type="uml:Extension" href="OpenInterfaceModel_Profile.profile.uml#_0jS38LbyEeaufdfMFhfy_A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_viDyUv_mEeaI0OG3Zoa57Q" points="[-79, -46, 285, 168]$[-364, -214, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_viDyUv_mEeaI0OG3Zoa57Q" points="[2, 0, 0, 46]$[2, -11, 0, 35]$[2, -46, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wFM7oP_mEeaI0OG3Zoa57Q" id="(0.4880952380952381,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_wFNisP_mEeaI0OG3Zoa57Q" id="(0.5,1.0)"/>
     </edges>

--- a/UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml
+++ b/UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml
@@ -1,6 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<uml:Profile xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_UbM6ILbyEeaufdfMFhfy_A" name="OpenInterfaceModel_Profile">
+<uml:Profile xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_UbM6ILbyEeaufdfMFhfy_A" name="OpenInterfaceModel_Profile" metaclassReference="__iOI4CZqEee8VYv13r5Sxg _FEh64CZrEee8VYv13r5Sxg">
   <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_vXgnYOMXEeaVnpsnjRW9Pg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+    <contents xmi:type="ecore:EPackage" xmi:id="_5WB28CZrEee8VYv13r5Sxg" name="OpenInterfaceModel_Profile" nsURI="http:///schemas/OpenInterfaceModel_Profile/_5WBP4CZrEee8VYv13r5Sxg/6" nsPrefix="OpenInterfaceModel_Profile">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WCeAyZrEee8VYv13r5Sxg" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WCeBCZrEee8VYv13r5Sxg" key="Version" value="0.0.7"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WCeBSZrEee8VYv13r5Sxg" key="Comment" value="name property of the «RootElement» stereotype made mandatory.&#xD;&#xA;&#xD;&#xA;Editorial change:&#xD;&#xA;Imported the required metaclasses via “Element Import”."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WCeBiZrEee8VYv13r5Sxg" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WCeByZrEee8VYv13r5Sxg" key="Date" value="2017-04-21"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5WCeCCZrEee8VYv13r5Sxg" key="Author" value=""/>
+      </eAnnotations>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_5WB28SZrEee8VYv13r5Sxg" name="RootElement">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB28iZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_oOSqILbyEeaufdfMFhfy_A"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_5WB28yZrEee8VYv13r5Sxg" name="base_Class" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB29SZrEee8VYv13r5Sxg" name="name" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB29yZrEee8VYv13r5Sxg" name="multiplicity" ordered="false" lowerBound="1" defaultValueLiteral="1..1">
+          <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB2-SZrEee8VYv13r5Sxg" name="description" ordered="false">
+          <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+        </eStructuralFeatures>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_5WB2-yZrEee8VYv13r5Sxg" name="OpenInterfaceModelAttribute">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB2_CZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_ECvBANcqEea1ncO03M1x2w"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_5WB2_SZrEee8VYv13r5Sxg" name="base_Property" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Property"/>
+        </eStructuralFeatures>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB2_yZrEee8VYv13r5Sxg" name="writeAllowed" ordered="false" lowerBound="1" eType="_5WB3ByZrEee8VYv13r5Sxg" defaultValueLiteral="CREATE_AND_UPDATE"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB3ASZrEee8VYv13r5Sxg" name="attributeValueChangeNotification" ordered="false" lowerBound="1" eType="_5WB3DSZrEee8VYv13r5Sxg" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB3AyZrEee8VYv13r5Sxg" name="bitLength" ordered="false" eType="_5WB3EiZrEee8VYv13r5Sxg" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB3BSZrEee8VYv13r5Sxg" name="encoding" ordered="false" eType="_5WB3GSZrEee8VYv13r5Sxg" defaultValueLiteral="NA"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_5WB3ByZrEee8VYv13r5Sxg" name="WriteAllowed">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB3CCZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_-0T0YP_mEeaI0OG3Zoa57Q"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3CSZrEee8VYv13r5Sxg" name="CREATE_ONLY"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3CiZrEee8VYv13r5Sxg" name="UPDATE_ONLY" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3CyZrEee8VYv13r5Sxg" name="CREATE_AND_UPDATE" value="2"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3DCZrEee8VYv13r5Sxg" name="WRITE_NOT_ALLOWED" value="3"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_5WB3DSZrEee8VYv13r5Sxg" name="NotificationDefinition">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB3DiZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_CgjnINcrEea1ncO03M1x2w"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3DyZrEee8VYv13r5Sxg" name="NA"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3ECZrEee8VYv13r5Sxg" name="NO" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3ESZrEee8VYv13r5Sxg" name="YES" value="2"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_5WB3EiZrEee8VYv13r5Sxg" name="BitLength">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB3EyZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_bU64oNcrEea1ncO03M1x2w"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3FCZrEee8VYv13r5Sxg" name="NA"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3FSZrEee8VYv13r5Sxg" name="LENGTH_8_BIT" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3FiZrEee8VYv13r5Sxg" name="LENGTH_16_BIT" value="2"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3FyZrEee8VYv13r5Sxg" name="LENGTH_32_BIT" value="3"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3GCZrEee8VYv13r5Sxg" name="LENGTH_64_BIT" value="4"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EEnum" xmi:id="_5WB3GSZrEee8VYv13r5Sxg" name="Encoding">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB3GiZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_bU8t0NcrEea1ncO03M1x2w"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3GyZrEee8VYv13r5Sxg" name="NA"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3HCZrEee8VYv13r5Sxg" name="BASE_64" value="1"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3HSZrEee8VYv13r5Sxg" name="HEX" value="2"/>
+        <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_5WB3HiZrEee8VYv13r5Sxg" name="OCTET" value="3"/>
+      </eClassifiers>
+      <eClassifiers xmi:type="ecore:EClass" xmi:id="_5WB3HyZrEee8VYv13r5Sxg" name="OpenInterfaceModelClass">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5WB3ICZrEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_cmVzYNjPEea1wr7GsSffog"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB3ISZrEee8VYv13r5Sxg" name="objectCreationNotification" ordered="false" lowerBound="1" eType="_5WB3DSZrEee8VYv13r5Sxg" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_5WB3IyZrEee8VYv13r5Sxg" name="objectDeletionNotification" ordered="false" lowerBound="1" eType="_5WB3DSZrEee8VYv13r5Sxg" defaultValueLiteral="NA"/>
+        <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_5WB3JSZrEee8VYv13r5Sxg" name="base_Class" ordered="false" lowerBound="1">
+          <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+        </eStructuralFeatures>
+      </eClassifiers>
+    </contents>
     <contents xmi:type="ecore:EPackage" xmi:id="_7UCi0BklEeefasUHllQw0w" name="OpenInterfaceModel_Profile" nsURI="http:///schemas/OpenInterfaceModel_Profile/_7T-RYBklEeefasUHllQw0w/5" nsPrefix="OpenInterfaceModel_Profile">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7UGNMRklEeefasUHllQw0w" source="PapyrusVersion">
         <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7UGNMhklEeefasUHllQw0w" key="Version" value="0.0.6"/>
@@ -432,14 +502,19 @@
     </contents>
   </eAnnotations>
   <ownedComment xmi:type="uml:Comment" xmi:id="_2CeJAO3XEeaQNdpg-LmPpw" annotatedElement="_UbM6ILbyEeaufdfMFhfy_A">
-    <body>OpenInterfaceModelProfile v0.0.6:&#xD;
-Bugfix: Made OpenInterfaceModelClass mandatory.</body>
+    <body>OpenInterfaceModelProfile v0.0.7:&#xD;
+name property of the «RootElement» stereotype made mandatory.&#xD;
+Editorial change:&#xD;
+Imported the required metaclasses via “Element Import”.</body>
   </ownedComment>
+  <elementImport xmi:type="uml:ElementImport" xmi:id="__iOI4CZqEee8VYv13r5Sxg" alias="Class">
+    <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
+  </elementImport>
+  <elementImport xmi:type="uml:ElementImport" xmi:id="_FEh64CZrEee8VYv13r5Sxg" alias="Property">
+    <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Property"/>
+  </elementImport>
   <packageImport xmi:type="uml:PackageImport" xmi:id="_UgS1gLbyEeaufdfMFhfy_A">
     <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
-  </packageImport>
-  <packageImport xmi:type="uml:PackageImport" xmi:id="_UgS1gbbyEeaufdfMFhfy_A">
-    <importedPackage xmi:type="uml:Model" href="pathmap://UML_METAMODELS/UML.metamodel.uml#_0"/>
   </packageImport>
   <packagedElement xmi:type="uml:Stereotype" xmi:id="_oOSqILbyEeaufdfMFhfy_A" name="RootElement">
     <ownedComment xmi:type="uml:Comment" xmi:id="_y92usLbzEeaufdfMFhfy_A" annotatedElement="_oOSqILbyEeaufdfMFhfy_A">
@@ -453,7 +528,7 @@ Bugfix: Made OpenInterfaceModelClass mandatory.</body>
         <body>Used to specify a name for the root instance if applicable or needed for some mapped schemas e.g. Yang</body>
       </ownedComment>
       <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-      <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CWezAO9yEeacif85MvwsiA"/>
+      <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CWezAO9yEeacif85MvwsiA" value="1"/>
       <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CWhPQO9yEeacif85MvwsiA" value="1"/>
     </ownedAttribute>
     <ownedAttribute xmi:type="uml:Property" xmi:id="_E3Lh4N4eEeaGLqqeTEyVEQ" name="multiplicity">

--- a/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.notation
+++ b/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.notation
@@ -1597,7 +1597,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3-Nv-d5gEeaGLqqeTEyVEQ"/>
       </children>
       <element xmi:type="uml:Stereotype" href="OpenModel_Profile.profile.uml#_1j1YMN5gEeaGLqqeTEyVEQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3-NI4d5gEeaGLqqeTEyVEQ" x="274" y="640" height="65"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3-NI4d5gEeaGLqqeTEyVEQ" x="281" y="640" height="65"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_cHlx4N5hEeaGLqqeTEyVEQ" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_cHlx4d5hEeaGLqqeTEyVEQ" showTitle="true"/>
@@ -1881,7 +1881,7 @@
     <edges xmi:type="notation:Connector" xmi:id="_P0HswO-GEeaFytHm7I89bw" type="1022" source="_PzTNYO-GEeaFytHm7I89bw" target="_3-NI4N5gEeaGLqqeTEyVEQ" routing="Rectilinear">
       <styles xmi:type="notation:FontStyle" xmi:id="_P0Hswe-GEeaFytHm7I89bw"/>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P0Hswu-GEeaFytHm7I89bw" points="[11, 0, -29, 23]$[11, -23, -29, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_P0Hswu-GEeaFytHm7I89bw" points="[11, 0, -26, 23]$[11, -23, -26, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UFieoO-GEeaFytHm7I89bw" id="(0.4847277556440903,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UFjFsO-GEeaFytHm7I89bw" id="(0.7071428571428572,1.0)"/>
     </edges>

--- a/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml
+++ b/UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml
@@ -2,6 +2,268 @@
 <xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ProfileLifecycle_Profile="http:///schemas/ProfileLifecycle_Profile/_DCEdUPmcEearwuwnW-lBGg/1" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmlns:umlnotationext="http://www.eclipse.org/papyrus/umlnotation" xsi:schemaLocation="http:///schemas/ProfileLifecycle_Profile/_DCEdUPmcEearwuwnW-lBGg/1 ../ProfileLifecycleProfile/ProfileLifecycle_Profile.profile.uml#_DCG5kPmcEearwuwnW-lBGg">
   <uml:Profile xmi:id="_m1xqsHBgEd6FKu9XX1078A" name="OpenModel_Profile" metaclassReference="_h2TkIAPwEeewDI5jM-81FA _h2ULMAPwEeewDI5jM-81FA _h2WAYAPwEeewDI5jM-81FA _h2WAYQPwEeewDI5jM-81FA _h2WncAPwEeewDI5jM-81FA _h2WncQPwEeewDI5jM-81FA _h2XOgAPwEeewDI5jM-81FA _h2X1kAPwEeewDI5jM-81FA _h2YcoAPwEeewDI5jM-81FA _h2ZDsAPwEeewDI5jM-81FA _h2ZqwAPwEeewDI5jM-81FA _h2aR0APwEeewDI5jM-81FA _h2aR0QPwEeewDI5jM-81FA _h2a44APwEeewDI5jM-81FA">
     <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_m2rCkXBgEd6FKu9XX1078A" source="http://www.eclipse.org/uml2/2.0.0/UML">
+      <contents xmi:type="ecore:EPackage" xmi:id="_8opJICZpEee8VYv13r5Sxg" name="OpenModel_Profile" nsURI="http:///schemas/OpenModel_Profile/_8olewCZpEee8VYv13r5Sxg/22" nsPrefix="OpenModel_Profile">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8ozhNSZpEee8VYv13r5Sxg" source="PapyrusVersion">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8ozhNiZpEee8VYv13r5Sxg" key="Version" value="0.2.10"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8ozhNyZpEee8VYv13r5Sxg" key="Comment" value="Property target of «Specify» stereotype made a list ([*])"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8ozhOCZpEee8VYv13r5Sxg" key="Copyright" value=""/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8ozhOSZpEee8VYv13r5Sxg" key="Date" value="2017-04-21"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_8ozhOiZpEee8VYv13r5Sxg" key="Author" value=""/>
+        </eAnnotations>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJISZpEee8VYv13r5Sxg" name="OpenModelAttribute">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJIiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_36ZCQHBgEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJIyZpEee8VYv13r5Sxg" name="base_StructuralFeature" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StructuralFeature"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJJSZpEee8VYv13r5Sxg" name="partOfObjectKey" ordered="false" lowerBound="1" defaultValueLiteral="0">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Integer"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJJyZpEee8VYv13r5Sxg" name="uniqueSet" ordered="false" upperBound="-1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Integer"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJKSZpEee8VYv13r5Sxg" name="isInvariant" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJKyZpEee8VYv13r5Sxg" name="valueRange" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJLSZpEee8VYv13r5Sxg" name="unsigned" ordered="false" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJLyZpEee8VYv13r5Sxg" name="counter" ordered="false" eType="_8opJNyZpEee8VYv13r5Sxg" defaultValueLiteral="NA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJMSZpEee8VYv13r5Sxg" name="unit" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJMyZpEee8VYv13r5Sxg" name="support" ordered="false" lowerBound="1" eType="_8opJPSZpEee8VYv13r5Sxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJNSZpEee8VYv13r5Sxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_8opJNyZpEee8VYv13r5Sxg" name="Counter">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJOCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_NtRBsFfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJOSZpEee8VYv13r5Sxg" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJOiZpEee8VYv13r5Sxg" name="COUNTER" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJOyZpEee8VYv13r5Sxg" name="GAUGE" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJPCZpEee8VYv13r5Sxg" name="ZERO_COUNTER" value="3"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_8opJPSZpEee8VYv13r5Sxg" name="SupportQualifier">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJPiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_tIP_UL7QEeGcHtJ-koFuEQ"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJPyZpEee8VYv13r5Sxg" name="MANDATORY"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJQCZpEee8VYv13r5Sxg" name="OPTIONAL" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJQSZpEee8VYv13r5Sxg" name="CONDITIONAL_MANDATORY" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJQiZpEee8VYv13r5Sxg" name="CONDITIONAL_OPTIONAL" value="3"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJQyZpEee8VYv13r5Sxg" name="CONDITIONAL" value="4"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJRCZpEee8VYv13r5Sxg" name="OpenModelClass">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJRSZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_JVMFMHBhEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJRiZpEee8VYv13r5Sxg" name="base_Class" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJSCZpEee8VYv13r5Sxg" name="support" ordered="false" lowerBound="1" eType="_8opJPSZpEee8VYv13r5Sxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJSiZpEee8VYv13r5Sxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJTCZpEee8VYv13r5Sxg" name="OpenModelOperation">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJTSZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_FRG9AHBnEd6FKu9XX1078A"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJTiZpEee8VYv13r5Sxg" name="base_Operation" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Operation"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJUCZpEee8VYv13r5Sxg" name="isOperationIdempotent" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJUiZpEee8VYv13r5Sxg" name="isAtomic" ordered="false" lowerBound="1" defaultValueLiteral="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//Boolean"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJVCZpEee8VYv13r5Sxg" name="support" ordered="false" lowerBound="1" eType="_8opJPSZpEee8VYv13r5Sxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJViZpEee8VYv13r5Sxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJWCZpEee8VYv13r5Sxg" name="OpenModelParameter">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJWSZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_jG59cHEqEd6SxZ5y0DIogw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJWiZpEee8VYv13r5Sxg" name="base_Parameter" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Parameter"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJXCZpEee8VYv13r5Sxg" name="valueRange" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJXiZpEee8VYv13r5Sxg" name="support" ordered="false" lowerBound="1" eType="_8opJPSZpEee8VYv13r5Sxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJYCZpEee8VYv13r5Sxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_8opJYiZpEee8VYv13r5Sxg" name="NotificationDefinition">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJYyZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_HgbRQBGqEd-nT5bmeQ1LHg"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJZCZpEee8VYv13r5Sxg" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJZSZpEee8VYv13r5Sxg" name="NO" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJZiZpEee8VYv13r5Sxg" name="YES" value="2"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJZyZpEee8VYv13r5Sxg" name="Names">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJaCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_jiSAMI7kEeGyB5ASrrNdIA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJaSZpEee8VYv13r5Sxg" name="base_Association" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJayZpEee8VYv13r5Sxg" name="Choice">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJbCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_27D5AL7XEeGcHtJ-koFuEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJbSZpEee8VYv13r5Sxg" name="base_DataType" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//DataType"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJbyZpEee8VYv13r5Sxg" name="base_Class" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Class"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJcSZpEee8VYv13r5Sxg" name="Exception">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJciZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_el7rwL7YEeGcHtJ-koFuEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJcyZpEee8VYv13r5Sxg" name="base_DataType" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//DataType"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJdSZpEee8VYv13r5Sxg" name="NamedBy">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJdiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_3E1eYPNAEeGLMdrUcsEncQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJdyZpEee8VYv13r5Sxg" name="base_Dependency" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Dependency"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJeSZpEee8VYv13r5Sxg" name="StrictComposite">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJeiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_vQjMkJ2BEeSDYd59zPupRA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJeyZpEee8VYv13r5Sxg" name="base_Association" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Association"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJfSZpEee8VYv13r5Sxg" name="Cond">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJfiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_h7id0J2CEeSDYd59zPupRA"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJfyZpEee8VYv13r5Sxg" name="condition" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJgSZpEee8VYv13r5Sxg" name="base_Relationship" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Relationship"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJgyZpEee8VYv13r5Sxg" name="Experimental">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJhCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_FU4UgJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJhSZpEee8VYv13r5Sxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJhyZpEee8VYv13r5Sxg" name="LikelyToChange">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJiCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_HmOsEJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJiSZpEee8VYv13r5Sxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJiyZpEee8VYv13r5Sxg" name="Preliminary">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJjCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_LEgJwJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJjSZpEee8VYv13r5Sxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJjyZpEee8VYv13r5Sxg" name="Obsolete">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJkCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_M6xu4J2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJkSZpEee8VYv13r5Sxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJkyZpEee8VYv13r5Sxg" name="Example">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJlCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_OwwZEJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJlSZpEee8VYv13r5Sxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJlyZpEee8VYv13r5Sxg" name="Faulty">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJmCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_QGmKoJ2EEeSk-dMsN-xZbw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJmSZpEee8VYv13r5Sxg" name="base_Element" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJmyZpEee8VYv13r5Sxg" name="OpenModelInterface">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJnCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_oKbrsKiIEeSJmIxGbzx9kA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJnSZpEee8VYv13r5Sxg" name="base_Interface" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Interface"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJnyZpEee8VYv13r5Sxg" name="support" ordered="false" lowerBound="1" eType="_8opJPSZpEee8VYv13r5Sxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJoSZpEee8VYv13r5Sxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJoyZpEee8VYv13r5Sxg" name="OpenModelNotification">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJpCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_74KP4EZPEeW32YsOmT7W0Q"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJpSZpEee8VYv13r5Sxg" name="triggerConditionList" ordered="false" lowerBound="1" upperBound="-1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJpyZpEee8VYv13r5Sxg" name="support" ordered="false" lowerBound="1" eType="_8opJPSZpEee8VYv13r5Sxg" defaultValueLiteral="MANDATORY"/>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJqSZpEee8VYv13r5Sxg" name="condition" ordered="false">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJqyZpEee8VYv13r5Sxg" name="base_Signal" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Signal"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJrSZpEee8VYv13r5Sxg" name="PruneAndRefactor">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJriZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_aUYHcEZgEeWzOqfPW42hmw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJryZpEee8VYv13r5Sxg" name="base_Realization" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Realization"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJsSZpEee8VYv13r5Sxg" name="Deprecated">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJsiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_ma6wEJDeEeW51dNDZIXIMA"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJsyZpEee8VYv13r5Sxg" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJtSZpEee8VYv13r5Sxg" name="Mature">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJtiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_wvWWABdhEeatXPvf_dRw8w"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJtyZpEee8VYv13r5Sxg" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJuSZpEee8VYv13r5Sxg" name="Reference">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJuiZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_949Q4FfpEeak-v4LxEsCQw"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJuyZpEee8VYv13r5Sxg" name="base_Element" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJvSZpEee8VYv13r5Sxg" name="reference" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_8opJvyZpEee8VYv13r5Sxg" name="BitLength">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJwCZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_M9B3kFfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJwSZpEee8VYv13r5Sxg" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJwiZpEee8VYv13r5Sxg" name="LENGTH_8_BIT" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJwyZpEee8VYv13r5Sxg" name="LENGTH_16_BIT" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJxCZpEee8VYv13r5Sxg" name="LENGTH_32_BIT" value="3"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJxSZpEee8VYv13r5Sxg" name="LENGTH_64_BIT" value="4"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EEnum" xmi:id="_8opJxiZpEee8VYv13r5Sxg" name="Encoding">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJxyZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_OZ1z0FfrEeak-v4LxEsCQw"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJyCZpEee8VYv13r5Sxg" name="NA"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJySZpEee8VYv13r5Sxg" name="BASE_64" value="1"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJyiZpEee8VYv13r5Sxg" name="HEX" value="2"/>
+          <eLiterals xmi:type="ecore:EEnumLiteral" xmi:id="_8opJyyZpEee8VYv13r5Sxg" name="OCTET" value="3"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJzCZpEee8VYv13r5Sxg" name="ExtendedComposite" eSuperTypes="_8opJeSZpEee8VYv13r5Sxg">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJzSZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_aJ-ukNjjEea1wr7GsSffog"/>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJzyZpEee8VYv13r5Sxg" name="Specify">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJ0CZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_1j1YMN5gEeaGLqqeTEyVEQ"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJ0SZpEee8VYv13r5Sxg" name="base_Abstraction" ordered="false" lowerBound="1">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Abstraction"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EAttribute" xmi:id="_8opJ0yZpEee8VYv13r5Sxg" name="target" ordered="false" upperBound="-1">
+            <eType xmi:type="ecore:EDataType" href="http://www.eclipse.org/uml2/5.0.0/Types#//String"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+        <eClassifiers xmi:type="ecore:EClass" xmi:id="_8opJ1SZpEee8VYv13r5Sxg" name="PassedByReference">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_8opJ1iZpEee8VYv13r5Sxg" source="http://www.eclipse.org/uml2/2.0.0/UML" references="_6urDcP_gEeaI0OG3Zoa57Q"/>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJ1yZpEee8VYv13r5Sxg" name="base_Property" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Property"/>
+          </eStructuralFeatures>
+          <eStructuralFeatures xmi:type="ecore:EReference" xmi:id="_8opJ2SZpEee8VYv13r5Sxg" name="base_Parameter" ordered="false">
+            <eType xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Parameter"/>
+          </eStructuralFeatures>
+        </eClassifiers>
+      </contents>
       <contents xmi:type="ecore:EPackage" xmi:id="_aG-rgAPxEeewDI5jM-81FA" name="OpenModel_Profile" nsURI="http:///schemas/OpenModel_Profile/_aG1hkAPxEeewDI5jM-81FA/21" nsPrefix="OpenModel_Profile">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_aHFZMwPxEeewDI5jM-81FA" source="PapyrusVersion">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_aHGAQAPxEeewDI5jM-81FA" key="Version" value="0.2.9"/>
@@ -7693,10 +7955,8 @@
       </contents>
     </eAnnotations>
     <ownedComment xmi:type="uml:Comment" xmi:id="_cxO3YBeFEeaUiMmCiapTYQ" annotatedElement="_m1xqsHBgEd6FKu9XX1078A">
-      <body>OpenModel Profile v0.2.8:&#xD;
-Stereotype PassedByReference added (moved from InterfaceModelProfile)&#xD;
-Property settingTime removed from OpenModelAttribute stereotype&#xD;
-Property settingActor removed from OpenModelAttribute stereotype</body>
+      <body>OpenModel Profile v0.2.10:&#xD;
+Property target of «Specify» stereotype made a list ([*])</body>
     </ownedComment>
     <elementImport xmi:type="uml:ElementImport" xmi:id="_h2TkIAPwEeewDI5jM-81FA" alias="Class">
       <importedElement xmi:type="uml:Class" href="pathmap://UML_METAMODELS/UML.metamodel.uml#Class"/>
@@ -8732,7 +8992,7 @@ target=/TapiTopology:TopologyContext/TapiTopology:Topology/TapiTopology:Node/Tap
         </ownedComment>
         <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pWo2YO1lEealZpKGxQi2Dw"/>
-        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pWvkEO1lEealZpKGxQi2Dw" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pWvkEO1lEealZpKGxQi2Dw" value="*"/>
       </ownedAttribute>
     </packagedElement>
     <packagedElement xmi:type="uml:Extension" xmi:id="_yo-7MN5hEeaGLqqeTEyVEQ" name="E_Specify_Abstraction1" memberEnd="_yo_iQN5hEeaGLqqeTEyVEQ _yo_iQd5hEeaGLqqeTEyVEQ">

--- a/UmlTestModels/.project
+++ b/UmlTestModels/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>UmlTestModels</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/UmlTestModels/CommonModel.uml
+++ b/UmlTestModels/CommonModel.uml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenInterfaceModel_Profile="http:///schemas/OpenInterfaceModel_Profile/_7T-RYBklEeefasUHllQw0w/5" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_aG1hkAPxEeewDI5jM-81FA/21" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenInterfaceModel_Profile/_7T-RYBklEeefasUHllQw0w/5 ../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_7UCi0BklEeefasUHllQw0w http:///schemas/OpenModel_Profile/_aG1hkAPxEeewDI5jM-81FA/21 ../OpenModelProfile/OpenModel_Profile.profile.uml#_aG-rgAPxEeewDI5jM-81FA">
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenInterfaceModel_Profile="http:///schemas/OpenInterfaceModel_Profile/_5WBP4CZrEee8VYv13r5Sxg/6" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_8olewCZpEee8VYv13r5Sxg/22" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenInterfaceModel_Profile/_5WBP4CZrEee8VYv13r5Sxg/6 ../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_5WB28CZrEee8VYv13r5Sxg http:///schemas/OpenModel_Profile/_8olewCZpEee8VYv13r5Sxg/22 ../OpenModelProfile/OpenModel_Profile.profile.uml#_8opJICZpEee8VYv13r5Sxg">
   <uml:Model xmi:id="_dtVNoBhqEeezp8ogwSi4gg" name="CommonModel">
     <packageImport xmi:type="uml:PackageImport" xmi:id="_dxsJMBhqEeezp8ogwSi4gg">
       <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
@@ -8,7 +8,7 @@
       <packagedElement xmi:type="uml:Class" xmi:id="_pb01EBhqEeezp8ogwSi4gg" name="ObjectClass1">
         <ownedComment xmi:type="uml:Comment" xmi:id="_qu2twBhrEeezp8ogwSi4gg" annotatedElement="_pb01EBhqEeezp8ogwSi4gg">
           <body>Stereotype «RootElement»&#xD;
-name: String [0..1] = _objectClass1&#xD;
+name: String [1] = _objectClass1&#xD;
 multiplicity: String [1] = 1..1&#xD;
 description: String [0..1] = Presence indicates ...</body>
         </ownedComment>
@@ -38,7 +38,7 @@ description: String [0..1] = Presence indicates ...</body>
       <packagedElement xmi:type="uml:Class" xmi:id="_g0H3oB3JEeeDz_2PEvvmGA" name="ObjectClass3">
         <ownedComment xmi:type="uml:Comment" xmi:id="_MgRHcB3KEeeDz_2PEvvmGA" annotatedElement="_g0H3oB3JEeeDz_2PEvvmGA">
           <body>Stereotype «RootElement»&#xD;
-name: String [0..1] = _objectClass3&#xD;
+name: String [1] = _objectClass3&#xD;
 multiplicity: String [1] = 1..*&#xD;
 description: String [0..1] = Presence indicates ...</body>
         </ownedComment>
@@ -139,28 +139,28 @@ description: String [0..1] = Presence indicates ...</body>
       </packagedElement>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_ivbOgBhqEeezp8ogwSi4gg">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CfmsYhn8Eeezp8ogwSi4gg" source="PapyrusVersion">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CfmsYxn8Eeezp8ogwSi4gg" key="Version" value="0.0.6"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CfmsZBn8Eeezp8ogwSi4gg" key="Comment" value="Bugfix: Made OpenInterfaceModelClass mandatory."/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CfmsZRn8Eeezp8ogwSi4gg" key="Copyright" value=""/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CfmsZhn8Eeezp8ogwSi4gg" key="Date" value="2017-04-04"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CfmsZxn8Eeezp8ogwSi4gg" key="Author" value=""/>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_pe5XcCZxEee8VYv13r5Sxg" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pe5XcSZxEee8VYv13r5Sxg" key="Version" value="0.0.7"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pe5XciZxEee8VYv13r5Sxg" key="Comment" value="name property of the «RootElement» stereotype made mandatory.&#xD;&#xA;&#xD;&#xA;Editorial change:&#xD;&#xA;Imported the required metaclasses via “Element Import”."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pe5XcyZxEee8VYv13r5Sxg" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pe5XdCZxEee8VYv13r5Sxg" key="Date" value="2017-04-21"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pe5XdSZxEee8VYv13r5Sxg" key="Author" value=""/>
       </eAnnotations>
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ivb1kBhqEeezp8ogwSi4gg" source="http://www.eclipse.org/uml2/2.0.0/UML">
-        <references xmi:type="ecore:EPackage" href="../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_7UCi0BklEeefasUHllQw0w"/>
+        <references xmi:type="ecore:EPackage" href="../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_5WB28CZrEee8VYv13r5Sxg"/>
       </eAnnotations>
       <appliedProfile xmi:type="uml:Profile" href="../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_UbM6ILbyEeaufdfMFhfy_A"/>
     </profileApplication>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_iw2x5hhqEeezp8ogwSi4gg">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iw3Y8RhqEeezp8ogwSi4gg" source="PapyrusVersion">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iw3Y8hhqEeezp8ogwSi4gg" key="Version" value="0.2.9"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iw3Y8xhqEeezp8ogwSi4gg" key="Comment" value="Bug fix:&#xD;&#xA;Made PassedByReference::base_Property and PassedByReference::base_Parameter optional since the PassedByReference stereotype extends more than one metaclass.&#xD;&#xA;&#xD;&#xA;Editorial change:&#xD;&#xA;Imported the required metaclasses via &quot;Element Import&quot;."/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iw3Y9BhqEeezp8ogwSi4gg" key="Copyright" value=""/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iw3Y9RhqEeezp8ogwSi4gg" key="Date" value="2017-03-08"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iw3Y9hhqEeezp8ogwSi4gg" key="Author" value=""/>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_pfJ2ICZxEee8VYv13r5Sxg" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pfJ2ISZxEee8VYv13r5Sxg" key="Version" value="0.2.10"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pfJ2IiZxEee8VYv13r5Sxg" key="Comment" value="Property target of «Specify» stereotype made a list ([*])"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pfJ2IyZxEee8VYv13r5Sxg" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pfJ2JCZxEee8VYv13r5Sxg" key="Date" value="2017-04-21"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_pfJ2JSZxEee8VYv13r5Sxg" key="Author" value=""/>
       </eAnnotations>
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iw3Y8BhqEeezp8ogwSi4gg" source="http://www.eclipse.org/uml2/2.0.0/UML">
-        <references xmi:type="ecore:EPackage" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_aG-rgAPxEeewDI5jM-81FA"/>
+        <references xmi:type="ecore:EPackage" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_8opJICZpEee8VYv13r5Sxg"/>
       </eAnnotations>
       <appliedProfile xmi:type="uml:Profile" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
     </profileApplication>

--- a/UmlTestModels/Spec1Model.notation
+++ b/UmlTestModels/Spec1Model.notation
@@ -602,18 +602,10 @@
       <element xmi:type="uml:Comment" href="Spec1Model.uml#_EmBCIB3UEeeDz_2PEvvmGA"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FWJekR3UEeeDz_2PEvvmGA" x="88" y="552" width="537" height="41"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_NIFJ0x3UEeeDz_2PEvvmGA" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_NIFJ1B3UEeeDz_2PEvvmGA" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NIFJ1h3UEeeDz_2PEvvmGA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="Spec1Model.uml#_YR_6AB3TEeeDz_2PEvvmGA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NIFJ1R3UEeeDz_2PEvvmGA" x="312" y="484"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_QwHngB3UEeeDz_2PEvvmGA" type="2012">
       <children xmi:type="notation:DecorationNode" xmi:id="_QwHngh3UEeeDz_2PEvvmGA" type="5038"/>
       <element xmi:type="uml:Comment" href="Spec1Model.uml#_PlKQQB3UEeeDz_2PEvvmGA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwHngR3UEeeDz_2PEvvmGA" x="112" y="752"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwHngR3UEeeDz_2PEvvmGA" x="112" y="744"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ZB3JUB3WEeeDz_2PEvvmGA" type="2011" fillColor="12632256">
       <children xmi:type="notation:DecorationNode" xmi:id="_ZB4-gB3WEeeDz_2PEvvmGA" type="5037"/>
@@ -723,6 +715,14 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xC5uNSBMEeeyq6HnXj4lSQ" x="1160" y="628"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_OJsEYCZyEee8VYv13r5Sxg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_OJsEYSZyEee8VYv13r5Sxg" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OJsEYyZyEee8VYv13r5Sxg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="Spec1Model.uml#_YR_6AB3TEeeDz_2PEvvmGA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OJsEYiZyEee8VYv13r5Sxg" x="280" y="524"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_iza_8RLTEeeHvMP49jln8w" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_iza_8hLTEeeHvMP49jln8w"/>
@@ -1049,17 +1049,7 @@
       <element xsi:nil="true"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_F3_nYh3UEeeDz_2PEvvmGA" points="[0, 0, -229, 47]$[234, -48, 5, -1]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F4AOcB3UEeeDz_2PEvvmGA" id="(0.5065176908752328,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F4AOcR3UEeeDz_2PEvvmGA" id="(0.503584229390681,1.0)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_NIFJ1x3UEeeDz_2PEvvmGA" type="StereotypeCommentLink" source="_YSC9UB3TEeeDz_2PEvvmGA" target="_NIFJ0x3UEeeDz_2PEvvmGA">
-      <styles xmi:type="notation:FontStyle" xmi:id="_NIFJ2B3UEeeDz_2PEvvmGA"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NIFJ3B3UEeeDz_2PEvvmGA" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Abstraction" href="Spec1Model.uml#_YR_6AB3TEeeDz_2PEvvmGA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NIFJ2R3UEeeDz_2PEvvmGA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NIFJ2h3UEeeDz_2PEvvmGA"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NIFJ2x3UEeeDz_2PEvvmGA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_F4AOcR3UEeeDz_2PEvvmGA" id="(0.2358642972536349,0.86)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_RIoOIB3UEeeDz_2PEvvmGA" type="4013" source="_QwHngB3UEeeDz_2PEvvmGA" target="_YSC9UB3TEeeDz_2PEvvmGA">
       <styles xmi:type="notation:FontStyle" xmi:id="_RIoOIR3UEeeDz_2PEvvmGA"/>
@@ -1221,6 +1211,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xC5uOSBMEeeyq6HnXj4lSQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xC5uOiBMEeeyq6HnXj4lSQ"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xC5uOyBMEeeyq6HnXj4lSQ"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_OJsEZCZyEee8VYv13r5Sxg" type="StereotypeCommentLink" source="_YSC9UB3TEeeDz_2PEvvmGA" target="_OJsEYCZyEee8VYv13r5Sxg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_OJsEZSZyEee8VYv13r5Sxg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_OJsEaSZyEee8VYv13r5Sxg" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Abstraction" href="Spec1Model.uml#_YR_6AB3TEeeDz_2PEvvmGA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OJsEZiZyEee8VYv13r5Sxg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OJsEZyZyEee8VYv13r5Sxg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OJsEaCZyEee8VYv13r5Sxg"/>
     </edges>
   </notation:Diagram>
   <css:ModelStyleSheets xmi:id="_m787kBLTEeeHvMP49jln8w">

--- a/UmlTestModels/Spec1Model.uml
+++ b/UmlTestModels/Spec1Model.uml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenInterfaceModel_Profile="http:///schemas/OpenInterfaceModel_Profile/_7T-RYBklEeefasUHllQw0w/5" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_aG1hkAPxEeewDI5jM-81FA/21" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenInterfaceModel_Profile/_7T-RYBklEeefasUHllQw0w/5 ../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_7UCi0BklEeefasUHllQw0w http:///schemas/OpenModel_Profile/_aG1hkAPxEeewDI5jM-81FA/21 ../OpenModelProfile/OpenModel_Profile.profile.uml#_aG-rgAPxEeewDI5jM-81FA">
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenInterfaceModel_Profile="http:///schemas/OpenInterfaceModel_Profile/_5WBP4CZrEee8VYv13r5Sxg/6" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_8olewCZpEee8VYv13r5Sxg/22" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenInterfaceModel_Profile/_5WBP4CZrEee8VYv13r5Sxg/6 ../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_5WB28CZrEee8VYv13r5Sxg http:///schemas/OpenModel_Profile/_8olewCZpEee8VYv13r5Sxg/22 ../OpenModelProfile/OpenModel_Profile.profile.uml#_8opJICZpEee8VYv13r5Sxg">
   <uml:Model xmi:id="_FdZTYBLOEeeHvMP49jln8w" name="Spec1Model">
     <packageImport xmi:type="uml:PackageImport" xmi:id="_Fiz-4BLOEeeHvMP49jln8w">
       <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
@@ -60,46 +60,55 @@ target=/CommonModel:RootElement:_objectClass3/CommonModel:ObjectClass3:_objectCl
       </packagedElement>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_Juvz0BLOEeeHvMP49jln8w">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_6D_BcBkrEeezp8ogwSi4gg" source="PapyrusVersion">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6D_BcRkrEeezp8ogwSi4gg" key="Version" value="0.0.6"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6D_BchkrEeezp8ogwSi4gg" key="Comment" value="Bugfix: Made OpenInterfaceModelClass mandatory."/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6D_BcxkrEeezp8ogwSi4gg" key="Copyright" value=""/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6D_BdBkrEeezp8ogwSi4gg" key="Date" value="2017-04-04"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_6D_BdRkrEeezp8ogwSi4gg" key="Author" value=""/>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AJk1ECZxEee8VYv13r5Sxg" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJk1ESZxEee8VYv13r5Sxg" key="Version" value="0.0.7"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJk1EiZxEee8VYv13r5Sxg" key="Comment" value="name property of the «RootElement» stereotype made mandatory.&#xD;&#xA;&#xD;&#xA;Editorial change:&#xD;&#xA;Imported the required metaclasses via “Element Import”."/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJk1EyZxEee8VYv13r5Sxg" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJk1FCZxEee8VYv13r5Sxg" key="Date" value="2017-04-21"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJk1FSZxEee8VYv13r5Sxg" key="Author" value=""/>
       </eAnnotations>
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Juwa4BLOEeeHvMP49jln8w" source="http://www.eclipse.org/uml2/2.0.0/UML">
-        <references xmi:type="ecore:EPackage" href="../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_7UCi0BklEeefasUHllQw0w"/>
+        <references xmi:type="ecore:EPackage" href="../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_5WB28CZrEee8VYv13r5Sxg"/>
       </eAnnotations>
       <appliedProfile xmi:type="uml:Profile" href="../OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_UbM6ILbyEeaufdfMFhfy_A"/>
     </profileApplication>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_Jx6ckBLOEeeHvMP49jln8w">
-      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Jx7DoBLOEeeHvMP49jln8w" source="PapyrusVersion">
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Jx7DoRLOEeeHvMP49jln8w" key="Version" value="0.2.9"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Jx7DohLOEeeHvMP49jln8w" key="Comment" value="Bug fix:&#xD;&#xA;Made PassedByReference::base_Property and PassedByReference::base_Parameter optional since the PassedByReference stereotype extends more than one metaclass.&#xD;&#xA;&#xD;&#xA;Editorial change:&#xD;&#xA;Imported the required metaclasses via &quot;Element Import&quot;."/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Jx7DoxLOEeeHvMP49jln8w" key="Copyright" value=""/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Jx7DpBLOEeeHvMP49jln8w" key="Date" value="2017-03-08"/>
-        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_Jx7DpRLOEeeHvMP49jln8w" key="Author" value=""/>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_AJumECZxEee8VYv13r5Sxg" source="PapyrusVersion">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJumESZxEee8VYv13r5Sxg" key="Version" value="0.2.10"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJumEiZxEee8VYv13r5Sxg" key="Comment" value="Property target of «Specify» stereotype made a list ([*])"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJumEyZxEee8VYv13r5Sxg" key="Copyright" value=""/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJumFCZxEee8VYv13r5Sxg" key="Date" value="2017-04-21"/>
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_AJumFSZxEee8VYv13r5Sxg" key="Author" value=""/>
       </eAnnotations>
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_Jx6ckRLOEeeHvMP49jln8w" source="http://www.eclipse.org/uml2/2.0.0/UML">
-        <references xmi:type="ecore:EPackage" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_aG-rgAPxEeewDI5jM-81FA"/>
+        <references xmi:type="ecore:EPackage" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_8opJICZpEee8VYv13r5Sxg"/>
       </eAnnotations>
       <appliedProfile xmi:type="uml:Profile" href="../OpenModelProfile/OpenModel_Profile.profile.uml#_m1xqsHBgEd6FKu9XX1078A"/>
     </profileApplication>
   </uml:Model>
   <OpenModel_Profile:OpenModelClass xmi:id="_cIBe8BLTEeeHvMP49jln8w" base_Class="_cIA34BLTEeeHvMP49jln8w"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_f2THgRLTEeeHvMP49jln8w" base_Class="_f2THgBLTEeeHvMP49jln8w"/>
-  <OpenModel_Profile:Specify xmi:id="_06tgABLUEeeHvMP49jln8w" base_Abstraction="_zmeQ8BLUEeeHvMP49jln8w" target="/CommonModel:ObjectClass1:_rootInstance"/>
+  <OpenModel_Profile:Specify xmi:id="_06tgABLUEeeHvMP49jln8w" base_Abstraction="_zmeQ8BLUEeeHvMP49jln8w">
+    <target>/CommonModel:ObjectClass1:_rootInstance</target>
+  </OpenModel_Profile:Specify>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_loF8MRhTEeezp8ogwSi4gg" base_Property="_loF8MBhTEeezp8ogwSi4gg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_loHKUBhTEeezp8ogwSi4gg" base_StructuralFeature="_loF8MBhTEeezp8ogwSi4gg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_uDI14RhTEeezp8ogwSi4gg" base_Property="_uDI14BhTEeezp8ogwSi4gg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_uDJc8BhTEeezp8ogwSi4gg" base_StructuralFeature="_uDI14BhTEeezp8ogwSi4gg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6D-aYBkrEeezp8ogwSi4gg" base_Class="_cIA34BLTEeeHvMP49jln8w"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6D-aYRkrEeezp8ogwSi4gg" base_Class="_f2THgBLTEeeHvMP49jln8w"/>
-  <OpenModel_Profile:Specify xmi:id="_DK9zABn7Eeezp8ogwSi4gg" base_Abstraction="_-4-ZYBn6Eeezp8ogwSi4gg" target="/CommonModel:ObjectClass1:_rootInstance/CommonModel:ObjectClass1:_class2"/>
+  <OpenModel_Profile:Specify xmi:id="_DK9zABn7Eeezp8ogwSi4gg" base_Abstraction="_-4-ZYBn6Eeezp8ogwSi4gg">
+    <target>/CommonModel:ObjectClass1:_rootInstance/CommonModel:ObjectClass1:_objectClass2</target>
+  </OpenModel_Profile:Specify>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_J62OQB3TEeeDz_2PEvvmGA" base_Class="_J61nMB3TEeeDz_2PEvvmGA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_J621UB3TEeeDz_2PEvvmGA" base_Class="_J61nMB3TEeeDz_2PEvvmGA"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Rpc4sR3TEeeDz_2PEvvmGA" base_Property="_Rpc4sB3TEeeDz_2PEvvmGA"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_Rpc4sh3TEeeDz_2PEvvmGA" base_StructuralFeature="_Rpc4sB3TEeeDz_2PEvvmGA"/>
-  <OpenModel_Profile:Specify xmi:id="_BIvC8B3UEeeDz_2PEvvmGA" base_Abstraction="_y2iIoB3TEeeDz_2PEvvmGA"/>
-  <OpenModel_Profile:Specify xmi:id="_NH91EB3UEeeDz_2PEvvmGA" base_Abstraction="_YR_6AB3TEeeDz_2PEvvmGA"/>
+  <OpenModel_Profile:Specify xmi:id="_BIvC8B3UEeeDz_2PEvvmGA" base_Abstraction="_y2iIoB3TEeeDz_2PEvvmGA">
+    <target>/CommonModel:RootElement:_objectClass3/CommonModel:ObjectClass3:_objectClass4</target>
+  </OpenModel_Profile:Specify>
+  <OpenModel_Profile:Specify xmi:id="_OJiTYCZyEee8VYv13r5Sxg" base_Abstraction="_YR_6AB3TEeeDz_2PEvvmGA">
+    <target>/CommonModel:RootElement:_objectClass1/CommonModel:ObjectClass1:_objectClass2/CommonModel:ObjectClass2:_objectClass5</target>
+    <target>/CommonModel:RootElement:_objectClass3/CommonModel:ObjectClass3:_objectClass4/CommonModel:ObjectClass4:_objectClass5</target>
+  </OpenModel_Profile:Specify>
 </xmi:XMI>


### PR DESCRIPTION
OpenModel Profile v0.2.10:
Property target of «Specify» stereotype made a list ([*]).

OpenInterfaceModelProfile v0.0.7:
name property of the «RootElement» stereotype made mandatory.
Editorial change:
Imported the required metaclasses via “Element Import”.

These changes have been agreed in the IISOMI UML to YANG Mapping Guidelines sub-team on April 5.