### PR TITLE
Yang config file should support a list of revision statements (instead of a single one)

### DIFF
--- a/UmlYangTools/xmi2yang/model/yang/module.js
+++ b/UmlYangTools/xmi2yang/model/yang/module.js
@@ -61,6 +61,8 @@ Module.prototype.writeNode = function (layer) {
     //this.contact == "" || !this.contact ? contact = "" : contact = PRE + "\tcontact \"" + this.contact + "\";\r\n";
     this.contact = this.contact.replace(/\r\n/g, '\r\n' + PRE + '\t\t');
     contact = PRE + "\tcontact \"" + this.contact + "\";\r\n";
+    var revision_stmt = "";
+    for(var indx=0; indx<this.revision.length; indx++){
     var revis;
     //var date=new Date();
     /*if(this.revision.date == null || this.revision.date == ""){
@@ -81,7 +83,7 @@ Module.prototype.writeNode = function (layer) {
         }
         revis = new Date().Format("yyyy-MM-dd");
     }else{*/
-        revis = this.revision.date;
+        revis = this.revision[indx].date;
     //}
 
     /*if(!this.revision){
@@ -89,12 +91,12 @@ Module.prototype.writeNode = function (layer) {
         this.revision += "\r\nreference \"RFC 6020 and RFC 6087\";";
     }else */
     var revision = "";
-    if(typeof this.revision == "object"){
-        for(var i in this.revision){
+    if(typeof this.revision[indx] == "object"){
+        for(var i in this.revision[indx]){
             if(i == "date"){
                 continue;
             }
-            revision += "\r\n" + i + " \"" + this.revision[i] + "\";";
+            revision += "\r\n" + i + " \"" + this.revision[indx][i] + "\";";
         }
         /*revision += "\r\ndescription \"" + this.revision.description + "\";";
         revision += "\r\nreference \"" + this.revision.reference + "\";";*/
@@ -102,6 +104,8 @@ Module.prototype.writeNode = function (layer) {
     revision = revision.replace(/\r\n/g, '\r\n' + PRE + '\t\t');
     revis = PRE + "\trevision " + revis + " {" + revision + "\r\n\t" + PRE + "}\r\n";
     //this.revision !== "" && this.revision ?  revis = PRE + "\trevision " + this.revision + "{}\r\n":revis =  PRE + "\trevision " + revis + "{}\r\n" ;
+    revision_stmt = revision_stmt + revis;
+    }
     var description;
     if(!this.description){
         this.description = "none";
@@ -136,7 +140,7 @@ Module.prototype.writeNode = function (layer) {
         org +
         contact +
         description +
-        revis +
+        revision_stmt +
         st + "}\r\n";
     return st;
 };

--- a/UmlYangTools/xmi2yang/parser/index.js
+++ b/UmlYangTools/xmi2yang/parser/index.js
@@ -339,7 +339,7 @@ function buildResult(opts,cb){
             (function () {
                 try {
                     var st = yangProcessors.writeYang(ym);//print the module to yang file
-                    var path = opts.yangDir + "/" + ym.name + "@" + ym.revision.date + '.yang';
+                    var path = opts.yangDir + "/" + ym.name + "@" + ym.revision[0].date + '.yang';
                     console.log("[parser] writing " + path);
                     fs.writeFile(path, st, function(error){
                         if(error){

--- a/UmlYangTools/xmi2yang/project/config.json
+++ b/UmlYangTools/xmi2yang/project/config.json
@@ -4,11 +4,13 @@
     "organization":"Metro Ethernet Forum (MEF)",
     "contact":"MEF",
     "withSuffix":false,
-    "revision": {
-      "date":"2017-02-27",
-      "description":"MEF NRP 1.0.alpha",
-      "reference":"ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087"
-    }
+    "revision": [
+	    {
+	      "date":"2017-02-27",
+	      "description":"MEF NRP 1.0.alpha",
+	      "reference":"ONF-TR-527, ONF-TR-512, ONF-TR-531, RFC 6020 and RFC 6087"
+	    }
+    ]
   },
   "tapi": {
     "namespace":"urn:onf:params:xml:ns:yang:",
@@ -26,10 +28,12 @@
     "withSuffix":false,
     "organization":"ONF (Open Networking Foundation) IMP Working Group",
     "contact":"WG Web: <https://www.open{[]}networking.org/technical-communities/areas/services/> \n WG List: mailto: <wg list name>@opennetworking.org>, \n.WG Chair: your-WG-chair<mailto:your-WG-chair@example.com> \nEditor: your-name<mailto:your-email@example.com>",
-    "revision":{
-      "date":"2017-11-13",
-      "description":"Test revision",
-      "reference":"Papyrus"
-    }
+    "revision":[
+	    {
+	      "date":"2017-11-13",
+	      "description":"Test revision",
+	      "reference":"Papyrus"
+	    }
+    ]
   }
 }


### PR DESCRIPTION
Fix to allow the Yang config file to support a list of revision statements (instead of a single one)
- this is needed since a new version of an yang file/module has to preserve all previous revision statements